### PR TITLE
feat(ui): rebuild the payments landing as a tabbed shell and redesign the Receive flow

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -456,6 +456,12 @@
 		47A514602848F75B005A8E3E /* TxDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A5145F2848F75B005A8E3E /* TxDetailViewController.swift */; };
 		47A514622848FEAD005A8E3E /* Tx.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 47A514612848FEAD005A8E3E /* Tx.storyboard */; };
 		47A5146428491C60005A8E3E /* TxDetailCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A5146328491C60005A8E3E /* TxDetailCells.swift */; };
+		C017200000000000000AA2 /* RequestAmountScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C017200000000000000AA1 /* RequestAmountScreen.swift */; };
+		C017200000000000000AA3 /* RequestAmountScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C017200000000000000AA1 /* RequestAmountScreen.swift */; };
+		C017200000000000000BA2 /* RequestAmountHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C017200000000000000BA1 /* RequestAmountHostingController.swift */; };
+		C017200000000000000BA3 /* RequestAmountHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C017200000000000000BA1 /* RequestAmountHostingController.swift */; };
+		C0172000000000000009A2 /* SpecifyAmountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000009A1 /* SpecifyAmountView.swift */; };
+		C0172000000000000009A3 /* SpecifyAmountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000009A1 /* SpecifyAmountView.swift */; };
 		47AC8413297822E000BD1B49 /* SpecifyAmountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AC8412297822E000BD1B49 /* SpecifyAmountViewController.swift */; };
 		47AE8B9528BFACA100490F5E /* ExploreDash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AE8B9428BFACA100490F5E /* ExploreDash.swift */; };
 		47AE8B9C28BFAD3600490F5E /* ExplorePointOfUse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AE8B9B28BFAD2800490F5E /* ExplorePointOfUse.swift */; };
@@ -653,6 +659,12 @@
 		56F5C9FD51AE5508BB5E579B /* ChainNetworkToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D788CCB6B35B655BD713129E /* ChainNetworkToggle.swift */; };
 		57632D5A61F78ED6E896B1AF /* StorageRecordDetailViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCBA057E553F81F54ACE6E1 /* StorageRecordDetailViews.swift */; };
 		58825FFD2913876CC5D4AA21 /* InternalTransferScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62C70E4EBB7458C362B7669 /* InternalTransferScreen.swift */; };
+		C0172000000000000003A2 /* PaymentsTabRootController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000003A1 /* PaymentsTabRootController.swift */; };
+		C0172000000000000003A3 /* PaymentsTabRootController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000003A1 /* PaymentsTabRootController.swift */; };
+		C0172000000000000007A2 /* PaymentsReceiveContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000007A1 /* PaymentsReceiveContent.swift */; };
+		C0172000000000000007A3 /* PaymentsReceiveContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000007A1 /* PaymentsReceiveContent.swift */; };
+		C0172000000000000001A2 /* PaymentsTabSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000001A1 /* PaymentsTabSelector.swift */; };
+		C0172000000000000001A3 /* PaymentsTabSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000001A1 /* PaymentsTabSelector.swift */; };
 		59A140F3992CD2438ADC84CE /* DWPreviewSeedPhraseModel+Mnemonic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D8BC6623C81DD3F008A668 /* DWPreviewSeedPhraseModel+Mnemonic.swift */; };
 		3F240D45721AF32B81BC447C /* RecoveryPhraseLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210C818A8AAC76F91676AFF9 /* RecoveryPhraseLength.swift */; };
 		5A1EC0FE2E29A10000000002 /* ShieldedActivityHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */; };
@@ -868,6 +880,8 @@
 		75B3C1A32E36100100CAFE03 /* ShortcutSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1A12E36100100CAFE01 /* ShortcutSelectionView.swift */; };
 		75B3C1B22E36100100CAFE05 /* ShortcutCustomizeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1B12E36100100CAFE04 /* ShortcutCustomizeBannerView.swift */; };
 		75B3C1B32E36100100CAFE06 /* ShortcutCustomizeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1B12E36100100CAFE04 /* ShortcutCustomizeBannerView.swift */; };
+		C0172000000000000008A2 /* TransientToastModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000008A1 /* TransientToastModifier.swift */; };
+		C0172000000000000008A3 /* TransientToastModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0172000000000000008A1 /* TransientToastModifier.swift */; };
 		75BDE7AC2BF3287400556791 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75BDE7AB2BF3287400556791 /* Toast.swift */; };
 		75BDE7AD2BF3287400556791 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75BDE7AB2BF3287400556791 /* Toast.swift */; };
 		75C3EE002DA7C63C00A4E9C0 /* DashSpendUserAuthScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C3EDFE2DA7C63C00A4E9C0 /* DashSpendUserAuthScreen.swift */; };
@@ -2737,6 +2751,9 @@
 		47A5145F2848F75B005A8E3E /* TxDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailViewController.swift; sourceTree = "<group>"; };
 		47A514612848FEAD005A8E3E /* Tx.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Tx.storyboard; sourceTree = "<group>"; };
 		47A5146328491C60005A8E3E /* TxDetailCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailCells.swift; sourceTree = "<group>"; };
+		C017200000000000000AA1 /* RequestAmountScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAmountScreen.swift; sourceTree = "<group>"; };
+		C017200000000000000BA1 /* RequestAmountHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAmountHostingController.swift; sourceTree = "<group>"; };
+		C0172000000000000009A1 /* SpecifyAmountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyAmountView.swift; sourceTree = "<group>"; };
 		51D1C700000D10CA1E000000 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		51D1C700000D10CA1E000001 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ja; path = ja.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		51D1C700000D10CA1E000002 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ko; path = ko.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -3030,6 +3047,7 @@
 		75AA33D72BFB4A5A00F12465 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		75B3C1A12E36100100CAFE01 /* ShortcutSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutSelectionView.swift; sourceTree = "<group>"; };
 		75B3C1B12E36100100CAFE04 /* ShortcutCustomizeBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCustomizeBannerView.swift; sourceTree = "<group>"; };
+		C0172000000000000008A1 /* TransientToastModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastModifier.swift; sourceTree = "<group>"; };
 		75BDE7AB2BF3287400556791 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		75C1F0442AE26AC0006929CA /* CoinJoinLevelsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinJoinLevelsViewModel.swift; sourceTree = "<group>"; };
 		75C3EDFD2DA7C63C00A4E9C0 /* DashSpendLoginInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashSpendLoginInfoView.swift; sourceTree = "<group>"; };
@@ -3121,6 +3139,9 @@
 		A17EED0126C7000000000002 /* WalletWipeSerialExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletWipeSerialExecutorTests.swift; sourceTree = "<group>"; };
 		A59D5720437F8A4137605940 /* PaymentRequestVerifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentRequestVerifier.swift; sourceTree = "<group>"; };
 		A62C70E4EBB7458C362B7669 /* InternalTransferScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InternalTransferScreen.swift; sourceTree = "<group>"; };
+		C0172000000000000003A1 /* PaymentsTabRootController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsTabRootController.swift; sourceTree = "<group>"; };
+		C0172000000000000007A1 /* PaymentsReceiveContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsReceiveContent.swift; sourceTree = "<group>"; };
+		C0172000000000000001A1 /* PaymentsTabSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsTabSelector.swift; sourceTree = "<group>"; };
 		A876A874736D422F781F797F /* SwiftDashSDKReceiveAddressReader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKReceiveAddressReader.swift; sourceTree = "<group>"; };
 		AA00000028D9A3DB00223B77 /* BuySellPortalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuySellPortalView.swift; sourceTree = "<group>"; };
 		AA0000032DUMMYID001234567 /* AddProviderToGiftCardsTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProviderToGiftCardsTable.swift; sourceTree = "<group>"; };
@@ -5601,6 +5622,7 @@
 				47A1B00030B5A10000D15A01 /* SendAmountScreen.swift */,
 				47B30D7F291123D30080C326 /* SendAmountViewController.swift */,
 				47AC8412297822E000BD1B49 /* SpecifyAmountViewController.swift */,
+				C0172000000000000009A1 /* SpecifyAmountView.swift */,
 			);
 			path = Amount;
 			sourceTree = "<group>";
@@ -5623,6 +5645,8 @@
 				2ACCD85A231939D600A96B62 /* Views */,
 				2ACCD8572319399100A96B62 /* DWRequestAmountViewController.h */,
 				2ACCD8582319399100A96B62 /* DWRequestAmountViewController.m */,
+				C017200000000000000AA1 /* RequestAmountScreen.swift */,
+				C017200000000000000BA1 /* RequestAmountHostingController.swift */,
 			);
 			path = RequestAmount;
 			sourceTree = "<group>";
@@ -6886,10 +6910,21 @@
 			path = Codec;
 			sourceTree = "<group>";
 		};
+		C0172000000000000000000 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				C0172000000000000001A1 /* PaymentsTabSelector.swift */,
+				C0172000000000000007A1 /* PaymentsReceiveContent.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		6916981A49557073ABA80EAB /* Landing */ = {
 			isa = PBXGroup;
 			children = (
+				C0172000000000000000000 /* Components */,
 				E735446F9E918618E97EDD38 /* PaymentsLandingScreen.swift */,
+				C0172000000000000003A1 /* PaymentsTabRootController.swift */,
 				FE64C10DA9C338D408982EBE /* PaymentsLandingViewModel.swift */,
 				B401E660599FEF6B18087F91 /* PaymentsLandingHostingController.swift */,
 			);
@@ -6998,6 +7033,7 @@
 				75EBAA0E2BB99036004488E3 /* TextIntro.swift */,
 				RC00A0032FA0000000000001 /* TopIntro.swift */,
 				75BDE7AB2BF3287400556791 /* Toast.swift */,
+				C0172000000000000008A1 /* TransientToastModifier.swift */,
 				75AA33CE2BF9D44A00F12465 /* ButtonsGroup.swift */,
 				75AA33D12BF9E18E00F12465 /* Color+DWStyle.swift */,
 				75AA33D42BF9E1D400F12465 /* Font+DWStyle.swift */,
@@ -9919,6 +9955,9 @@
 				759609232C455B2000F3BF04 /* SendIntro.swift in Sources */,
 				7549BE5A2DEAF50D004F0BAF /* IconBitmap.swift in Sources */,
 				47AC8413297822E000BD1B49 /* SpecifyAmountViewController.swift in Sources */,
+				C0172000000000000009A2 /* SpecifyAmountView.swift in Sources */,
+				C017200000000000000BA2 /* RequestAmountHostingController.swift in Sources */,
+				C017200000000000000AA2 /* RequestAmountScreen.swift in Sources */,
 				2AFCB9C423BE76EC00FF59A6 /* DWUpholdTransactionObject+DWView.m in Sources */,
 				75CDD7862C08D61300F433D2 /* DashAmount.swift in Sources */,
 				114CFED0296469D9005F421B /* CrowdNodeDepositTx.swift in Sources */,
@@ -10264,6 +10303,7 @@
 				753130972B4944130069C9B7 /* UpholdError.swift in Sources */,
 				2A913E9823A400D3006A2A59 /* DWContainerViewController.m in Sources */,
 				75BDE7AC2BF3287400556791 /* Toast.swift in Sources */,
+				C0172000000000000008A2 /* TransientToastModifier.swift in Sources */,
 				47B30D7A290D035B0080C326 /* DashTextAttachment.swift in Sources */,
 				BA1A0003C0FFEE00B15A0003 /* BalanceInfoSheet.swift in Sources */,
 				C9F067F229E4576D0022D958 /* HomeBalanceView.swift in Sources */,
@@ -10364,6 +10404,9 @@
 				0EB4679BC135B464D90CDC8B /* TransferTimingSheet.swift in Sources */,
 				EF053C0D81A007CC015EB3EE /* InternalTransferViewModel.swift in Sources */,
 				58825FFD2913876CC5D4AA21 /* InternalTransferScreen.swift in Sources */,
+				C0172000000000000001A2 /* PaymentsTabSelector.swift in Sources */,
+				C0172000000000000007A2 /* PaymentsReceiveContent.swift in Sources */,
+				C0172000000000000003A2 /* PaymentsTabRootController.swift in Sources */,
 				7C93319817E9E574070A504D /* InternalTransferHostingController.swift in Sources */,
 				C6344885F1E0A6C04D3D8437 /* InternalTransferConfirmSheet.swift in Sources */,
 				A15ED0B9E7AAF29C694E4E17 /* DWIdentityAuthorizer.swift in Sources */,
@@ -10895,6 +10938,7 @@
 				C9D2C7A32A320AA000D15901 /* DWVersionManager.m in Sources */,
 				C9D2C7A52A320AA000D15901 /* DWModalPresentationController.m in Sources */,
 				75BDE7AD2BF3287400556791 /* Toast.swift in Sources */,
+				C0172000000000000008A3 /* TransientToastModifier.swift in Sources */,
 				C9D2C7A72A320AA000D15901 /* ActionButtonViewController.swift in Sources */,
 				C9D2C7A82A320AA000D15901 /* BuySellServiceItemCell.swift in Sources */,
 				C956AF122A5B5949002FAB75 /* PasteboardContentView.swift in Sources */,
@@ -10911,6 +10955,9 @@
 				C9D2C7B12A320AA000D15901 /* CoinbaseBaseIDForCurrencyResponse.swift in Sources */,
 				C9D2C7B22A320AA000D15901 /* (null) in Sources */,
 				C9D2C7B32A320AA000D15901 /* SpecifyAmountViewController.swift in Sources */,
+				C0172000000000000009A3 /* SpecifyAmountView.swift in Sources */,
+				C017200000000000000BA3 /* RequestAmountHostingController.swift in Sources */,
+				C017200000000000000AA3 /* RequestAmountScreen.swift in Sources */,
 				756557B62CE84FFA0060348D /* FeeInfo.swift in Sources */,
 				C943B5922A40ED7B00AF23C5 /* DWTextField.m in Sources */,
 				75EBAA0D2BB9792F004488E3 /* FeatureTopText.swift in Sources */,
@@ -11401,6 +11448,9 @@
 				1C2999FF1FC854E7DB138250 /* TransferTimingSheet.swift in Sources */,
 				FF4A426923D0CF755AE981FB /* InternalTransferViewModel.swift in Sources */,
 				EFCF9D5D6630AD9BD0A62E29 /* InternalTransferScreen.swift in Sources */,
+				C0172000000000000001A3 /* PaymentsTabSelector.swift in Sources */,
+				C0172000000000000007A3 /* PaymentsReceiveContent.swift in Sources */,
+				C0172000000000000003A3 /* PaymentsTabRootController.swift in Sources */,
 				428C56F90F533CF0DD6774F1 /* InternalTransferHostingController.swift in Sources */,
 				E2D0F4AD56B92356C871F568 /* InternalTransferConfirmSheet.swift in Sources */,
 				17ED79A8B56522CD03A8CD5E /* ShieldedTransferCoordinator.swift in Sources */,

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -22,6 +22,28 @@ import SwiftDashSDK
 
 @objc
 extension UIViewController {
+    /// The tab bar controller somewhere at or under this one, searching
+    /// children and then anything presented.
+    ///
+    /// Downwards, not upwards: a controller shown as a sheet sits outside the
+    /// tab bar's hierarchy, so `tabBarController` is nil for it and walking
+    /// presenters only finds whoever called `present`. Started from the
+    /// window's root this finds the tab bar from anywhere.
+    ///
+    /// Two private copies of this already exist (`SwapTransactionStatus…`,
+    /// `BuyReceive…`); this is the shared one they should collapse into.
+    @objc
+    func dw_firstTabBarController() -> UITabBarController? {
+        if let tabBarController = self as? UITabBarController { return tabBarController }
+        for child in children {
+            if let tabBarController = child.dw_firstTabBarController() { return tabBarController }
+        }
+        if let presented = presentedViewController {
+            return presented.dw_firstTabBarController()
+        }
+        return nil
+    }
+
     @objc
     func topController() -> UIViewController {
         if let vc = self as? UITabBarController {

--- a/DashWallet/Sources/UI/Coinbase/Transfer Amount/TransferAmountView.swift
+++ b/DashWallet/Sources/UI/Coinbase/Transfer Amount/TransferAmountView.swift
@@ -109,10 +109,6 @@ struct TransferAmountView<ViewModel: TransferAmountViewModelProtocol>: View {
             inProgress: viewModel.isProcessing,
             actionHandler: { viewModel.transfer() }
         )
-        .frame(maxWidth: .infinity, maxHeight: 320)
-        .background(Color.dash.secondaryBackground)
-        .clipShape(.rect(cornerRadius: 20))
-        .background(Color.dash.secondaryBackground, ignoresSafeAreaEdges: .bottom)
     }
 }
 

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -807,7 +807,6 @@ struct PayContactSheet: View {
             inProgress: isSending,
             actionHandler: { pay() }
         )
-        .padding(.top, 8)
     }
 
     /// Fiat equivalent of what is typed, for the secondary line. Empty while

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendSinglePanel.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendSinglePanel.swift
@@ -140,9 +140,6 @@ struct DashSpendSinglePanel: View {
                 inProgress: inProgress,
                 actionHandler: onAction
             )
-            .frame(maxWidth: .infinity)
-            .bottomPanelStyle()
-            .background(Color.dash.secondaryBackground, ignoresSafeAreaEdges: .bottom)
         }
 
     }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift
@@ -157,10 +157,6 @@ struct DashSpendUserAuthScreen: View {
                         viewModel.onContinue()
                     }
                 )
-                .frame(maxWidth: .infinity)
-                .frame(height: UIDevice.isIphone5OrLess ? 290 : 320)
-                .padding(.horizontal, 20)
-                .padding(.bottom, 20)
             } else {
                 ZStack(alignment: .center) {
                     DashButton(

--- a/DashWallet/Sources/UI/Main/MainTabbarController.swift
+++ b/DashWallet/Sources/UI/Main/MainTabbarController.swift
@@ -122,6 +122,17 @@ class MainTabbarController: UITabBarController {
     private var paymentIsOpened = false
 
     weak var homeController: HomeViewController?
+    /// Root of the payments tab. Held so shortcut entry points can put it on
+    /// the right sub-tab before selecting it. Rebuilt by
+    /// `configureControllers()`, which also refreshes `paymentsTabIndex` —
+    /// the DashPay layout inserts tabs before this one.
+    private weak var paymentsTabRootController: PaymentsTabRootController?
+    private var paymentsTabIndex: Int?
+    #if DASHPAY
+    /// Nil until an identity exists — the Contacts tab is only built then, and
+    /// its position moves with the rest of the DashPay layout.
+    private var contactsTabIndex: Int?
+    #endif
     weak var menuNavigationController: MainMenuViewController?
 
     #if DASHPAY
@@ -216,6 +227,19 @@ class MainTabbarController: UITabBarController {
 extension MainTabbarController {
     private func configureControllers() {
         var viewControllers: [UIViewController] = []
+        // The bar is hidden by children — the payments landing does it while it
+        // is up — and hiding outlives the child that asked for it. A rebuild
+        // replaces `viewControllers` outright, which can take that child out of
+        // the hierarchy without a `viewWillDisappear` to undo it, leaving a
+        // wallet with no tab bar at all. Whoever wants it hidden after this
+        // will say so again on their next appearance.
+        setTabBarHidden(false, animated: false)
+        #if DASHPAY
+        // Cleared before the rebuild, not after: this pass may be the one that
+        // drops the Contacts tab (a wallet switch away from an identity), and a
+        // surviving index would then point at whatever took its place.
+        contactsTabIndex = nil
+        #endif
 
         // Home
         var item = MainTabbarTabs.home.tabBarItem()
@@ -240,16 +264,24 @@ extension MainTabbarController {
 
             let contactsVC = UIHostingController(rootView: ContactsScreen())
             contactsVC.tabBarItem = item
+            contactsTabIndex = viewControllers.count
             viewControllers.append(contactsVC)
         }
         #endif
 
-        // Payment (tapping this tab opens the payment modal instead of switching tabs)
+        // Payment. A real tab, not a modal: the landing is where the send /
+        // receive / transfer flows start, and the tab bar stays visible on it.
+        // The screens it pushes set `hidesBottomBarWhenPushed`, so the bar is
+        // gone from the first step that asks for an amount.
         let paymentImage = Self.makePaymentTabImage()
         item = MainTabbarTabs.payment.tabBarItem(image: paymentImage, selectedImage: paymentImage)
 
-        let paymentVC = EmptyController()
+        let paymentsRoot = PaymentsTabRootController()
+        paymentsTabRootController = paymentsRoot
+        let paymentVC = BaseNavigationController(rootViewController: paymentsRoot)
+        paymentVC.isNavigationBarHidden = true
         paymentVC.tabBarItem = item
+        paymentsTabIndex = viewControllers.count
         viewControllers.append(paymentVC)
         
         #if DASHPAY
@@ -433,6 +465,25 @@ extension MainTabbarController {
 
 // MARK: - Public
 extension MainTabbarController {
+    /// Switch to the history. Used by flows that finish somewhere else and
+    /// want the user to land where their transaction shows up.
+    @objc
+    public func showHome() {
+        selectedIndex = MainTabbarTabs.home.rawValue
+    }
+
+    #if DASHPAY
+    /// Switch to the contacts tab. Returns false when there is none — the tab
+    /// exists only alongside a DashPay identity — so the caller can say so
+    /// rather than appearing to do nothing.
+    @discardableResult
+    func showContacts() -> Bool {
+        guard let contactsTabIndex else { return false }
+        selectedIndex = contactsTabIndex
+        return true
+    }
+    #endif
+
     @objc
     public func performScanQRCodeAction() {
         dismiss(animated: false, completion: nil)
@@ -532,12 +583,35 @@ extension MainTabbarController: HomeViewControllerDelegate {
     func showPaymentsController(withActivePage pageIndex: PaymentsViewControllerState) {
         switch pageIndex {
         case .receive:
-            presentPaymentsLandingScreen(activeTab: .receive)
+            selectPaymentsTab(activeTab: .receive)
         case .enterAddress:
             presentSendToAddressScreen()
         case .pay, .none:
-            presentPaymentsLandingScreen(activeTab: .send)
+            selectPaymentsTab(activeTab: .send)
         }
+    }
+
+    /// Payments open as a large-detent sheet over whatever the user was
+    /// looking at, not as a tab switched to.
+    ///
+    /// The tab bar item stays — it is still how you get here — but selecting
+    /// its index is intercepted in `shouldSelect`. A sheet keeps the screen
+    /// underneath visible at the top and brings its own grabber and
+    /// swipe-to-dismiss, which is what "not full screen" means here.
+    ///
+    /// Every shortcut and menu entry comes through this one path, so they all
+    /// start at the destination picker rather than wherever a long-lived tab
+    /// was last left.
+    private func selectPaymentsTab(activeTab: PaymentsLandingTab) {
+        // Re-entering while it is already up would either fail silently or
+        // stack a second copy; put the open one on the requested tab instead.
+        if let presented = presentedViewController as? BaseNavigationController,
+           let landing = presented.viewControllers.first as? PaymentsLandingHostingController {
+            presented.popToRootViewController(animated: false)
+            landing.select(tab: activeTab)
+            return
+        }
+        presentPaymentsLandingScreen(activeTab: activeTab, showsHeader: false, asSheet: true)
     }
 
     /// The "Send to Address" shortcut skips the payments landing: straight
@@ -618,11 +692,14 @@ extension MainTabbarController: HomeViewControllerDelegate {
 
 extension MainTabbarController: UITabBarControllerDelegate {
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
-        if viewController is EmptyController {
-            showPaymentsController(withActivePage: .none)
+        // Payments is a sheet, not a destination. Its tab item is kept because
+        // it is the button everyone reaches for, but selecting the index would
+        // put the landing full screen — the presentation it was moved off.
+        if let paymentsTabIndex,
+           viewControllers?.firstIndex(of: viewController) == paymentsTabIndex {
+            selectPaymentsTab(activeTab: .send)
             return false
         }
-
         return true
     }
 }

--- a/DashWallet/Sources/UI/Payments/Amount/SendAmountScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/SendAmountScreen.swift
@@ -244,8 +244,6 @@ private struct SendAmountKeyboardSection: View {
                 inProgress: isLoading,
                 actionHandler: onSend
             )
-            .padding(.top, 10)
-            .padding(.bottom, 15)
         }
     }
 }

--- a/DashWallet/Sources/UI/Payments/Amount/SpecifyAmountView.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/SpecifyAmountView.swift
@@ -1,0 +1,156 @@
+//
+//  Created by tkhp
+//  Copyright © 2023 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DashUIKit
+import SwiftUI
+
+/// The amount step of the Receive flow: a title, the dual-currency amount
+/// field and the keypad that drives it.
+///
+/// Driven entirely by `BaseAmountModel` and three closures — the controller
+/// owns navigation, the currency list and what "Receive" means.
+struct SpecifyAmountView: View {
+    @ObservedObject var model: BaseAmountModel
+    let onBack: () -> Void
+    let onReceive: () -> Void
+    let onCurrencyTap: () -> Void
+
+    private func displayAmountString(from formatted: String, locale: Locale) -> String {
+        let decimalSeparator = locale.decimalSeparator ?? "."
+        let groupingSeparator = locale.groupingSeparator ?? ","
+        let allowed = CharacterSet.decimalDigits
+            .union(CharacterSet(charactersIn: decimalSeparator + groupingSeparator))
+        let trimmed = formatted.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered = String(trimmed.unicodeScalars.filter { allowed.contains($0) })
+        return filtered.isEmpty ? trimmed : filtered
+    }
+
+    private var primaryAmountNumeric: String {
+        displayAmountString(from: model.mainAmountString, locale: model.keyboardLocale)
+    }
+
+    private var secondaryAmountNumeric: String {
+        displayAmountString(from: model.supplementaryAmountString, locale: model.keyboardLocale)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            NavigationBar(leading: {
+                NavigationBarElement.back.button { onBack() }
+            })
+
+            VStack(alignment: .leading, spacing: 20) {
+                Text(NSLocalizedString("Specify Amount", comment: "Specify Amount"))
+                    .dashFont(.title1)
+                    .foregroundStyle(Color.dash.primaryText)
+
+
+                DashUIKit.EnterAmountView(
+                    primaryAmount: primaryAmountNumeric,
+                    secondaryAmount: secondaryAmountNumeric,
+                    primaryCurrency: .dash,
+                    secondaryCurrency: .fiat(model.localCurrencyCode),
+                    isPrimarySelected: model.currentInputItem.isMain,
+                    isCurrencySelectorHidden: model.isCurrencySelectorHidden,
+                    currencyCodes: model.inputItems.map { $0.currencyCode },
+                    selectedCurrencyCode: model.currentInputItem.currencyCode,
+                    onMax: nil,
+                    onSwap: { model.amountInputControlDidSwapInputs() },
+                    onCurrencyTap: onCurrencyTap,
+                    onPaste: model.pasteFromClipboard,
+                    onSelectInputType: { code in
+                        if let index = model.inputItems.firstIndex(where: { $0.currencyCode == code }) {
+                            model.selectInputItem(at: index)
+                        }
+                    }
+                )
+                // A fixed height, not a minimum: `EnterAmountView` ends in
+                // `frame(maxHeight: .infinity)`, so given only a floor it
+                // eats the `Spacer` below and centres the amount in the
+                // gap between the title and the keypad. 110 is the height
+                // its own preview uses.
+                .frame(height: 110)
+
+
+                Spacer(minLength: 0)
+            }
+            .padding(.top, 10)
+            .padding(.horizontal, 20)
+
+            HardwareNumericKeyboardView(
+                value: Binding(
+                    get: { model.currentInputString },
+                    set: { model.updateKeyboardInputString($0) }
+                ),
+                showDecimalSeparator: true,
+                locale: model.keyboardLocale,
+                actionButtonText: NSLocalizedString("Receive", comment: "Specify Amount"),
+                actionEnabled: model.isAllowedToContinue,
+                inProgress: false,
+                actionHandler: onReceive
+            )
+
+        }
+        .background(Color.dash.primaryBackground)
+    }
+}
+
+#if DEBUG
+
+/// `BaseAmountModel()` is what the controller itself builds. Its initializer
+/// subscribes to published wallet balance and reads exchange rates, both of
+/// which resolve to nothing without a wallet — it does not reach for the FFI,
+/// so it stands up in a canvas as-is.
+@MainActor
+private func specifyAmountSample(typed: String? = nil) -> some View {
+    let model = BaseAmountModel()
+    if let typed {
+        model.updateKeyboardInputString(typed)
+    }
+    return SpecifyAmountView(
+        model: model,
+        onBack: {},
+        onReceive: {},
+        onCurrencyTap: {})
+}
+
+@available(iOS 17, *)
+#Preview("Empty") {
+    specifyAmountSample()
+}
+
+/// With an amount the Receive button enables — and this is the layout to watch:
+/// the amount belongs directly under the title, not floating in the middle.
+@available(iOS 17, *)
+#Preview("Amount entered") {
+    specifyAmountSample(typed: "1.25")
+}
+
+@available(iOS 17, *)
+#Preview("Dark") {
+    specifyAmountSample(typed: "1.25")
+        .preferredColorScheme(.dark)
+}
+
+/// The title wraps and the keypad still has to fit above the safe area.
+@available(iOS 17, *)
+#Preview("Large type") {
+    specifyAmountSample()
+        .environment(\.dynamicTypeSize, .accessibility1)
+}
+
+#endif

--- a/DashWallet/Sources/UI/Payments/Amount/SpecifyAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/SpecifyAmountViewController.swift
@@ -48,7 +48,7 @@ final class SpecifyAmountViewController: ActionButtonViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor(named: "SecondaryBackground", in: .dashUIKit, compatibleWith: .current)
+        view.backgroundColor = UIColor(named: "PrimaryBackground", in: .dashUIKit, compatibleWith: .current)
         configureHierarchy()
     }
 
@@ -79,7 +79,7 @@ final class SpecifyAmountViewController: ActionButtonViewController {
         )
 
         let hostingController = UIHostingController(rootView: rootView)
-        hostingController.view.backgroundColor = UIColor(named: "SecondaryBackground", in: .dashUIKit, compatibleWith: .current)
+        hostingController.view.backgroundColor = UIColor(named: "PrimaryBackground", in: .dashUIKit, compatibleWith: .current)
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 
         addChild(hostingController)
@@ -116,90 +116,5 @@ extension SpecifyAmountViewController: DWLocalCurrencyViewControllerDelegate {
 
     func localCurrencyViewControllerDidCancel(_ controller: DWLocalCurrencyViewController) {
         controller.dismiss(animated: true)
-    }
-}
-
-private struct SpecifyAmountView: View {
-    @ObservedObject var model: BaseAmountModel
-    let onBack: () -> Void
-    let onReceive: () -> Void
-    let onCurrencyTap: () -> Void
-
-    private func displayAmountString(from formatted: String, locale: Locale) -> String {
-        let decimalSeparator = locale.decimalSeparator ?? "."
-        let groupingSeparator = locale.groupingSeparator ?? ","
-        let allowed = CharacterSet.decimalDigits
-            .union(CharacterSet(charactersIn: decimalSeparator + groupingSeparator))
-        let trimmed = formatted.trimmingCharacters(in: .whitespacesAndNewlines)
-        let filtered = String(trimmed.unicodeScalars.filter { allowed.contains($0) })
-        return filtered.isEmpty ? trimmed : filtered
-    }
-
-    private var primaryAmountNumeric: String {
-        displayAmountString(from: model.mainAmountString, locale: model.keyboardLocale)
-    }
-
-    private var secondaryAmountNumeric: String {
-        displayAmountString(from: model.supplementaryAmountString, locale: model.keyboardLocale)
-    }
-
-    var body: some View {
-        ZStack(alignment: .top) {
-            Color.dash.primaryBackground
-                .ignoresSafeArea(edges: .top)
-
-            VStack(spacing: 0) {
-                NavigationBar(leading: {
-                    NavigationBarElement.back.button { onBack() }
-                })
-                .background(Color.dash.secondaryBackground)
-
-                VStack(alignment: .leading, spacing: 26) {
-                    Text(NSLocalizedString("Specify Amount", comment: "Specify Amount"))
-                        .font(.largeTitle.weight(.bold))
-                        .foregroundColor(Color.dash.primaryText)
-                        .padding(.top, 10)
-
-                    DashUIKit.EnterAmountView(
-                        primaryAmount: primaryAmountNumeric,
-                        secondaryAmount: secondaryAmountNumeric,
-                        primaryCurrency: .dash,
-                        secondaryCurrency: .fiat(model.localCurrencyCode),
-                        isPrimarySelected: model.currentInputItem.isMain,
-                        isCurrencySelectorHidden: model.isCurrencySelectorHidden,
-                        currencyCodes: model.inputItems.map { $0.currencyCode },
-                        selectedCurrencyCode: model.currentInputItem.currencyCode,
-                        onMax: nil,
-                        onSwap: { model.amountInputControlDidSwapInputs() },
-                        onCurrencyTap: onCurrencyTap,
-                        onPaste: model.pasteFromClipboard,
-                        onSelectInputType: { code in
-                            if let index = model.inputItems.firstIndex(where: { $0.currencyCode == code }) {
-                                model.selectInputItem(at: index)
-                            }
-                        }
-                    )
-                    .frame(minHeight: 90)
-
-                    Spacer(minLength: 0)
-
-                    HardwareNumericKeyboardView(
-                        value: Binding(
-                            get: { model.currentInputString },
-                            set: { model.updateKeyboardInputString($0) }
-                        ),
-                        showDecimalSeparator: true,
-                        locale: model.keyboardLocale,
-                        actionButtonText: NSLocalizedString("Receive", comment: "Specify Amount"),
-                        actionEnabled: model.isAllowedToContinue,
-                        inProgress: false,
-                        actionHandler: onReceive
-                    )
-                }
-                .padding(.horizontal, 20)
-                .padding(.bottom, 20)
-                .background(Color.dash.secondaryBackground)
-            }
-        }
     }
 }

--- a/DashWallet/Sources/UI/Payments/Landing/Components/PaymentsReceiveContent.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/Components/PaymentsReceiveContent.swift
@@ -1,0 +1,466 @@
+//
+//  Created by Roman Chornyi
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import DashUIKit
+
+/// The Receive tab: the balance toggle, the QR for its address, and the two
+/// actions on that address.
+///
+/// Takes the view model rather than a resolved address, because the toggle
+/// writes back to it and the placeholder wording depends on which balance is
+/// selected — passing the parts separately would just rebuild the same object.
+struct PaymentsReceiveContent: View {
+    @ObservedObject var viewModel: PaymentsLandingViewModel
+
+    var onCopyAddress: () -> Void
+    var onShareAddress: () -> Void
+    var onSpecifyAmount: () -> Void
+    /// Opens the transaction behind a receipt. Passed through rather than
+    /// acted on — which controller presents the details is the host's.
+    var onViewTransaction: (Data) -> Void = { _ in }
+    /// Closes the whole receive surface from the receipt's Done button.
+    var onDone: () -> Void = {}
+    /// `nil` renders the row dimmed and untappable. There is no import flow to
+    /// route to yet — `ShortcutAction.importPrivateKey` is still a `break` in
+    /// `HomeViewController+Shortcuts` — and a row that silently does nothing
+    /// reads as a broken button.
+    var onImportPrivateKey: (() -> Void)? = nil
+
+    /// Which way the last network change moved along `receiveNetworks`, so the
+    /// incoming card slides in from the side it came from — the same rule the
+    /// tab selector above follows.
+    @State private var slidesForward = true
+
+    private enum Layout {
+        /// Matches `SegmentedControlLayout`'s own spring, so the pill and the
+        /// card it selects travel together.
+        static let slideResponse: Double = 0.3
+        static let slideDamping: Double = 0.7
+    }
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 20) {
+            if let receipt = viewModel.receipt {
+                // A payment landed while this screen was being presented. The
+                // receipt takes the whole surface: the address it was paid to
+                // is spent attention now, and the next thing the user does is
+                // finish or receive another.
+                ReceiveReceiptCard(
+                    receipt: receipt,
+                    canViewTransaction: viewModel.canViewTransaction,
+                    onViewTransaction: onViewTransaction,
+                    onReceiveAnother: viewModel.receiveAnother,
+                    onDone: onDone)
+                    .transition(.scale(scale: 0.94).combined(with: .opacity))
+            } else {
+                addressContent
+            }
+        }
+    }
+
+    // MARK: - Network selection
+
+    /// Which address the card shows, as a row of buttons rather than a
+    /// `SegmentedControl` — the design puts this inside the card, where the
+    /// pill control's own background would be a second surface on top of the
+    /// card's.
+    ///
+    /// `fillsWidth` on each so the three divide the row evenly; without it,
+    /// zero spacing would clump them at the leading edge. The selected one
+    /// carries the tint and the others are plain, because three identical
+    /// buttons would leave the screen unable to say which address is on it.
+    private var networkRow: some View {
+        HStack(spacing: 0) {
+            ForEach(viewModel.receiveNetworks) { network in
+                DashUIKit.DashButton(
+                    text: network.title,
+                    fillsWidth: true,
+                    size: .medium,
+                    style: network == viewModel.network ? .tintedGray : .plainBlack,
+                    action: { select(network) }
+                )
+            }
+        }
+        .padding(20)
+    }
+
+    /// Everything that changes the network goes through here so the direction
+    /// of travel is known before the change lands — the card has to enter from
+    /// whichever side the new segment sits on, and only this knows which.
+    private var networkSelection: Binding<ChainNetwork> {
+        Binding(
+            get: { viewModel.network },
+            set: { select($0) })
+    }
+
+    private func select(_ network: ChainNetwork) {
+        let options = viewModel.receiveNetworks
+        guard let from = options.firstIndex(of: viewModel.network),
+              let to = options.firstIndex(of: network),
+              from != to
+        else { return }
+
+        slidesForward = to > from
+        withAnimation(.spring(response: Layout.slideResponse,
+                              dampingFraction: Layout.slideDamping)) {
+            viewModel.network = network
+        }
+    }
+
+    /// Matches the direction of travel: moving right, the new card enters from
+    /// the right and the old one leaves to the left.
+    private var slide: AnyTransition {
+        .asymmetric(
+            insertion: .move(edge: slidesForward ? .trailing : .leading),
+            removal: .move(edge: slidesForward ? .leading : .trailing))
+    }
+
+    /// The QR, the address and the actions — everything the screen shows while
+    /// it is still waiting to be paid.
+    private var addressContent: some View {
+        VStack(alignment: .center, spacing: 20) {
+            VStack(spacing: 0) {
+                // Inside the card, and outside the animated block below it:
+                // the control that causes the change must not travel with what
+                // it changes.
+                networkRow
+
+                // The card itself holds still — only what is inside it travels.
+                // ZStack so the outgoing and incoming contents share one slot
+                // instead of stacking; keyed on the network so a change reads
+                // as a replacement to animate rather than an in-place edit of
+                // the QR and the address.
+                ZStack(alignment: .top) {
+                    cardBody
+                        .id(viewModel.network)
+                        .transition(slide)
+                }
+                // Keeps the travelling contents inside the card's edges. Square
+                // rather than the card's 20pt radius: nothing is drawn near the
+                // corners, so the rounding would cost a mask for no visible
+                // difference.
+                .clipped()
+            }
+            .modifier(MenuViewModifier(innerPadding: 0))
+
+            // import private key - if needed
+
+            if onImportPrivateKey != nil {
+                Button {
+                    onImportPrivateKey?()
+                } label: {
+                    DashUIKit.MenuItem(
+                        leadingIcon: .custom(DashIcon.Menu.importPrivateKey.rawValue, bundle: .dashUIKit),
+                        title: NSLocalizedString("Import private key", comment: "Payments"),
+                        accessory: .none
+                    )
+                    .modifier(MenuViewModifier())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    /// What the card shows for the selected network: the QR, the address and
+    /// the actions on it.
+    private var cardBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+                VStack(alignment: .center, spacing: 20) {
+                    qrCard
+
+                    // 12, not 40: the address needs every point it can get to
+                    // stay on one line, and the gap was spending them on
+                    // nothing. `maxWidth: .infinity` on the text column is what
+                    // keeps the copy button on the trailing edge now that the
+                    // gap no longer pushes it there.
+                    HStack(spacing: 12) {
+                        if let address = viewModel.currentAddress {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(NSLocalizedString("Your DASH address", comment: "Payments"))
+                                    .dashFont(.footnote)
+                                    .foregroundStyle(Color.dash.secondaryText)
+
+                                // One line, and cut in the middle when it does
+                                // not fit. A Dash address is a single token the
+                                // user reads across to check; broken over two
+                                // lines it reads as two. Cutting the tail hides
+                                // the half people actually check — the last
+                                // characters are what gets compared against the
+                                // sender's screen — so both ends stay.
+                                Text(address)
+                                    .dashFont(.subhead)
+                                    .foregroundColor(.dash.primaryText)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            // The address is the thing the user is reaching
+                            // for; the button beside it is the affordance, not
+                            // the only target. Tapping the text copies too.
+                            .contentShape(Rectangle())
+                            .onTapGesture { onCopyAddress() }
+                            .accessibilityElement(children: .combine)
+                            .accessibilityAddTraits(.isButton)
+                            .accessibilityHint(Text(NSLocalizedString("Copy", comment: "")))
+                        } else {
+                            Text(NSLocalizedString("No address available", comment: "Payments"))
+                                .font(.footnote)
+                                .foregroundColor(Color.dash.secondaryText)
+                        }
+
+
+                        DashUIKit.DashButton(
+                            leadingIcon: .custom(DashIcon.Icons.copyOutline.rawValue, bundle: .dashUIKit),
+                            isEnabled: hasAddress,
+                            size: .medium,
+                            style: .tintedGray,
+                            action: onCopyAddress
+                        )
+                    }
+                    .padding(.vertical, 6)
+                }
+                // Stretches the QR/address block across the card. Without it
+                // the block sizes to its content and the leading-aligned card
+                // pins it left, which is what happened when the row's spacing
+                // stopped being wide enough to fill the width on its own.
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 20)
+                .padding(.top, 40)
+                .padding(.bottom, 10)
+
+                // `isEnabled:` rather than `.disabled(…)`: DashButton derives
+                // its own colours from that property and applies `.disabled`
+                // internally, so an outside modifier blocks the tap but leaves
+                // the button looking live.
+                HStack(spacing: 20) {
+                    DashUIKit.DashButton(
+                        text: NSLocalizedString("Share address", comment: "Payments"),
+                        isEnabled: hasAddress,
+                        size: .medium,
+                        style: .tintedGray,
+                        action: onShareAddress
+                    )
+
+                    DashUIKit.DashButton(
+                        text: NSLocalizedString("Specify amount", comment: "Payments"),
+                        isEnabled: hasAddress && viewModel.network == .core,
+                        size: .medium,
+                        style: .tintedGray,
+                        action: onSpecifyAmount
+                    )
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+
+                watchingForPayment
+                    .padding(.top, 14)
+                    .padding(.bottom, 20)
+        }
+    }
+
+    @ViewBuilder
+    private var watchingForPayment: some View {
+        if viewModel.isWatchingForReceipt {
+            ReceiveWatchingIndicator()
+        }
+    }
+
+    private var hasAddress: Bool {
+        viewModel.currentAddress != nil
+    }
+
+    // MARK: - QR
+
+    @ViewBuilder
+    private var qrCard: some View {
+        VStack(spacing: 20) {
+            if let address = viewModel.currentAddress,
+               let qr = QRCodeGenerator.image(for: address) {
+                Image(uiImage: qr)
+                    .interpolation(.none)
+                    .resizable()
+                    .frame(width: 200, height: 200)
+                    // White in both themes, not `secondaryBackground`: this is
+                    // the code's quiet zone, and a scanner needs the contrast
+                    // whatever the app is wearing. Without it the dark card ran
+                    // straight up to the modules.
+                    .padding(10)
+                    .background(Color.dash.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            } else if viewModel.network == .platform && !viewModel.platformIsReady {
+                placeholder(NSLocalizedString("Platform sync starting…", comment: ""))
+            } else if viewModel.network == .shielded {
+                // Nil only until the shielded sub-wallet binds at startup
+                // (the view model retries as the platform stack comes up).
+                placeholder(NSLocalizedString("Shielded wallet starting…", comment: ""))
+            } else {
+                placeholder(NSLocalizedString("No address available", comment: ""))
+            }
+        }
+    }
+
+    /// Same 220pt square the QR occupies (200 + 10 padding a side), so
+    /// switching balances doesn't make the actions below jump.
+    private func placeholder(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            SwiftUI.ProgressView()
+            Text(message)
+                .font(.footnote)
+                .foregroundColor(Color.dash.secondaryText)
+        }
+        .frame(width: 220, height: 220)
+    }
+
+}
+
+// MARK: - ReceiveReceiptCard
+
+/// The payment that just landed, in place of the address it was paid to.
+///
+/// Ported from the attended-receive work rather than rebuilt: the header is the
+/// same `PaymentSuccessHeader` the send flow finishes on, so a receipt and a
+/// sent confirmation read as two sides of one screen instead of two designs.
+///
+/// It reports rather than acts — which controller shows the transaction, and
+/// what Done closes, are the host's to decide.
+private struct ReceiveReceiptCard: View {
+    let receipt: ReceiveReceipt
+    let canViewTransaction: Bool
+    let onViewTransaction: (Data) -> Void
+    let onReceiveAnother: () -> Void
+    let onDone: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            PaymentSuccessHeader(
+                title: NSLocalizedString("Received", comment: "Receive success title"),
+                amountDuffs: Int64(clamping: receipt.amountDuffs),
+                fiatText: CurrencyExchanger.shared.fiatAmountString(
+                    for: receipt.amountDuffs.dashAmount))
+
+            VStack(spacing: 8) {
+                row(NSLocalizedString("Balance", comment: "Receive receipt rail"),
+                    receipt.rail.balanceName)
+                row(NSLocalizedString("Status", comment: "Receive receipt status"),
+                    receipt.statusTitle)
+                row(NSLocalizedString("Time", comment: "Receive receipt time"),
+                    receipt.receivedAt.formatted(date: .omitted, time: .shortened))
+                if let memo = receipt.memo, !memo.isEmpty {
+                    row(NSLocalizedString("Memo", comment: "Receive receipt memo"), memo)
+                }
+            }
+            .padding(14)
+            .modifier(MenuViewModifier(innerPadding: 0))
+
+            if canViewTransaction, let transactionId = receipt.transactionId {
+                Button {
+                    onViewTransaction(transactionId)
+                } label: {
+                    Text(NSLocalizedString("View transaction", comment: "Receive receipt action"))
+                        .dashFont(.subheadMedium)
+                        .foregroundColor(.dash.blue)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer(minLength: 12)
+
+            ButtonsGroup(
+                orientation: .horizontal,
+                size: .large,
+                positiveButtonText: NSLocalizedString("Done", comment: "Receive receipt action"),
+                positiveButtonAction: onDone,
+                negativeButtonText: NSLocalizedString("Receive another", comment: "Receive receipt action"),
+                negativeButtonAction: onReceiveAnother)
+                .padding(.bottom, 16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func row(_ title: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(title)
+                .dashFont(.caption1)
+                .foregroundColor(.dash.secondaryText)
+            Spacer()
+            Text(value)
+                .dashFont(.caption1Medium)
+                .foregroundColor(.dash.primaryText)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+        }
+    }
+}
+
+// MARK: - ReceiveWatchingIndicator
+
+/// Says the screen is doing something on the user's behalf while an address is
+/// on display, so a handoff does not feel like nothing is happening.
+///
+/// Shared with the specify-amount sheet, which makes the same promise over a QR
+/// that carries the amount — the two must not drift into saying it differently.
+struct ReceiveWatchingIndicator: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            // `controlSize`, not `scaleEffect`: scaling resamples the spinner
+            // after it is drawn, which is what turned it into a crunchy
+            // asterisk. This asks UIKit for a small indicator and gets it drawn
+            // at that size.
+            SwiftUI.ProgressView()
+                .controlSize(.small)
+            Text(NSLocalizedString("Watching for a payment…", comment: "Receive screen activity"))
+                .dashFont(.caption1)
+                .foregroundColor(.dash.secondaryText)
+        }
+        .frame(maxWidth: .infinity)
+        .transition(.opacity)
+    }
+}
+
+#if DEBUG
+
+@MainActor
+private func receiveSample(
+    network: ChainNetwork = .core,
+    coreAddress: String? = "XyZ8kFqW3nR5tHmB2vJcL7pQaS4dEuG9wN"
+) -> some View {
+    PaymentsReceiveContent(
+        viewModel: .makeForPreview(activeTab: .receive, network: network, coreAddress: coreAddress),
+        onCopyAddress: {},
+        onShareAddress: {},
+        onSpecifyAmount: {})
+        .padding(.horizontal, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color.dash.primaryBackground)
+}
+
+@available(iOS 17, *)
+#Preview("Core address") {
+    receiveSample()
+}
+
+/// Both action pills disable without an address — the row must not collapse.
+@available(iOS 17, *)
+#Preview("No address") {
+    receiveSample(coreAddress: nil)
+}
+
+#endif

--- a/DashWallet/Sources/UI/Payments/Landing/Components/PaymentsTabSelector.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/Components/PaymentsTabSelector.swift
@@ -1,0 +1,138 @@
+//
+//  Created by Roman Chornyi
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import DashUIKit
+
+/// The payments landing's Receive / Internal / Send selector: an arrow icon
+/// over a label per segment, the selected one raised on a filled pill.
+///
+/// The drawing is the app's `SegmentedControl` in its icon variant, not a
+/// local lookalike. The landing used to hand-roll the same pill and had already
+/// drifted from it — flatter corners, a tighter shadow — while also missing the
+/// sliding indicator, drag-to-select and the `.isSelected` accessibility trait
+/// the shared control provides.
+///
+/// What stays here is the landing's own decision: which tabs to offer, and how
+/// a `PaymentsLandingTab` names and illustrates itself. The balance-row sheets
+/// narrow the list to two, so the caller passes it in rather than the selector
+/// reading `PaymentsLandingViewModel`.
+struct PaymentsTabSelector: View {
+    let tabs: [PaymentsLandingTab]
+    @Binding var selection: PaymentsLandingTab
+
+    var body: some View {
+        SegmentedControl(
+            options: tabs,
+            selection: $selection,
+            label: { $0.title },
+            icon: { tab, isSelected in tab.icon(isSelected: isSelected) })
+    }
+}
+
+/// The arrow a tab draws, in the direction's own colour when it is the selected
+/// tab and in grey when it is not.
+///
+/// Two files per tab rather than one tinted two ways: the colour lives in the
+/// artwork, and a coloured arrow dimmed to the unselected treatment would no
+/// longer match the grey label beside it.
+///
+/// Here rather than beside `title` on the tab itself: the enum lives in the
+/// view model, which has no business importing DashUIKit, and which arrow a tab
+/// shows is this selector's decision the same way the title is.
+private extension PaymentsLandingTab {
+    func icon(isSelected: Bool) -> DashIconSource {
+        switch self {
+        case .receive:
+            return (isSelected ? DashIcon.SegmentedControl.receive : .receiveDisabled).source
+        case .internalTransfer:
+            return (isSelected ? DashIcon.SegmentedControl.transfer : .transferDisabled).source
+        case .send:
+            return (isSelected ? DashIcon.SegmentedControl.send : .sendDisabled).source
+        }
+    }
+}
+
+#if DEBUG
+
+/// Live selection, so the canvas exercises the tap path rather than a frozen
+/// snapshot of one state.
+private struct PaymentsTabSelectorPreview: View {
+    let tabs: [PaymentsLandingTab]
+    @State private var selection: PaymentsLandingTab
+
+    init(tabs: [PaymentsLandingTab] = PaymentsLandingTab.allCases,
+         selection: PaymentsLandingTab = .internalTransfer) {
+        self.tabs = tabs
+        _selection = State(initialValue: selection)
+    }
+
+    var body: some View {
+        PaymentsTabSelector(tabs: tabs, selection: $selection)
+            .padding(20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .background(Color.dash.primaryBackground)
+    }
+}
+
+@available(iOS 17, *)
+#Preview("Three tabs") {
+    PaymentsTabSelectorPreview()
+}
+
+/// Each end of the track — the pill's corners sit inside the container's, so
+/// the first and last segments are where that reads worst.
+@available(iOS 17, *)
+#Preview("First selected") {
+    PaymentsTabSelectorPreview(selection: .receive)
+}
+
+@available(iOS 17, *)
+#Preview("Last selected") {
+    PaymentsTabSelectorPreview(selection: .send)
+}
+
+/// The balance-row receive sheet narrows to two tabs — the segments must
+/// redistribute rather than leave a gap where Send was.
+@available(iOS 17, *)
+#Preview("Two tabs") {
+    PaymentsTabSelectorPreview(
+        tabs: [.receive, .internalTransfer],
+        selection: .receive)
+}
+
+/// One tab: the pill spans the whole track.
+@available(iOS 17, *)
+#Preview("One tab") {
+    PaymentsTabSelectorPreview(tabs: [.internalTransfer])
+}
+
+@available(iOS 17, *)
+#Preview("Dark") {
+    PaymentsTabSelectorPreview()
+        .preferredColorScheme(.dark)
+}
+
+/// Labels grow but the icons don't, and the labels are the only thing that can
+/// wrap — the widest point for the selected pill.
+@available(iOS 17, *)
+#Preview("Large type") {
+    PaymentsTabSelectorPreview()
+        .environment(\.dynamicTypeSize, .accessibility1)
+}
+
+#endif

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -27,6 +27,7 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         let screen = PaymentsLandingScreen(
             viewModel: viewModel,
             onClose: { [weak self] in self?.dismiss(animated: true) },
+            onDone: { [weak self] in self?.finishReceiving() },
             onCopyAddress: { [weak self] in self?.copyCurrentAddress() },
             onShareAddress: { [weak self] in self?.shareCurrentAddress() },
             onSpecifyAmount: { [weak self] in self?.pushSpecifyAmount() },
@@ -43,6 +44,7 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
                     viewModel: self.embeddedSendViewModel,
                     onSendCompleted: { [weak self] in self?.dismiss(animated: true) })
             },
+            onCloseLanding: { [weak self] in self?.leaveLanding() },
             showsHeader: showsHeader)
         return UIHostingController(rootView: screen)
     }()
@@ -54,6 +56,22 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
     private static let shieldedBalanceTimingShownKey = "DWShieldedBalanceTimingShown"
 
     private var cancellables = Set<AnyCancellable>()
+    /// Set while the receive flow pushes one of its OWN steps.
+    ///
+    /// Specify Amount is not somewhere else — it is the next screen of the same
+    /// receive, and the address it is naming an amount for is the one the
+    /// session was armed on. Without this the landing's `viewWillDisappear`
+    /// suspends watching the moment that screen is pushed, so nothing is
+    /// detected while the user is on the very screen they are handing over.
+    private var isPushingReceiveStep = false
+    /// The specify-amount sheet while it is up, so a receipt can dismiss it.
+    private weak var requestAmountController: RequestAmountHostingController?
+    /// Kept apart from `cancellables`: these live exactly as long as that sheet
+    /// does, and are dropped with it rather than for the screen's lifetime.
+    private var requestAmountObservers = Set<AnyCancellable>()
+    /// Live for as long as a receive step is pushed — the sheet is optional
+    /// within that, and the return has to happen with or without it.
+    private var receiveStepObservers = Set<AnyCancellable>()
     /// The Internal tab was activated before the landing finished appearing
     /// (e.g. it is the initial tab) — present the timing sheet from
     /// `viewDidAppear` instead of against a view that isn't on screen yet.
@@ -193,6 +211,13 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Also on the way back from a pushed step, which restored the bar on
+        // its own way out.
+        applyTabBarVisibility()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         // Programmatic dismissal does not call
@@ -200,6 +225,8 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         // here as well so returning from transaction details can resume the
         // same receive session (or start a fresh "Receive another" session).
         viewModel.setReceiptWatchingObscured(false)
+        isPushingReceiveStep = false
+        receiveStepObservers.removeAll()
         viewModel.setReceiveSurfaceVisible(true)
         if timingSheetPendingAppearance {
             timingSheetPendingAppearance = false
@@ -209,16 +236,25 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        // Stepping deeper into the receive flow is not leaving it. Everything
+        // else — a tab change, a dismissal, a pop — still puts the session to
+        // sleep.
+        guard !isPushingReceiveStep else { return }
         viewModel.setReceiveSurfaceVisible(false)
+        // Leaving for another tab, or being dismissed — either way the bar is
+        // not ours to keep hidden. A pushed step hides it for itself.
+        if presentingViewController == nil {
+            tabBarController?.setTabBarHidden(false, animated: false)
+        }
     }
 
     // MARK: - Actions
 
+    /// Copies only. The "Copied" toast is drawn by the SwiftUI screen — this
+    /// controller has no view of its own to hang it on that isn't behind the
+    /// tab bar.
     private func copyCurrentAddress() {
         viewModel.copyCurrentAddressToPasteboard()
-        view.dw_showInfoHUD(
-            withText: NSLocalizedString("Copied", comment: ""),
-            offsetForNavBar: false)
     }
 
     private func shareCurrentAddress() {
@@ -237,7 +273,42 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
     private func pushSpecifyAmount() {
         let specify = SpecifyAmountViewController.controller()
         specify.delegate = self
-        navigationController?.pushViewController(specify, animated: true)
+        isPushingReceiveStep = true
+        observeReceiptWhileOnReceiveStep()
+        pushWithoutTabBar(specify)
+    }
+
+    /// Bring the user back to the receipt from wherever in the receive flow
+    /// they are standing.
+    ///
+    /// Armed by the push, not by the sheet: the sheet is optional — Specify
+    /// Amount can be sat on with nothing over it — and a receipt arriving there
+    /// used to leave the user one screen short of the thing they were waiting
+    /// for, with no way to know it had happened.
+    private func observeReceiptWhileOnReceiveStep() {
+        receiveStepObservers.removeAll()
+
+        viewModel.$receipt
+            .compactMap { $0 }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.receiveStepObservers.removeAll()
+
+                guard let sheet = self.requestAmountController else {
+                    self.returnToLandingFromReceiveStep()
+                    return
+                }
+                // The sheet first, then the step under it — dismissing and
+                // popping in the same turn runs the two animations over each
+                // other.
+                self.requestAmountObservers.removeAll()
+                self.requestAmountController = nil
+                sheet.dismiss(animated: true) { [weak self] in
+                    self?.returnToLandingFromReceiveStep()
+                }
+            }
+            .store(in: &receiveStepObservers)
     }
 
     /// The base class routes a scanned payment straight into the payment
@@ -252,6 +323,115 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         dismiss(animated: true) { [weak self] in
             self?.embeddedSendViewModel.ingestScannedInput(paymentInput)
         }
+    }
+
+    /// Puts the landing on `tab` without rebuilding it — the tab-bar entry
+    /// points select this controller rather than presenting a copy.
+    func select(tab: PaymentsLandingTab) {
+        viewModel.activeTab = tab
+    }
+
+    /// The tab bar controller this landing belongs to.
+    ///
+    /// `tabBarController` alone is not enough any more: the landing is
+    /// presented as a sheet, and a presented controller is outside the tab
+    /// bar's hierarchy, so that property is nil. Walking the presenter chain
+    /// finds it whether this was pushed inside a tab or shown over one.
+    private var mainTabBarController: MainTabbarController? {
+        if let tabBarController = tabBarController as? MainTabbarController {
+            return tabBarController
+        }
+        // Searched down from the window's root, not up the presenter chain:
+        // the presenter is whichever screen happened to call `present`, and
+        // the window root is a container rather than the tab bar itself.
+        return view.window?.rootViewController?.dw_firstTabBarController() as? MainTabbarController
+    }
+
+    /// The X above the Internal form. Dismisses where something presented this
+    /// landing, and leaves for the history where nothing did — as the payments
+    /// tab's root, `dismiss` is a no-op, which is the bug the receive receipt's
+    /// Done button had.
+    private func leaveLanding() {
+        if presentingViewController != nil {
+            dismiss(animated: true)
+        } else {
+            (tabBarController as? MainTabbarController)?.showHome()
+        }
+    }
+
+    /// The tab bar goes while the landing is up, and the X above the selector
+    /// takes its place as the way out.
+    ///
+    /// The Internal tab forced the question — it embeds the transfer form now,
+    /// and its keypad and Continue button were sharing the bottom of the screen
+    /// with the bar, which the payments tab's own rule already forbids: the bar
+    /// is gone from the first step that asks for an amount. Hiding it on that
+    /// tab alone, though, would flicker the chrome in and out as the user moved
+    /// between the three, so it goes for the whole landing.
+    ///
+    /// Only meaningful on the tab. The balance-row sheets are presented and
+    /// have no tab bar to hide.
+    private func applyTabBarVisibility() {
+        guard let tabBarController, presentingViewController == nil else { return }
+        tabBarController.setTabBarHidden(true, animated: true)
+    }
+
+    /// Where Done on a receive receipt goes.
+    ///
+    /// Presented as a sheet there is something to dismiss; as the payments
+    /// tab's root there is not — `dismiss` was a no-op, which is why the button
+    /// appeared dead. Leaving for the history is what finishing means there,
+    /// and it is where the receipt's transaction shows up.
+    private func finishReceiving() {
+        if presentingViewController != nil {
+            dismiss(animated: true)
+        } else {
+            (tabBarController as? MainTabbarController)?.showHome()
+        }
+    }
+
+    /// Mirror the session into the specify-amount sheet, and close that sheet
+    /// the moment a payment lands — the receipt is on the surface behind it,
+    /// and a QR for an amount just paid would be the stalest thing on screen.
+    private func observeReceiptWhileRequestingAmount(_ controller: RequestAmountHostingController) {
+        requestAmountObservers.removeAll()
+
+        viewModel.$isWatchingForReceipt
+            .receive(on: RunLoop.main)
+            .sink { [weak controller] watching in
+                controller?.setWatchingForReceipt(watching)
+            }
+            .store(in: &requestAmountObservers)
+
+    }
+
+    /// Pop back to the landing from a pushed receive step, if that is where we
+    /// are. `isPushingReceiveStep` is the flag for exactly that state, and
+    /// `viewDidAppear` clears it on arrival.
+    ///
+    /// The pop targets the STACK MEMBER holding this controller, not this
+    /// controller. In the payments tab the landing is a child of
+    /// `PaymentsTabRootController`, which is what the navigation stack
+    /// actually contains; presented, it is the navigation controller's own
+    /// root. Popping to `self` therefore named a controller that is not in the
+    /// stack at all, and UIKit had nothing to pop to — the sheet closed and
+    /// nothing else moved.
+    private func returnToLandingFromReceiveStep() {
+        guard isPushingReceiveStep, let navigationController else { return }
+
+        let host = navigationController.viewControllers.first { controller in
+            controller === self || controller.children.contains { $0 === self }
+        }
+        guard let host, navigationController.topViewController !== host else { return }
+
+        navigationController.popToViewController(host, animated: true)
+    }
+
+    /// The landing keeps the tab bar; everything it pushes is a step in a
+    /// flow and takes the whole screen.
+    private func pushWithoutTabBar(_ controller: UIViewController) {
+        controller.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(controller, animated: true)
     }
 
     /// First-ever visit to the free-form Internal tab: explain transfer
@@ -321,29 +501,53 @@ extension PaymentsLandingHostingController: NavigationBarDisplayable {
 
 extension PaymentsLandingHostingController: SpecifyAmountViewControllerDelegate {
     func specifyAmountViewController(_ vc: SpecifyAmountViewController, didInput amount: UInt64) {
-        let model = DWReceiveModel(amount: amount)
-
-        let requestController = DWRequestAmountViewController(model: model)
-        requestController.delegate = self
-        viewModel.setReceiptWatchingObscured(true)
-        present(requestController, animated: true) { [weak self, weak requestController] in
-            requestController?.presentationController?.delegate = self
-        }
+        // The SwiftUI sheet, not `DWRequestAmountViewController`: this landing
+        // is the redesigned path, and it sizes its own detent. The ObjC pair is
+        // still what the legacy `ReceiveViewController` presents.
+        //
+        // The session keeps running behind THIS sheet, unlike every other one
+        // the landing presents.
+        //
+        // #1041 suspends watching whenever something covers the receive UI, and
+        // for the share sheet or transaction details that is right — the user
+        // is not presenting anything. This sheet is the opposite: a QR with the
+        // amount already in it, held up for someone to pay. Pausing detection
+        // on the handoff surface would pause it exactly where the feature is
+        // for. Nothing is lost either way — the session's baseline survives a
+        // suspend — but the sheet could not say it was watching, and could not
+        // get out of the way when the payment landed.
+        let requestController = RequestAmountHostingController.present(
+            from: self,
+            model: DWReceiveModel(amount: amount),
+            delegate: self)
+        requestAmountController = requestController
+        requestController.setWatchingForReceipt(viewModel.isWatchingForReceipt)
+        observeReceiptWhileRequestingAmount(requestController)
     }
 }
 
-// MARK: DWRequestAmountViewControllerDelegate
+// MARK: RequestAmountHostingControllerDelegate
 
-extension PaymentsLandingHostingController: DWRequestAmountViewControllerDelegate {
-    func requestAmountViewController(_ controller: DWRequestAmountViewController, didReceiveAmountWithInfo info: String) {
+extension PaymentsLandingHostingController: RequestAmountHostingControllerDelegate {
+    /// The requested amount arrived, which this sheet notices through its own
+    /// balance-change observer. Getting out of the way is all that is left to
+    /// do: the attended receipt on the surface behind already says what landed,
+    /// with the rail, the status and the transaction.
+    ///
+    /// It used to pop the navigation stack and raise an info HUD as well. Both
+    /// were written for a landing that had been PUSHED — as the payments tab's
+    /// root there is nothing to pop, and that HUD went onto the navigation
+    /// controller's view, where it drew underneath the tab bar as an
+    /// unidentifiable smudge.
+    func requestAmountHostingController(
+        _ controller: RequestAmountHostingController,
+        didReceiveAmountWithInfo info: String
+    ) {
         controller.dismiss(animated: true) {
-            self.viewModel.setReceiptWatchingObscured(false)
-            self.navigationController?.popViewController(animated: true)
-
-            let popAnimationDuration = 300
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(popAnimationDuration)) {
-                self.navigationController?.view.dw_showInfoHUD(withText: info)
-            }
+            // No un-obscuring: this sheet never suspended the session. What
+            // does end here is the sheet's own mirroring of it.
+            self.requestAmountObservers.removeAll()
+            self.requestAmountController = nil
         }
     }
 }

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -352,11 +352,23 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
     /// tab's root, `dismiss` is a no-op, which is the bug the receive receipt's
     /// Done button had.
     private func leaveLanding() {
-        if presentingViewController != nil {
+        if isPresentedModally {
             dismiss(animated: true)
         } else {
-            (tabBarController as? MainTabbarController)?.showHome()
+            mainTabBarController?.showHome()
         }
+    }
+
+    /// Whether this landing was presented rather than being the payments tab's
+    /// own root.
+    ///
+    /// Asked of the navigation controller as well as of self: every modal
+    /// presentation of this screen wraps it in a `BaseNavigationController`, so
+    /// the container is what UIKit presented. `presentingViewController` does
+    /// resolve through the container, but naming both makes the intent survive
+    /// a future re-parenting rather than depending on that inheritance.
+    private var isPresentedModally: Bool {
+        presentingViewController != nil || navigationController?.presentingViewController != nil
     }
 
     /// The tab bar goes while the landing is up, and the X above the selector
@@ -383,10 +395,10 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
     /// appeared dead. Leaving for the history is what finishing means there,
     /// and it is where the receipt's transaction shows up.
     private func finishReceiving() {
-        if presentingViewController != nil {
+        if isPresentedModally {
             dismiss(animated: true)
         } else {
-            (tabBarController as? MainTabbarController)?.showHome()
+            mainTabBarController?.showHome()
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -9,12 +9,18 @@ import UIKit
 
 struct PaymentsLandingScreen: View {
     @ObservedObject var viewModel: PaymentsLandingViewModel
-    @Environment(\.colorScheme) private var colorScheme
 
     var onClose: () -> Void
+    /// Done on a receive receipt. Separate from `onClose`, which dismisses:
+    /// this landing is also the payments TAB's root, where nothing presented it
+    /// and dismissing is a no-op — which is why Done did nothing there.
+    var onDone: () -> Void
     var onCopyAddress: () -> Void
     var onShareAddress: () -> Void
     var onSpecifyAmount: () -> Void
+    /// Opens the transaction behind a receive receipt. The host resolves the
+    /// txid and presents the details, and pauses the attended session while
+    /// they are up.
     var onViewTransaction: (Data) -> Void
     var onScanQR: () -> Void
     /// The Internal tab's embedded transfer form. The full landing shows it
@@ -37,298 +43,311 @@ struct PaymentsLandingScreen: View {
     /// The Send tab's address is valid → advance to the amount step. The host
     /// pushes `ExternalSendAmountScreen` onto the landing's navigation stack.
     var onSendContinue: () -> Void = {}
+    /// Leaves the payments tab entirely — the X above the Internal form. The
+    /// host resolves where that goes; on the tab there is nothing to dismiss.
+    var onCloseLanding: () -> Void = {}
     /// False for the balance-row receive/send sheets: their grabber + hero
     /// selector are the top chrome — no X close button or title row.
     var showsHeader: Bool = true
 
+    /// Raised by the Receive tab's copy button. Lives here rather than in
+    /// `PaymentsReceiveContent` so the toast floats over the whole screen —
+    /// inside that subtree it would be pinned above the action buttons.
+    @State private var showsCopiedToast = false
+    /// Which way the last tab change moved along `visibleTabs`, so the
+    /// incoming content slides in from the side it came from.
+    @State private var slidesForward = true
+
+    private enum Layout {
+        /// Side margin for the picker cards, so they line up with the tab
+        /// selector above them instead of running to the screen edges.
+        static let cardHorizontalPadding: CGFloat = 20
+        /// Gap under the (currently unreachable) header.
+        static let headerBottomPadding: CGFloat = 20
+        /// Breathing room above the selector where it is the first thing on
+        /// screen — the balance-row sheets, under their grabber.
+        static let selectorTopPadding: CGFloat = 20
+        /// Tighter for the balance-row sheets: the form they embed needs the
+        /// vertical room for its amount row, endpoint cards and keypad.
+        static let embeddedFormTopPadding: CGFloat = 12
+        /// Far enough that a tap that drifts, or a vertical flick, is not read
+        /// as a tab change.
+        static let swipeMinimumDistance: CGFloat = 24
+        /// Matches the selector pill's own spring (`SegmentedControlLayout`),
+        /// so the pill and the content travel together.
+        static let slideResponse: Double = 0.3
+        static let slideDamping: Double = 0.7
+    }
+
+    /// Who the screen is drawing for. The payments tab shows pickers; the
+    /// balance-row sheets hand one pinned endpoint to a whole embedded form
+    /// instead. Resolved once here rather than re-derived per tab, so the
+    /// spacing and the content can never disagree about which one it is.
+    private enum Mode {
+        /// The payments tab: every tab opens on a destination card.
+        case picker
+        /// Balance-row send sheet — the tapped balance is the source.
+        case sendingFrom(ChainNetwork)
+        /// Balance-row receive sheet — the receive toggle's balance is the
+        /// destination, kept in lockstep by the hosting controller.
+        case receivingInto
+    }
+
+    private var mode: Mode {
+        if let transferSendFrom { return .sendingFrom(transferSendFrom) }
+        if transferReceivePinned { return .receivingInto }
+        return .picker
+    }
+
+    private var isPickerMode: Bool {
+        if case .picker = mode { return true }
+        return false
+    }
+
+    /// A horizontal swipe changes tab anywhere on the payments tab, including
+    /// over the Internal form's keypad.
+    ///
+    /// It costs nothing there: `embeddedTransferViewModel` is owned by the
+    /// hosting controller, not by the tab, so a typed amount is still in the
+    /// field on the way back. Off only in the balance-row sheets, which are one
+    /// pinned route each and have no tabs to page between.
+    private var allowsTabSwipe: Bool {
+        isPickerMode
+    }
+
+    /// Whether anything is drawn above the tab selector — the back header, or
+    /// the close bar the payments tab carries now that it has no tab bar.
+    private var hasTopChrome: Bool {
+        showsHeader || isPickerMode
+    }
+
     var body: some View {
-        // Tighter chrome when a tab embeds a full form (transfer or send) —
-        // its amount + cards + keypad need most of the sheet.
-        let isEmbeddedForm = viewModel.activeTab != .receive
-        VStack(alignment: .center, spacing: isEmbeddedForm ? 12 : 20) {
+        VStack(alignment: .center, spacing: 10) {
             if showsHeader {
                 header
+            } else if isPickerMode {
+                closeBar
             }
 
-            tabSelector
-                .padding(.horizontal, 20)
-                .padding(.top, showsHeader ? 0 : 12)
+            VStack(alignment: .center, spacing: 20) {
+                PaymentsTabSelector(
+                    tabs: viewModel.visibleTabs,
+                    selection: tabSelection
+                )
+                .frame(height: 70)
+                // Only where the selector is the top of the screen. With chrome
+                // above it this is a second top margin stacked on the VStack's
+                // own spacing, and the two read as one oversized gap.
+                .padding(.top, hasTopChrome ? 0 : Layout.selectorTopPadding)
+                .padding(.horizontal, 16)
 
-            switch viewModel.activeTab {
-            case .receive:
-                receiveContent
-                if viewModel.receipt == nil {
-                    Spacer()
+                // ZStack, not a plain sibling: during the slide both the
+                // outgoing and incoming tab exist, and they have to share one
+                // slot instead of stacking and shoving the layout.
+                ZStack(alignment: .top) {
+                    tabContent
+                        .id(viewModel.activeTab)
+                        .transition(slide)
                 }
-            case .internalTransfer:
-                if let sendFrom = transferSendFrom {
-                    // Send sheet: the From card is pinned by the tapped
-                    // balance; the To rows pick the destination.
-                    InternalTransferScreen(
-                        viewModel: embeddedTransferViewModel,
-                        onCompleted: onTransferCompleted,
-                        showsHeader: false,
-                        sendFrom: sendFrom)
-                } else if transferReceivePinned {
-                    // The hosting controller keeps the pinned route in
-                    // lockstep with the receive toggle (its `$network`
-                    // subscription), so the fixed To card and the executed
-                    // transfer can never disagree.
-                    InternalTransferScreen(
-                        viewModel: embeddedTransferViewModel,
-                        onCompleted: onTransferCompleted,
-                        showsHeader: false,
-                        receiveInto: viewModel.network)
-                } else {
-                    // Full landing: the transfer form itself, free From and
-                    // To pickers — no intermediate action-row step.
-                    InternalTransferScreen(
-                        viewModel: embeddedTransferViewModel,
-                        onCompleted: onTransferCompleted,
-                        showsHeader: false)
-                }
-            case .send:
-                SendScreen(
-                    viewModel: embeddedSendViewModel,
-                    onClose: onClose,
-                    onScanQR: onScanQR,
-                    onContinue: onSendContinue,
-                    showsHeader: false)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // A mask rather than `clipped()`, and one that reaches into the
+                // bottom safe area. The clip is here to stop the outgoing and
+                // incoming tabs drawing over each other as they slide, which is
+                // a horizontal job; clipping the bottom as well cut off the
+                // keypad panel's own run into that strip, leaving it to end in
+                // mid-air above the home indicator.
+                .mask(Rectangle().ignoresSafeArea(edges: .bottom))
             }
         }
         .background(Color.dash.primaryBackground)
+        // Makes the empty area below the card draggable too, so the swipe
+        // works on the whole screen rather than only over the content.
+        .contentShape(Rectangle())
+        // `.gesture` (not `highPriority`) so rows and buttons keep winning
+        // their taps. `including:` is how the gesture is switched off — the
+        // modifier has no nil overload.
+        .gesture(tabSwipe, including: allowsTabSwipe ? .all : .subviews)
         .navigationBarHidden(true)
+        // Keyed on the receipt's id, not on the receipt: a second payment
+        // arriving replaces the card rather than cross-fading into itself.
         .animation(.spring(response: 0.45, dampingFraction: 0.82), value: viewModel.receipt?.id)
         .sensoryFeedback(.success, trigger: viewModel.receipt?.id)
+        .transientToast(
+            isPresented: $showsCopiedToast,
+            style: .copied,
+            message: NSLocalizedString("Copied", comment: ""))
+    }
+
+    // MARK: - Swipe between tabs
+
+    /// A horizontal swipe anywhere on the screen moves the selector one tab,
+    /// the way the segmented control above it implies it should.
+    ///
+    /// Off in the balance-row sheets (`including: .subviews` above): there a
+    /// tab is a whole form with a keypad, and paging away mid-entry would drop
+    /// what the user typed. The picker tabs have nothing to lose and no scroll
+    /// view of their own to fight over the gesture.
+    private var tabSwipe: some Gesture {
+        DragGesture(minimumDistance: Layout.swipeMinimumDistance)
+            .onEnded { value in
+                // Ignore a mostly-vertical drag, so a flick down the screen
+                // doesn't change tab on its horizontal wobble.
+                guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                selectTab(offsetBy: value.translation.width < 0 ? 1 : -1)
+            }
+    }
+
+    /// Moves `offset` tabs along `visibleTabs`, stopping at either end rather
+    /// than wrapping — the selector shows the whole list, so wrapping would
+    /// read as the pill teleporting.
+    private func selectTab(offsetBy offset: Int) {
+        let tabs = viewModel.visibleTabs
+        guard let current = tabs.firstIndex(of: viewModel.activeTab) else { return }
+        let target = current + offset
+        guard tabs.indices.contains(target) else { return }
+
+        select(tabs[target])
+    }
+
+    /// Everything that changes the tab goes through here, including the
+    /// selector's own taps and drag — the content slides in from whichever
+    /// side the new tab sits on, and only this knows which side that is.
+    private var tabSelection: Binding<PaymentsLandingTab> {
+        Binding(
+            get: { viewModel.activeTab },
+            set: { select($0) })
+    }
+
+    private func select(_ tab: PaymentsLandingTab) {
+        let tabs = viewModel.visibleTabs
+        guard let from = tabs.firstIndex(of: viewModel.activeTab),
+              let to = tabs.firstIndex(of: tab),
+              from != to
+        else { return }
+
+        slidesForward = to > from
+        withAnimation(.spring(response: Layout.slideResponse,
+                              dampingFraction: Layout.slideDamping)) {
+            viewModel.activeTab = tab
+        }
+    }
+
+    /// Matches the direction of travel: going right, the new tab enters from
+    /// the right and the old one leaves to the left.
+    private var slide: AnyTransition {
+        .asymmetric(
+            insertion: .move(edge: slidesForward ? .trailing : .leading),
+            removal: .move(edge: slidesForward ? .leading : .trailing))
+    }
+
+    /// Wraps a picker card as ONE view: spaced off the selector and pinned to
+    /// the top. The Spacer has to live inside the branch — as a sibling in the
+    /// outer stack it would not travel with the card, and the slide would tear
+    /// the two apart.
+    private func pickerLayout<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack(spacing: 0) {
+            content()
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Tab content
+
+    /// Each branch owns the gap under the selector, because the two kinds of
+    /// content want different ones — a picker card breathes, an embedded form
+    /// needs the pixels for its keypad.
+    @ViewBuilder
+    private var tabContent: some View {
+        switch viewModel.activeTab {
+        case .receive:
+            pickerLayout {
+                PaymentsReceiveContent(
+                    viewModel: viewModel,
+                    onCopyAddress: {
+                        onCopyAddress()
+                        showsCopiedToast = true
+                    },
+                    onShareAddress: onShareAddress,
+                    onSpecifyAmount: onSpecifyAmount,
+                    onViewTransaction: onViewTransaction,
+                    onDone: {
+                        viewModel.finishReceiving()
+                        onDone()
+                    }
+                )
+                .padding(.horizontal, Layout.cardHorizontalPadding)
+            }
+
+        case .internalTransfer:
+            switch mode {
+            case .picker:
+                // No destination card first: the form's own From and To cards
+                // pick the same endpoints, so the card was a step that asked
+                // for something the next screen asked for again.
+                InternalTransferScreen(
+                    viewModel: embeddedTransferViewModel,
+                    onCompleted: onTransferCompleted,
+                    showsHeader: false
+                )
+                .padding(.top, Layout.embeddedFormTopPadding)
+
+            case let .sendingFrom(source):
+                InternalTransferScreen(
+                    viewModel: embeddedTransferViewModel,
+                    onCompleted: onTransferCompleted,
+                    showsHeader: false,
+                    sendFrom: source
+                )
+                .padding(.top, Layout.embeddedFormTopPadding)
+
+            case .receivingInto:
+                InternalTransferScreen(
+                    viewModel: embeddedTransferViewModel,
+                    onCompleted: onTransferCompleted,
+                    showsHeader: false,
+                    receiveInto: viewModel.network
+                )
+                .padding(.top, Layout.embeddedFormTopPadding)
+            }
+
+        case .send:
+            SendScreen(
+                viewModel: embeddedSendViewModel,
+                onClose: onClose,
+                onScanQR: onScanQR,
+                onContinue: onSendContinue,
+                showsHeader: false
+            )
+            .padding(.top, Layout.embeddedFormTopPadding)
+        }
     }
 
     // MARK: - Header
 
+    /// Back only, no title. The landing is where a flow starts, so the tab
+    /// selector below already names the destination; the screens it pushes
+    /// carry their own titles.
+    ///
+    /// Currently unreachable: every caller passes `showsHeader: false` since
+    /// the landing became a tab.
     private var header: some View {
-        HStack {
-            Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(Color.dash.primaryText)
-                    .frame(width: 36, height: 36)
-                    .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
-            }
-            Spacer()
-            Text(headerTitle)
-                .font(.headline)
-                .foregroundColor(.dash.primaryText)
-            Spacer()
-            Color.clear.frame(width: 36, height: 36)
-        }
-        .padding(.horizontal, 20)
-        .padding(.top, 10)
+        NavigationBar(
+            leading: { NavigationBarElement.back.button(action: onClose) })
+            .padding(.bottom, Layout.headerBottomPadding)
     }
 
-    private var headerTitle: String {
-        switch viewModel.activeTab {
-        case .receive: return NSLocalizedString("Receive", comment: "")
-        case .internalTransfer: return NSLocalizedString("Internal transfer", comment: "")
-        case .send: return NSLocalizedString("Send", comment: "")
-        }
-    }
-
-    // MARK: - Tab selector
-
-    private var tabSelector: some View {
-        HStack(spacing: 4) {
-            ForEach(viewModel.visibleTabs) { tab in
-                Button(action: { viewModel.activeTab = tab }) {
-                    VStack(spacing: 4) {
-                        Image(systemName: tab.iconSystemName)
-                            .font(.system(size: 16, weight: .semibold))
-                        Text(tab.title)
-                            .font(.system(size: 13, weight: .medium))
-                    }
-                    .foregroundColor(viewModel.activeTab == tab ? Color.dash.primaryText : Color.dash.secondaryText)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            // Selected pill: a solid white raised card in light mode; a
-                            // translucent light fill in dark so the primaryText label stays
-                            // legible (pure white would be invisible on the dark selector).
-                            // Mirrors the app's SegmentedControl selected-fill treatment.
-                            .fill(viewModel.activeTab == tab
-                                ? (colorScheme == .dark ? Color.dash.whiteAlpha20 : Color.dash.white)
-                                : Color.clear)
-                            .shadow(
-                                color: viewModel.activeTab == tab
-                                    ? Color.dash.shadow : .clear,
-                                radius: 2, x: 0, y: 1))
-                }
-            }
-        }
-        .padding(4)
-        .background(Color.dash.secondaryBackground)
-        .cornerRadius(10)
-    }
-
-    // MARK: - Receive
-
-    private var receiveContent: some View {
-        VStack(alignment: .center, spacing: 20) {
-            ChainNetworkToggle(selection: $viewModel.network, options: ChainNetwork.allCases)
-                .padding(.horizontal, 20)
-
-            if let receipt = viewModel.receipt {
-                receiptCard(receipt)
-                    .transition(.scale(scale: 0.94).combined(with: .opacity))
-            } else {
-                qrCard
-
-                HStack(spacing: 12) {
-                    Button(action: onShareAddress) {
-                        actionPill(title: NSLocalizedString("Share address", comment: ""))
-                    }
-                    .disabled(viewModel.currentAddress == nil)
-
-                    Button(action: onSpecifyAmount) {
-                        actionPill(title: NSLocalizedString("Specify amount", comment: ""))
-                    }
-                    .disabled(viewModel.currentAddress == nil || viewModel.network != .core)
-                }
-                .padding(.horizontal, 20)
-
-                if viewModel.isWatchingForReceipt {
-                    HStack(spacing: 8) {
-                        SwiftUI.ProgressView()
-                            .scaleEffect(0.8)
-                        Text(NSLocalizedString("Watching for a payment…", comment: "Receive screen activity"))
-                            .font(.caption)
-                            .foregroundColor(.dash.secondaryText)
-                    }
-                    .transition(.opacity)
-                }
-            }
-        }
-    }
-
-    private func receiptCard(_ receipt: ReceiveReceipt) -> some View {
-        VStack(spacing: 16) {
-            PaymentSuccessHeader(
-                title: NSLocalizedString("Received", comment: "Receive success title"),
-                amountDuffs: Int64(clamping: receipt.amountDuffs),
-                fiatText: CurrencyExchanger.shared.fiatAmountString(
-                    for: receipt.amountDuffs.dashAmount))
-
-            VStack(spacing: 8) {
-                receiptInfoRow(
-                    title: NSLocalizedString("Balance", comment: "Receive receipt rail"),
-                    value: receipt.rail.balanceName)
-                receiptInfoRow(
-                    title: NSLocalizedString("Status", comment: "Receive receipt status"),
-                    value: receipt.statusTitle)
-                receiptInfoRow(
-                    title: NSLocalizedString("Time", comment: "Receive receipt time"),
-                    value: receipt.receivedAt.formatted(date: .omitted, time: .shortened))
-                if let memo = receipt.memo, !memo.isEmpty {
-                    receiptInfoRow(
-                        title: NSLocalizedString("Memo", comment: "Receive receipt memo"),
-                        value: memo)
-                }
-            }
-            .padding(14)
-            .background(Color.dash.secondaryBackground)
-            .cornerRadius(14)
-            .padding(.horizontal, 20)
-
-            if viewModel.canViewTransaction, let transactionId = receipt.transactionId {
-                Button {
-                    onViewTransaction(transactionId)
-                } label: {
-                    Text(NSLocalizedString("View transaction", comment: "Receive receipt action"))
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundColor(.dash.blue)
-                }
-            }
-
-            Spacer(minLength: 12)
-
-            ButtonsGroup(
-                orientation: .horizontal,
-                size: .large,
-                positiveButtonText: NSLocalizedString("Done", comment: "Receive receipt action"),
-                positiveButtonAction: onClose,
-                negativeButtonText: NSLocalizedString("Receive another", comment: "Receive receipt action"),
-                negativeButtonAction: viewModel.receiveAnother)
-                .padding(.horizontal, 16)
-                .padding(.bottom, 16)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private func receiptInfoRow(title: String, value: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
-            Text(title)
-                .font(.caption)
-                .foregroundColor(.dash.secondaryText)
-            Spacer()
-            Text(value)
-                .font(.caption.weight(.medium))
-                .foregroundColor(.dash.primaryText)
-                .multilineTextAlignment(.trailing)
-                .lineLimit(2)
-        }
-    }
-
-    private var qrCard: some View {
-        VStack(spacing: 14) {
-            if let address = viewModel.currentAddress,
-               let qr = QRCodeGenerator.image(for: address) {
-                Image(uiImage: qr)
-                    .interpolation(.none)
-                    .resizable()
-                    .frame(width: 220, height: 220)
-                    .padding(12)
-                    .background(Color.dash.white)
-                    .cornerRadius(16)
-
-                VStack(spacing: 4) {
-                    Text(NSLocalizedString("Your DASH address", comment: ""))
-                        .font(.caption)
-                        .foregroundColor(Color.dash.secondaryText)
-                    Text(address)
-                        .font(.system(.footnote, design: .monospaced))
-                        .foregroundColor(.dash.primaryText)
-                        .multilineTextAlignment(.center)
-                }
-                .padding(.horizontal, 20)
-                .onTapGesture { onCopyAddress() }
-            } else if viewModel.network == .platform && !viewModel.platformIsReady {
-                placeholder(NSLocalizedString("Platform sync starting…", comment: ""))
-            } else if viewModel.network == .shielded {
-                // Nil only until the shielded sub-wallet binds at startup
-                // (the view model retries as the platform stack comes up).
-                placeholder(NSLocalizedString("Shielded wallet starting…", comment: ""))
-            } else {
-                placeholder(NSLocalizedString("No address available", comment: ""))
-            }
-        }
-    }
-
-    private func placeholder(_ message: String) -> some View {
-        VStack(spacing: 8) {
-            SwiftUI.ProgressView()
-            Text(message)
-                .font(.footnote)
-                .foregroundColor(Color.dash.secondaryText)
-        }
-        .frame(width: 220, height: 220)
-    }
-
-    private func actionPill(title: String) -> some View {
-        Text(title)
-            .font(.system(size: 14, weight: .medium))
-            .foregroundColor(.dash.primaryText)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(Color.dash.secondaryBackground)
-            .cornerRadius(12)
+    /// The way out of the payments tab once the tab bar is gone from under it.
+    ///
+    /// On every tab, not only the one with the keypad: chrome that appeared and
+    /// disappeared as the user moved between the three would read as the screen
+    /// changing identity rather than the content changing.
+    ///
+    /// Close rather than back: this is the payments tab's own root, so there is
+    /// nothing behind it to go back to — the X leaves the flow. Trailing, where
+    /// a modal's close sits.
+    private var closeBar: some View {
+        NavigationBar(
+            trailing: { NavigationBarElement.close.button(action: onCloseLanding) })
     }
 
 }

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -375,9 +375,11 @@ final class PaymentsLandingViewModel: ObservableObject {
     /// coming back should start from a clean receive screen rather than the
     /// receipt of a payment already dealt with.
     func finishReceiving() {
+        // No reconcile: that would see a nil session and start a fresh one,
+        // which is the opposite of what Done means. Leaving the screen is what
+        // stops the watcher, and returning is what starts the next session.
         receipt = nil
         invalidateReceiptSession()
-        reconcileReceiptWatching()
     }
 
     func receiveAnother() {
@@ -784,6 +786,11 @@ final class PaymentsLandingViewModel: ObservableObject {
         platformAddress = PlatformAddressSyncCoordinator.shared
             .derivedAddresses.nextReceiveAddress?.address
         reloadShieldedAddress()
+        #if DASHPAY
+        // The identity is network-scoped, so a network switch can invalidate
+        // the Send tab's username row exactly as a registration change does.
+        refreshCanSendToUsername()
+        #endif
         reconcileReceiptWatching()
     }
 

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -22,14 +22,6 @@ enum PaymentsLandingTab: String, CaseIterable, Identifiable {
         case .send: return NSLocalizedString("Send", comment: "")
         }
     }
-
-    var iconSystemName: String {
-        switch self {
-        case .receive: return "arrow.down"
-        case .internalTransfer: return "arrow.up.arrow.down"
-        case .send: return "arrow.up"
-        }
-    }
 }
 
 enum CoreReceiptSettlementStatus: Int, Comparable {
@@ -117,6 +109,40 @@ final class PaymentsLandingViewModel: ObservableObject {
     /// Which hero tabs this presentation offers. The full landing shows all
     /// three; the balance-row receive sheet narrows to Receive + Internal.
     let visibleTabs: [PaymentsLandingTab]
+    /// Mirrors `DWGlobalOptions.advancedModeEnabled` so the Internal card can
+    /// narrow to Shielded while the mode is off.
+    ///
+    /// Its own mirror rather than the transfer model's: that one is handed to
+    /// the screen as a plain `var`, so observing it here would mean re-rendering
+    /// the whole landing on every keystroke in the embedded amount field.
+    @Published private(set) var isAdvancedMode = DWGlobalOptions.sharedInstance().advancedModeEnabled
+
+    /// Which addresses the Receive tab offers.
+    ///
+    /// Core and Shielded are both ordinary destinations — a wallet can be paid
+    /// privately without calling itself advanced. Platform is the one that
+    /// needs the mode: it holds credits rather than spendable Dash, and
+    /// offering it by default invites payments the payer cannot spend back.
+    var receiveNetworks: [ChainNetwork] {
+        isAdvancedMode ? [.core, .shielded, .platform] : [.core, .shielded]
+    }
+
+    /// Whether the Send tab offers "Send to username".
+    ///
+    /// Both halves are required: the row opens the contact book, which needs an
+    /// identity to hold contacts, and a wallet that cannot name itself has
+    /// nothing to send *from* in that flow. False everywhere DashPay is not
+    /// built.
+    @Published private(set) var canSendToUsername = false
+
+    /// Whether the Send tab offers "Swap to other crypto".
+    ///
+    /// The same gate the Dash DEX shortcut is behind: the portal swaps real
+    /// assets across real chains, which testnet coins cannot do, and it is
+    /// useless without the SwapKit key. Fixed for the lifetime of the screen —
+    /// both inputs need a relaunch to change.
+    let canSwapToOtherCrypto = !WalletEnvironment.isTestnet && SwapKitConstants.isConfigured
+
     @Published private(set) var coreAddress: String? = nil
     @Published private(set) var platformAddress: String? = nil
     @Published private(set) var shieldedAddress: String? = nil
@@ -163,6 +189,34 @@ final class PaymentsLandingViewModel: ObservableObject {
 
         reloadCoreAddress()
         reloadShieldedAddress()
+
+        NotificationCenter.default.publisher(for: .advancedModeDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.isAdvancedMode = DWGlobalOptions.sharedInstance().advancedModeEnabled
+                // Platform is the only segment the mode takes away, and it can
+                // be the selected one at that moment — leaving the tab showing
+                // a Platform address with no segment left to move off it.
+                if !self.isAdvancedMode, !self.receiveNetworks.contains(self.network) {
+                    self.network = .core
+                }
+            }
+            .store(in: &cancellables)
+
+        #if DASHPAY
+        refreshCanSendToUsername()
+
+        // The identity can be adopted while this landing is already up — a
+        // registration finishing, or a recovery resolving one — and the row
+        // has to appear without the user leaving the tab.
+        NotificationCenter.default.publisher(for: .DWDashPayRegistrationStatusUpdated)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refreshCanSendToUsername()
+            }
+            .store(in: &cancellables)
+        #endif
 
         PlatformAddressSyncCoordinator.shared.$derivedAddresses
             .receive(on: RunLoop.main)
@@ -226,6 +280,50 @@ final class PaymentsLandingViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
+    #if DEBUG
+    /// Lightweight initializer used only by SwiftUI previews: takes the
+    /// addresses as literals instead of reading them from the wallet, and
+    /// subscribes to nothing.
+    private init(
+        previewActiveTab: PaymentsLandingTab,
+        previewNetwork: ChainNetwork,
+        previewVisibleTabs: [PaymentsLandingTab],
+        previewCoreAddress: String?,
+        previewPlatformAddress: String?,
+        previewShieldedAddress: String?
+    ) {
+        activeTab = previewActiveTab
+        network = previewNetwork
+        visibleTabs = previewVisibleTabs
+        coreAddress = previewCoreAddress
+        platformAddress = previewPlatformAddress
+        shieldedAddress = previewShieldedAddress
+        // A preview has no host to route to and no transaction to route with,
+        // so the receipt's "View transaction" stays hidden rather than drawing
+        // a control that could not do anything.
+        allowsTransactionDetails = false
+    }
+
+    /// Preview view model. Pass `nil` for an address to preview that
+    /// network's placeholder state instead of the QR card.
+    static func makeForPreview(
+        activeTab: PaymentsLandingTab = .internalTransfer,
+        network: ChainNetwork = .core,
+        visibleTabs: [PaymentsLandingTab] = PaymentsLandingTab.allCases,
+        coreAddress: String? = "XyZ8kFqW3nR5tHmB2vJcL7pQaS4dEuG9wN",
+        platformAddress: String? = "XmQ4rT7bN2vK9sD5xF8jH3kL6pW1aZcYuE",
+        shieldedAddress: String? = nil
+    ) -> PaymentsLandingViewModel {
+        PaymentsLandingViewModel(
+            previewActiveTab: activeTab,
+            previewNetwork: network,
+            previewVisibleTabs: visibleTabs,
+            previewCoreAddress: coreAddress,
+            previewPlatformAddress: platformAddress,
+            previewShieldedAddress: shieldedAddress)
+    }
+    #endif
+
     var currentAddress: String? {
         if session?.rail == network, let displayedAddress {
             return displayedAddress
@@ -272,6 +370,16 @@ final class PaymentsLandingViewModel: ObservableObject {
         }
     }
 
+    /// The user is finished with this receipt and leaving. Unlike
+    /// `receiveAnother`, no new session is armed and no address is re-derived —
+    /// coming back should start from a clean receive screen rather than the
+    /// receipt of a payment already dealt with.
+    func finishReceiving() {
+        receipt = nil
+        invalidateReceiptSession()
+        reconcileReceiptWatching()
+    }
+
     func receiveAnother() {
         receipt = nil
         invalidateReceiptSession()
@@ -286,6 +394,17 @@ final class PaymentsLandingViewModel: ObservableObject {
     private func reloadCoreAddress() {
         coreAddress = SwiftDashSDKReceiveAddressReader.receiveAddress()
     }
+
+    #if DASHPAY
+    /// Reads the network-scoped SDK truth, the same source
+    /// `JoinDashPayRegistrationPolicy` treats as authoritative. The legacy
+    /// `DWGlobalOptions` username mirror is global and cleared on every network
+    /// switch, so it would offer the row on a network with no identity.
+    private func refreshCanSendToUsername() {
+        let identity = DWCurrentUserIdentityInfo.shared
+        canSendToUsername = identity.hasIdentity && identity.username?.isEmpty == false
+    }
+    #endif
 
     /// Resolves the wallet's default Orchard payment address and encodes it
     /// for display. `shieldedDefaultAddress` returns nil until the shielded

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsTabRootController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsTabRootController.swift
@@ -1,0 +1,87 @@
+//
+//  Created by Roman Chornyi
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+/// Root of the payments tab, and the reason the landing is not built at launch.
+///
+/// `PaymentsLandingHostingController.init` constructs three view models that
+/// read the wallet — balances over the FFI, a derived receive address, the sync
+/// monitor. Making the landing the tab's root directly would run all of that
+/// during `configureControllers()`, before the user has gone anywhere near
+/// payments (and again on every DashPay tab reconfiguration). This container
+/// defers it to `viewDidLoad`, which UIKit only runs when the tab is first
+/// shown.
+final class PaymentsTabRootController: UIViewController {
+
+    private var landingController: PaymentsLandingHostingController?
+    /// A tab requested before the landing existed — applied on load. Shortcut
+    /// entry points select this tab and name a sub-tab in the same turn, which
+    /// can be the very first time the tab is shown.
+    private var pendingTab: PaymentsLandingTab?
+
+    /// Puts the landing on `tab`, or remembers it if the landing has not been
+    /// built yet.
+    func select(tab: PaymentsLandingTab) {
+        guard let landingController else {
+            pendingTab = tab
+            return
+        }
+        landingController.select(tab: tab)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .dw_background()
+
+        let landing = PaymentsLandingHostingController(
+            activeTab: pendingTab ?? .send,
+            showsHeader: false)
+        pendingTab = nil
+        landingController = landing
+
+        addChild(landing)
+        landing.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(landing.view)
+        NSLayoutConstraint.activate([
+            // Full bounds, not the safe area: the landing hosts SwiftUI, which
+            // applies the safe-area inset itself. Pinning to the guide here
+            // would count the status bar twice.
+            landing.view.topAnchor.constraint(equalTo: view.topAnchor),
+            landing.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            landing.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            landing.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+        landing.didMove(toParent: self)
+    }
+}
+
+// MARK: - NavigationBarDisplayable
+
+/// The payments tab has no navigation bar: the landing draws its own tab
+/// selector at the top and nothing above it.
+///
+/// `MainTabbarController` already sets `isNavigationBarHidden` on the
+/// navigation controller, but that only holds until the first appearance:
+/// `BaseNavigationController`'s `willShow` pass re-derives it per controller
+/// and falls back to SHOWING the bar for anything that does not declare
+/// otherwise. The bar it then put back carried no title and no back button, so
+/// it read as an unexplained ~44pt gap above the selector rather than as a bar.
+extension PaymentsTabRootController: NavigationBarDisplayable {
+    var isBackButtonHidden: Bool { true }
+    var isNavigationBarHidden: Bool { true }
+}

--- a/DashWallet/Sources/UI/Payments/Receive/RequestAmount/RequestAmountHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Receive/RequestAmount/RequestAmountHostingController.swift
@@ -56,12 +56,19 @@ final class RequestAmountHostingController: UIViewController {
         @Published var copiedToastVisible = false
         /// Driven by the presenter's attended receive session, when it has one.
         @Published var isWatchingForReceipt = false
+        /// The requested amount in fiat. Published rather than computed in the
+        /// view: rates can land after this sheet is on screen, and the view
+        /// redraws on this object alone.
+        @Published var fiatAmount: String = ""
     }
 
     /// The content's natural height, as `BottomSheet(fillsHeight: false)`
     /// publishes it. Seeded before presentation and updated on every layout —
     /// the QR arriving, the username row appearing, Dynamic Type changing.
     fileprivate var measuredHeight: CGFloat = 0
+
+    /// Handle for the exchange-rate subscription, released in `deinit`.
+    private var exchangerObserver: CurrencyExchangerObserver?
 
     init(model: DWReceiveModelProtocol) {
         self.model = model
@@ -144,6 +151,23 @@ final class RequestAmountHostingController: UIViewController {
             selector: #selector(checkRequestStatus),
             name: SwiftDashSDKWalletState.balanceDidChangeNotification,
             object: nil)
+
+        // Rates can land after this sheet is up — the exchanger keeps its own
+        // observer list rather than posting a notification, so subscribe to it
+        // and restate the fiat line when it does.
+        exchangerObserver = CurrencyExchanger.shared.addObserver { [weak self] _ in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.state.fiatAmount = CurrencyExchanger.shared
+                    .fiatAmountString(for: self.model.amount.dashAmount)
+            }
+        }
+    }
+
+    deinit {
+        if let exchangerObserver {
+            CurrencyExchanger.shared.removeObserver(exchangerObserver)
+        }
     }
 
     // MARK: - Content
@@ -211,6 +235,7 @@ final class RequestAmountHostingController: UIViewController {
     private func reloadFromModel() {
         state.qrCodeImage = model.qrCodeImage
         state.paymentAddress = model.paymentAddress
+        state.fiatAmount = CurrencyExchanger.shared.fiatAmountString(for: model.amount.dashAmount)
         #if DASHPAY
         state.username = model.username
         #endif
@@ -295,7 +320,7 @@ private struct RequestAmountScreenContainer: View {
     var body: some View {
         RequestAmountScreen(
             amountDuffs: amountDuffs,
-            fiatAmount: CurrencyExchanger.shared.fiatAmountString(for: amountDuffs.dashAmount),
+            fiatAmount: state.fiatAmount,
             qrCodeImage: state.qrCodeImage,
             paymentAddress: state.paymentAddress,
             username: state.username,

--- a/DashWallet/Sources/UI/Payments/Receive/RequestAmount/RequestAmountHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Receive/RequestAmount/RequestAmountHostingController.swift
@@ -1,0 +1,312 @@
+//
+//  Created by Roman Chornyi
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DashUIKit
+import SwiftUI
+import UIKit
+
+// MARK: - RequestAmountHostingControllerDelegate
+
+protocol RequestAmountHostingControllerDelegate: AnyObject {
+    func requestAmountHostingController(
+        _ controller: RequestAmountHostingController,
+        didReceiveAmountWithInfo info: String)
+}
+
+// MARK: - RequestAmountHostingController
+
+/// SwiftUI port of `DWRequestAmountViewController`, kept as a copy beside it —
+/// the ObjC pair is still what the payments landing presents.
+///
+/// The chrome is `DashUIKit.BottomSheet` rather than the ObjC
+/// `DWBaseModalViewController`: grabber, title and background all come from the
+/// design system, so this holds nothing but the model wiring.
+///
+/// It still owns the model, because `DWReceiveModelProtocol` pushes updates
+/// through a delegate rather than publishing them — `State` below is what turns
+/// that into something SwiftUI can observe.
+final class RequestAmountHostingController: UIViewController {
+
+    weak var delegate: RequestAmountHostingControllerDelegate?
+
+    private let model: DWReceiveModelProtocol
+    private let state: State
+
+    /// Bridges the ObjC delegate callback into `@Published` values.
+    @MainActor
+    fileprivate final class State: ObservableObject {
+        @Published var qrCodeImage: UIImage?
+        @Published var paymentAddress: String?
+        @Published var username: String?
+        /// Raised by a copy, cleared by `transientToast`'s own timer.
+        @Published var copiedToastVisible = false
+        /// Driven by the presenter's attended receive session, when it has one.
+        @Published var isWatchingForReceipt = false
+    }
+
+    /// The content's natural height, as `BottomSheet(fillsHeight: false)`
+    /// publishes it. Seeded before presentation and updated on every layout —
+    /// the QR arriving, the username row appearing, Dynamic Type changing.
+    fileprivate var measuredHeight: CGFloat = 0
+
+    init(model: DWReceiveModelProtocol) {
+        self.model = model
+        self.state = State()
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Presentation
+
+    /// Presents the sheet and keeps it sized to its content.
+    ///
+    /// The measuring lives here because it is the awkward part: SwiftUI's
+    /// `.presentationDetents` — and so `BottomSheet.selfSizing` — does not
+    /// bridge to a `UIHostingController` shown with `present()`; UIKit falls
+    /// back to `.large`. What does cross the bridge is the height
+    /// `BottomSheet(fillsHeight: false)` publishes for that modifier to read, so
+    /// the same measurement drives a custom UIKit detent here: seeded from
+    /// `sizeThatFits` before anything renders, then corrected by every
+    /// `BottomSheetHeightPreferenceKey` update. A one-shot `sizeThatFits` is not
+    /// enough — the amount's `scaleToFitWidth` reports its height from `State`,
+    /// which is still zero on that first pass.
+    @discardableResult
+    static func present(
+        from presenter: UIViewController,
+        model: DWReceiveModelProtocol,
+        delegate: RequestAmountHostingControllerDelegate?
+    ) -> RequestAmountHostingController {
+        let controller = RequestAmountHostingController(model: model)
+        controller.delegate = delegate
+        controller.modalPresentationStyle = .pageSheet
+
+        if let sheet = controller.sheetPresentationController {
+            // `BottomSheet` draws its own grabber.
+            sheet.prefersGrabberVisible = false
+            if #unavailable(iOS 26.0) {
+                sheet.preferredCornerRadius = 24
+            }
+            let width = presenter.view.bounds.width
+            controller.measuredHeight = controller.sheetHostingController
+                .sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
+                .height
+
+            // The resolver reads the controller rather than a captured number,
+            // so `invalidateDetents()` re-runs it against the latest
+            // measurement instead of the one taken before the first render.
+            sheet.detents = [.custom { [weak controller] context in
+                guard let controller, controller.measuredHeight > 0 else {
+                    return context.maximumDetentValue
+                }
+                // `fillsHeight: false` measures without the home-indicator
+                // inset, so the strip has to be added back here.
+                let bottomInset = controller.view.window?.safeAreaInsets.bottom ?? 0
+                return min(controller.measuredHeight + bottomInset, context.maximumDetentValue)
+            }]
+        }
+
+        presenter.present(controller, animated: true)
+        return controller
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // The detent paints the bottom safe-area strip itself, so the sheet
+        // background has to reach it.
+        view.backgroundColor = UIColor(Color.dash.primaryBackground)
+
+        setupContent()
+        model.delegate = self
+        reloadFromModel()
+
+        // The requested amount arriving is what closes this screen, and the
+        // only signal for it is the balance changing.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(checkRequestStatus),
+            name: SwiftDashSDKWalletState.balanceDidChangeNotification,
+            object: nil)
+    }
+
+    // MARK: - Content
+
+    /// Built lazily and held, because `present(from:model:delegate:)` measures
+    /// it before the view is ever loaded.
+    fileprivate lazy var sheetHostingController: UIHostingController<AnyView> = {
+        let screen = RequestAmountScreenContainer(
+            state: state,
+            amountDuffs: model.amount,
+            onCopyAddress: { [weak self] in self?.copyAddress() },
+            onCopyQRCode: { [weak self] in self?.copyQRCode() },
+            onCopyUsername: { [weak self] in self?.copyUsername() },
+            onShare: { [weak self] in self?.share() })
+
+        let sheet = DashUIKit.BottomSheet(
+            showBackButton: .constant(false),
+            fillsHeight: false
+        ) {
+            screen
+        }
+        // SwiftUI hands preference updates to a `@Sendable` closure, so the hop
+        // back to the main actor is explicit rather than implied by UIKit.
+        .onPreferenceChange(DashUIKit.BottomSheetHeightPreferenceKey.self) { height in
+            Task { @MainActor [weak self] in
+                self?.contentHeightDidChange(height)
+            }
+        }
+        return UIHostingController(rootView: AnyView(sheet))
+    }()
+
+    /// Reflect the presenter's attended receive session, so the sheet can say
+    /// it is still watching. Left alone by presenters that have no session.
+    func setWatchingForReceipt(_ watching: Bool) {
+        state.isWatchingForReceipt = watching
+    }
+
+    /// Re-resolves the detent against the height that just came out of layout.
+    /// Sub-point changes are ignored: the resolver rounds to the same detent
+    /// anyway, and re-entering `animateChanges` on every measurement pass makes
+    /// the sheet twitch.
+    private func contentHeightDidChange(_ height: CGFloat) {
+        guard height > 0, abs(height - measuredHeight) > 0.5 else { return }
+        measuredHeight = height
+
+        guard let sheet = sheetPresentationController else { return }
+        sheet.animateChanges { sheet.invalidateDetents() }
+    }
+
+    private func setupContent() {
+        let hostingController = sheetHostingController
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        hostingController.view.backgroundColor = .clear
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+        hostingController.didMove(toParent: self)
+    }
+
+    private func reloadFromModel() {
+        state.qrCodeImage = model.qrCodeImage
+        state.paymentAddress = model.paymentAddress
+        #if DASHPAY
+        state.username = model.username
+        #endif
+    }
+
+    // MARK: - Actions
+
+    private func copyAddress() {
+        model.copyAddressToPasteboard()
+        showCopied()
+    }
+
+    private func copyQRCode() {
+        model.copyQRImageToPasteboard()
+        showCopied()
+    }
+
+    private func copyUsername() {
+        #if DASHPAY
+        model.copyUsernameToPasteboard()
+        showCopied()
+        #endif
+    }
+
+    /// Only the haptic. The toast is drawn by the SwiftUI sheet through
+    /// `transientToast`, the same `DashUIKit.Toast` the Receive tab raises —
+    /// the UIKit `showToast` anchors to this controller's view, which inside a
+    /// sheet puts it behind the sheet rather than over it.
+    private func showCopied() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        state.copiedToastVisible = true
+    }
+
+    /// The helper anchors its iPad popover on a `UIButton`, and the real one
+    /// lives inside SwiftUI where UIKit cannot reach it. This zero-sized stand-in
+    /// sits at the centre of the content, which is where the popover would point
+    /// anyway.
+    private lazy var shareAnchor: UIButton = {
+        let button = UIButton(frame: .zero)
+        button.isUserInteractionEnabled = false
+        button.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            button.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+        return button
+    }()
+
+    private func share() {
+        dw_shareReceiveInfo(model, sender: shareAnchor)
+    }
+
+    @objc
+    private func checkRequestStatus() {
+        guard let info = model.requestAmountReceivedInfoIfReceived() else { return }
+        delegate?.requestAmountHostingController(self, didReceiveAmountWithInfo: info)
+    }
+}
+
+// MARK: - DWReceiveModelDelegate
+
+extension RequestAmountHostingController: DWReceiveModelDelegate {
+    func receivingInfoDidUpdate() {
+        reloadFromModel()
+    }
+}
+
+// MARK: - Container
+
+/// Observes the state mirror so the screen itself can stay a plain
+/// value-in / closures-out view.
+private struct RequestAmountScreenContainer: View {
+    @ObservedObject var state: RequestAmountHostingController.State
+
+    let amountDuffs: UInt64
+    let onCopyAddress: () -> Void
+    let onCopyQRCode: () -> Void
+    let onCopyUsername: () -> Void
+    let onShare: () -> Void
+
+    var body: some View {
+        RequestAmountScreen(
+            amountDuffs: amountDuffs,
+            fiatAmount: CurrencyExchanger.shared.fiatAmountString(for: amountDuffs.dashAmount),
+            qrCodeImage: state.qrCodeImage,
+            paymentAddress: state.paymentAddress,
+            username: state.username,
+            isWatchingForReceipt: state.isWatchingForReceipt,
+            onCopyAddress: onCopyAddress,
+            onCopyQRCode: onCopyQRCode,
+            onCopyUsername: onCopyUsername,
+            onShare: onShare)
+            .transientToast(
+                isPresented: $state.copiedToastVisible,
+                style: .copied,
+                message: NSLocalizedString("Copied", comment: ""))
+    }
+}

--- a/DashWallet/Sources/UI/Payments/Receive/RequestAmount/RequestAmountScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Receive/RequestAmount/RequestAmountScreen.swift
@@ -1,0 +1,306 @@
+//
+//  Created by Roman Chornyi
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DashUIKit
+import SwiftUI
+
+/// SwiftUI port of `DWRequestAmountContentView`: the requested amount over the
+/// QR that encodes it, the address under that, and Share.
+///
+/// Same contents and same copy-on-tap behaviour as the original, dressed in the
+/// redesign: the amount is `SwapAmountView`, the same component the amount step
+/// enters it with, and the card below is `PaymentsReceiveContent`'s — same QR
+/// size, same address row, same pill actions — so the sheet reads as the
+/// Receive tab with an amount on it. The original is still in the tree; nothing
+/// routes here yet.
+///
+/// Values in, closures out: the model stays with the host, because
+/// `DWReceiveModelProtocol` is an ObjC protocol with a delegate that pushes
+/// updates rather than publishing them.
+struct RequestAmountScreen: View {
+    let amountDuffs: UInt64
+    let fiatAmount: String
+    let qrCodeImage: UIImage?
+    let paymentAddress: String?
+    /// DashPay only; `nil` everywhere else, and the row is dropped.
+    var username: String? = nil
+
+    /// True while the attended receive session is live behind this sheet.
+    /// Default false so every other presenter of this screen is unchanged.
+    var isWatchingForReceipt: Bool = false
+
+    var onCopyAddress: () -> Void
+    var onCopyQRCode: () -> Void
+    var onCopyUsername: () -> Void = {}
+    var onShare: () -> Void
+
+    /// Taken from `PaymentsReceiveContent`, the Receive tab this sheet is the
+    /// amount-carrying twin of: the same 200pt QR in the same 10pt well, the
+    /// same address row, the same pill actions, the same `MenuViewModifier`
+    /// card around all of it.
+    private enum Layout {
+        static let contentInset: CGFloat = 20
+        /// A fixed square, not a fraction of the width — the Receive tab sizes
+        /// its QR this way so the rows under it never shift.
+        static let qrSide: CGFloat = 200
+        static let qrPadding: CGFloat = 10
+        /// The DashPay avatar, or the Dash "D", at the centre of the code.
+        static let qrBadgeFraction: CGFloat = 0.18
+    }
+
+    private var hasAddress: Bool { paymentAddress != nil }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            amount
+            card
+                .padding(.horizontal, 20)
+
+            if isWatchingForReceipt {
+                // This sheet is the handoff surface — a QR with the amount
+                // already in it, held up for someone to pay — so the session
+                // keeps running behind it and says so.
+                ReceiveWatchingIndicator()
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Amount
+
+    /// The same component the amount step draws with, so the number keeps its
+    /// size and weight as the user crosses from "Specify amount" into this
+    /// sheet. It renders the Dash glyph itself, and scales the whole group down
+    /// to fit rather than truncating the digits — which the fixed-size
+    /// `DWAmountPreviewView` this replaces could not do.
+    ///
+    /// Interaction is all opt-in and stays off here: no paste, no currency
+    /// chevron, no swap. This amount is a result, not an input.
+    private var amount: some View {
+        DashUIKit.SwapAmountView(
+            amount: amountDuffs.formattedDashAmountWithoutCurrencySymbol,
+            // An empty secondary renders as "0" inside the component, so the
+            // "rates have not arrived" case has to pass nil to drop the line.
+            secondaryText: fiatAmount.isEmpty ? nil : fiatAmount,
+            showDashLogo: true
+        )
+        .padding(.horizontal, Layout.contentInset)
+    }
+
+    // MARK: - Card
+
+    /// The Receive tab's card, rebuilt around this screen's contents: the QR
+    /// and its rows share one block of padding, and the action sits below them
+    /// with its own, so the button keeps the tab's 20pt frame instead of
+    /// inheriting the rows' spacing.
+    private var card: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .center, spacing: 20) {
+                Text(NSLocalizedString("This QR contains the specified amount", comment: "Receive screen"))
+                    .dashFont(.footnote)
+                    .foregroundStyle(Color.dash.primaryText)
+
+                qrCode
+
+                if let paymentAddress {
+                    addressRow(
+                        caption: NSLocalizedString("Your DASH address", comment: "Receive screen"),
+                        value: paymentAddress,
+                        action: onCopyAddress)
+                }
+
+                if let username {
+                    addressRow(
+                        caption: NSLocalizedString("Username", comment: "Receive screen"),
+                        value: username,
+                        action: onCopyUsername)
+                }
+
+                // The host wires `onShare` to the share sheet; without a
+                // control bound to it the requested payment could be copied
+                // but never sent to anyone.
+                DashUIKit.DashButton(
+                    text: NSLocalizedString("Share", comment: "Receive screen"),
+                    isEnabled: hasAddress,
+                    fillsWidth: true,
+                    size: .medium,
+                    style: .tintedGray,
+                    action: onShare
+                )
+                .padding(.bottom, 6)
+            }
+            .padding(.horizontal, Layout.contentInset)
+            .padding(.top, 40)
+            .padding(.bottom, 10)
+        }
+        .modifier(MenuViewModifier(innerPadding: 0))
+    }
+
+    // MARK: - QR
+
+    /// The Receive tab's QR: a fixed 200pt square in a 10pt well, drawn
+    /// straight onto the card rather than into a container of its own.
+    ///
+    /// Tapping copies the image, as the original's QR button did. The badge in
+    /// the middle is the DashPay avatar when there is one, and the Dash "D"
+    /// otherwise — the tab has no badge because it has no DashPay identity to
+    /// show, this screen does.
+    @ViewBuilder
+    private var qrCode: some View {
+        if let qrCodeImage {
+            Button(action: onCopyQRCode) {
+                Image(uiImage: qrCodeImage)
+                    .interpolation(.none)
+                    .resizable()
+                    .frame(width: Layout.qrSide, height: Layout.qrSide)
+                    .padding(Layout.qrPadding)
+                    .overlay(qrBadge(side: Layout.qrSide * Layout.qrBadgeFraction))
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        } else {
+            // The same 220pt square the QR occupies, so the rows below do not
+            // jump once the address resolves.
+            SwiftUI.ProgressView()
+                .frame(width: Layout.qrSide + Layout.qrPadding * 2,
+                       height: Layout.qrSide + Layout.qrPadding * 2)
+        }
+    }
+
+    @ViewBuilder
+    private func qrBadge(side: CGFloat) -> some View {
+        if let avatarInitial {
+            Text(avatarInitial)
+                .dashFont(.subheadMedium)
+                .foregroundColor(Color.dash.white)
+                .frame(width: side, height: side)
+                .background(Circle().fill(Color.dash.blue))
+                .overlay(Circle().stroke(Color.dash.white, lineWidth: 3))
+        } else {
+            DashIcon.Menu.dashLogoSquare.image
+                .resizable()
+                .scaledToFit()
+                .frame(width: side, height: side)
+        }
+    }
+
+    /// Stand-in for Android's avatar image: the profile picture is not on this
+    /// screen's model, so the username's first letter carries it.
+    private var avatarInitial: String? {
+        guard let first = username?.first else { return nil }
+        return String(first).uppercased()
+    }
+
+    // MARK: - Copyable rows
+
+    /// The Receive tab's address row: caption over a wrapping value, with a
+    /// `tintedGray` copy pill on the trailing edge.
+    ///
+    /// One deviation from the tab — the text takes the full width. The tab has
+    /// a single row and can let the pair sit centred; this screen can show two
+    /// (address and username), and centred rows of different lengths would put
+    /// their copy pills at different x.
+    private func addressRow(caption: String, value: String, action: @escaping () -> Void) -> some View {
+        HStack(spacing: 40) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(caption)
+                    .dashFont(.footnote)
+                    .foregroundStyle(Color.dash.secondaryText)
+
+                Text(value)
+                    .dashFont(.subhead)
+                    .foregroundColor(Color.dash.primaryText)
+                    .multilineTextAlignment(.leading)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            DashUIKit.DashButton(
+                leadingIcon: .custom(DashIcon.Icons.copyOutline.rawValue, bundle: .dashUIKit),
+                size: .medium,
+                style: .tintedGray,
+                action: action
+            )
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+#if DEBUG
+
+/// The screen as the host actually shows it — inside `DashUIKit.BottomSheet`,
+/// over a dimmed backdrop. On its own it has no chrome and no background of its
+/// own, so previewing it bare would flatter it.
+private func requestAmountSheet(
+    amountDuffs: UInt64 = 125_000_000,
+    fiatAmount: String = "$32.75",
+    address: String? = "XyZ8kFqW3nR5tHmB2vJcL7pQaS4dEuG9wN",
+    username: String? = nil
+) -> some View {
+    DashUIKit.BottomSheet(
+        showBackButton: .constant(false),
+        fillsHeight: false
+    ) {
+        RequestAmountScreen(
+            amountDuffs: amountDuffs,
+            fiatAmount: fiatAmount,
+            qrCodeImage: address.flatMap { QRCodeGenerator.image(for: $0) },
+            paymentAddress: address,
+            username: username,
+            onCopyAddress: {},
+            onCopyQRCode: {},
+            onCopyUsername: {},
+            onShare: {})
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+}
+
+@available(iOS 17, *)
+#Preview("Address") {
+    requestAmountSheet()
+}
+
+/// DashPay: the username row joins the address, and the badge in the middle of
+/// the QR becomes the avatar instead of the Dash logo.
+@available(iOS 17, *)
+#Preview("With username") {
+    requestAmountSheet(username: "Epsilon2")
+}
+
+/// Before the address resolves: a spinner in the QR's square so nothing below
+/// moves when it arrives, and Share dimmed rather than sharing nothing.
+@available(iOS 17, *)
+#Preview("No address") {
+    requestAmountSheet(address: nil)
+}
+
+/// The address must ellipsize in the middle rather than push the copy button
+/// off the row — the failure this layout is most likely to have.
+@available(iOS 17, *)
+#Preview("Long address · username") {
+    requestAmountSheet(
+        address: "yTBaseS8fJ4vFrmqhUvBaseLongAddressPaddedOutToItsFullWidth1234",
+        username: "a-rather-long-dashpay-username")
+}
+
+/// Whole units and a fraction read differently at this size; the fiat line
+/// disappears when rates have not arrived.
+@available(iOS 17, *)
+#Preview("Fractional · no rate") {
+    requestAmountSheet(amountDuffs: 12_345_678, fiatAmount: "")
+}
+
+#endif

--- a/DashWallet/Sources/UI/Payments/Receive/RequestAmount/RequestAmountScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Receive/RequestAmount/RequestAmountScreen.swift
@@ -172,6 +172,8 @@ struct RequestAmountScreen: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(Text(NSLocalizedString(
+                "Copy QR code", comment: "Receive: the QR image doubles as a copy control")))
         } else {
             // The same 220pt square the QR occupies, so the rows below do not
             // jump once the address resolves.

--- a/DashWallet/Sources/UI/Swap/Buy/EnterAmount/BuyEnterAmountView.swift
+++ b/DashWallet/Sources/UI/Swap/Buy/EnterAmount/BuyEnterAmountView.swift
@@ -146,11 +146,6 @@ struct BuyEnterAmountView: View {
                 }
             }
         )
-        .frame(maxWidth: .infinity, maxHeight: 320)
-        .padding(.horizontal, Layout.hPadding)
-        .background(Color.dash.secondaryBackground)
-        .clipShape(.rect(cornerRadius: 20))
-        .background(Color.dash.secondaryBackground, ignoresSafeAreaEdges: .bottom)
     }
 }
 

--- a/DashWallet/Sources/UI/Swap/Buy/Receive/BuyReceiveHostingController.swift
+++ b/DashWallet/Sources/UI/Swap/Buy/Receive/BuyReceiveHostingController.swift
@@ -78,15 +78,5 @@ final class BuyReceiveHostingController: UIViewController, NavigationBarDisplaya
     }
 }
 
-private extension UIViewController {
-    func dw_firstTabBarController() -> UITabBarController? {
-        if let tab = self as? UITabBarController { return tab }
-        for child in children {
-            if let tab = child.dw_firstTabBarController() { return tab }
-        }
-        if let presented = presentedViewController {
-            return presented.dw_firstTabBarController()
-        }
-        return nil
-    }
-}
+// `dw_firstTabBarController()` now lives on the shared `UIViewController`
+// category next to `topController()`.

--- a/DashWallet/Sources/UI/Swap/Convert/SwapConvertView.swift
+++ b/DashWallet/Sources/UI/Swap/Convert/SwapConvertView.swift
@@ -163,11 +163,6 @@ struct SwapConvertView: View {
             inProgress: viewModel.isLoading,
             actionHandler: onContinue
         )
-        .frame(maxWidth: .infinity, maxHeight: 320)
-        .padding(.horizontal, Layout.hPadding)
-        .background(Color.dash.secondaryBackground)
-        .clipShape(.rect(cornerRadius: 20))
-        .background(Color.dash.secondaryBackground, ignoresSafeAreaEdges: .bottom)
     }
 }
 

--- a/DashWallet/Sources/UI/Swap/TransactionStatus/SwapTransactionStatusHostingController.swift
+++ b/DashWallet/Sources/UI/Swap/TransactionStatus/SwapTransactionStatusHostingController.swift
@@ -207,17 +207,5 @@ private struct SwapTransactionStatusView: View {
     }
 }
 
-private extension UIViewController {
-    /// Finds the first UITabBarController in the view-controller hierarchy reachable from `self`
-    /// (children + presented), used to switch back to the Home tab when the flow was pushed.
-    func dw_firstTabBarController() -> UITabBarController? {
-        if let tab = self as? UITabBarController { return tab }
-        for child in children {
-            if let tab = child.dw_firstTabBarController() { return tab }
-        }
-        if let presented = presentedViewController {
-            return presented.dw_firstTabBarController()
-        }
-        return nil
-    }
-}
+// `dw_firstTabBarController()` now lives on the shared `UIViewController`
+// category next to `topController()`, where a third caller could reach it.

--- a/DashWallet/Sources/UI/SwiftUI Components/SegmentedControl.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/SegmentedControl.swift
@@ -28,6 +28,15 @@ private enum SegmentedControlLayout {
     static let shadowY: CGFloat = 5
     static let springResponse: Double = 0.3
     static let springDamping: Double = 0.7
+
+    // Icon variant (artwork stacked over the label). It sizes to its content
+    // instead of `height`, which only fits a single text line. The icons are
+    // drawn to one height and differing widths — a single arrow is half as
+    // wide as the double one — so pinning the height is what keeps the labels
+    // under them on one line.
+    static let iconHeight: CGFloat = 17
+    static let iconLabelSpacing: CGFloat = 4
+    static let iconSegmentVerticalPadding: CGFloat = 10
 }
 
 struct SegmentedControl<T: Hashable>: View {
@@ -36,6 +45,14 @@ struct SegmentedControl<T: Hashable>: View {
     let options: [T]
     @Binding var selection: T
     let label: (T) -> String
+    /// Artwork drawn above each label, chosen per selection state. `nil` (the
+    /// default) keeps the text-only segment every existing caller uses.
+    ///
+    /// It takes `isSelected` because a selected segment and an unselected one
+    /// are usually two different files rather than one file tinted two ways —
+    /// artwork that carries its own colour cannot be dimmed into the
+    /// unselected treatment the label gets.
+    var icon: ((_ option: T, _ isSelected: Bool) -> DashIconSource)? = nil
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var containerWidth: CGFloat = 0
@@ -65,12 +82,12 @@ struct SegmentedControl<T: Hashable>: View {
                     Button(action: {
                         select(option)
                     }) {
-                        Text(label(option))
-                            .font(.footnoteMedium)
+                        segmentContent(option)
                             .foregroundColor(selection == option ? .dash.primaryText : .dash.primaryText.opacity(0.4))
-                            .lineLimit(1)
                             .frame(maxWidth: .infinity)
-                            .padding(.vertical, Layout.segmentVerticalPadding)
+                            .padding(.vertical, icon == nil
+                                ? Layout.segmentVerticalPadding
+                                : Layout.iconSegmentVerticalPadding)
                             .contentShape(Rectangle())
                             .animation(.spring(response: Layout.springResponse, dampingFraction: Layout.springDamping), value: selection)
                     }
@@ -99,9 +116,32 @@ struct SegmentedControl<T: Hashable>: View {
                 }
         )
         .padding(Layout.containerPadding)
-        .frame(height: Layout.height)
+        // The icon variant is two lines tall, so it sizes to its content —
+        // `height` is the single-line text measurement.
+        .frame(height: icon == nil ? Layout.height : nil)
         .background(Color.dash.gray300Alpha20)
         .clipShape(RoundedRectangle(cornerRadius: Layout.containerCornerRadius))
+    }
+
+    @ViewBuilder
+    private func segmentContent(_ option: T) -> some View {
+        if let icon {
+            VStack(spacing: Layout.iconLabelSpacing) {
+                Image(dash: icon(option, selection == option))
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: Layout.iconHeight)
+                segmentLabel(option)
+            }
+        } else {
+            segmentLabel(option)
+        }
+    }
+
+    private func segmentLabel(_ option: T) -> some View {
+        Text(label(option))
+            .font(.footnoteMedium)
+            .lineLimit(1)
     }
 
     private func updateSelection(at x: CGFloat) {
@@ -141,6 +181,43 @@ private struct SegmentedControlPreview: View {
             SegmentedControl(options: ["Day", "Week", "Month"], selection: $three)
 
             SegmentedControl(options: ["1D", "1W", "1M", "1Y"], selection: $four)
+        }
+        .padding()
+    }
+}
+
+#Preview("Icon variant") {
+    SegmentedControlIconPreview()
+}
+
+/// The icon variant next to the text-only one, so the two stay recognisably the
+/// same control: same track, same pill, only the segment is two lines tall. Tap
+/// through the segments — each swaps between its coloured and grey artwork.
+private struct SegmentedControlIconPreview: View {
+    @State private var withIcons = "Internal"
+    @State private var textOnly = "Internal"
+
+    private let options = ["Receive", "Internal", "Send"]
+    private func icon(_ option: String, isSelected: Bool) -> DashIconSource {
+        switch option {
+        case "Receive":
+            return (isSelected ? DashIcon.SegmentedControl.receive : .receiveDisabled).source
+        case "Send":
+            return (isSelected ? DashIcon.SegmentedControl.send : .sendDisabled).source
+        default:
+            return (isSelected ? DashIcon.SegmentedControl.transfer : .transferDisabled).source
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            SegmentedControl(
+                options: options,
+                selection: $withIcons,
+                label: { $0 },
+                icon: icon)
+
+            SegmentedControl(options: options, selection: $textOnly)
         }
         .padding()
     }

--- a/DashWallet/Sources/UI/SwiftUI Components/Toast.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/Toast.swift
@@ -32,9 +32,14 @@ struct ToastView: View {
             if let icon = icon {
                 VStack {
                     Icon(name: icon)
+                        // `font` sizes SF Symbols only. A `.custom` asset is
+                        // resizable with no intrinsic cap, so without this
+                        // frame it grows to fill the row and squeezes the
+                        // text onto two lines.
+                        .font(.system(size: 15))
+                        .frame(maxHeight: 20)
                         .padding(.leading, 8)
                         .padding(.top, 12)
-                        .font(.system(size: 15))
                     Spacer()
                 }
             }

--- a/DashWallet/Sources/UI/SwiftUI Components/TransientToastModifier.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/TransientToastModifier.swift
@@ -1,0 +1,147 @@
+//
+//  Created by Roman Chornyi
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DashUIKit
+import SwiftUI
+
+extension View {
+    /// Overlays a `DashUIKit.Toast` at the bottom while `isPresented`, then
+    /// clears the flag after `duration`.
+    ///
+    /// The sibling `dexOfflineToast` shows a toast for as long as a condition
+    /// holds; this one is for a moment that has already passed — a copy, a
+    /// save — where nothing will turn the flag off but time.
+    ///
+    /// One toast at a time: the timer is keyed on `isPresented`, so a second
+    /// trigger while one is already up does NOT extend it. Setting a `true`
+    /// flag to `true` is not a change, so there is no event to restart on — the
+    /// second message rides out whatever is left of the first one's countdown.
+    /// A caller that needs each message timed in full has to lower the flag
+    /// between them.
+    func transientToast(
+        isPresented: Binding<Bool>,
+        style: ToastStyle,
+        message: String,
+        duration: TimeInterval = 2
+    ) -> some View {
+        modifier(TransientToastModifier(
+            isPresented: isPresented,
+            style: style,
+            message: message,
+            duration: duration))
+    }
+}
+
+extension View {
+    /// Overlays a `DashUIKit.Toast` for as long as `isVisible` holds.
+    ///
+    /// The sibling above is for a moment that has already passed and needs a
+    /// timer to clear it; this one is for a condition that clears itself — a
+    /// sync finishing, a connection returning.
+    func conditionToast(
+        isVisible: Bool,
+        style: ToastStyle,
+        message: String
+    ) -> some View {
+        modifier(ConditionToastModifier(isVisible: isVisible, style: style, message: message))
+    }
+}
+
+private struct ConditionToastModifier: ViewModifier {
+    let isVisible: Bool
+    let style: ToastStyle
+    let message: String
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottom) {
+                if isVisible {
+                    DashUIKit.Toast(style: style, message: message)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 16)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .animation(.easeInOut(duration: 0.3), value: isVisible)
+    }
+}
+
+private struct TransientToastModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let style: ToastStyle
+    let message: String
+    let duration: TimeInterval
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottom) {
+                if isPresented {
+                    // No `onDismiss`: it draws a close button, and the
+                    // `Spacer` beside that button makes the toast greedy —
+                    // it would stretch edge to edge instead of hugging the
+                    // message. Nothing here needs dismissing by hand anyway.
+                    DashUIKit.Toast(style: style, message: message)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 16)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .animation(.easeInOut(duration: 0.3), value: isPresented)
+            .task(id: isPresented) {
+                guard isPresented else { return }
+                try? await Task.sleep(for: .seconds(duration))
+                // Cancelled when the flag flips or the view goes away. It does
+                // not restart on a repeat of the same value — see the note on
+                // `transientToast`.
+                guard !Task.isCancelled else { return }
+                isPresented = false
+            }
+    }
+}
+
+#if DEBUG
+
+private struct TransientToastPreview: View {
+    @State private var copied = false
+
+    var body: some View {
+        VStack {
+            Spacer()
+            // Qualified: the app has a `DashButton` of its own, with a
+            // different Style enum.
+            DashUIKit.DashButton(
+                text: "Copy",
+                size: .medium,
+                style: .tintedGray,
+                action: { copied = true })
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.dash.primaryBackground)
+        .transientToast(
+            isPresented: $copied,
+            style: .copied,
+            message: NSLocalizedString("Copied", comment: ""))
+    }
+}
+
+@available(iOS 17, *)
+#Preview("Tap to show") {
+    TransientToastPreview()
+}
+
+#endif

--- a/DashWallet/Sources/UI/Views/UIView+DWHUD.m
+++ b/DashWallet/Sources/UI/Views/UIView+DWHUD.m
@@ -29,19 +29,46 @@ NSTimeInterval const DW_INFO_HUD_DISPLAY_TIME = 3.5;
 
 @implementation UIView (DWHUD)
 
+/// The progress HUD is held by reference (`dw_progressHUD`) rather than looked
+/// up, so show and hide always address the same object.
+///
+/// MBProgressHUD's own `HUDForView:` cannot serve here: info HUDs are the same
+/// class on the same view, and it returns the TOPMOST one. A flow that reports
+/// its result with `dw_showInfoHUD` and then takes its spinner down with
+/// `dw_hideProgressHUD` therefore dismissed the confirmation it had just put
+/// up, leaving nothing to hide the spinner — which then ran forever. The
+/// asset-lock retry in `TxDetailViewController` is exactly that pair, and it
+/// span on over a transfer that had already completed. The same lookup made
+/// `dw_showProgressHUD` adopt a visible info HUD and rewrite its label instead
+/// of raising a spinner at all.
+///
+/// Telling the two apart by `mode` would fix those but not this: a HUD stays in
+/// the hierarchy for the length of its fade-out with `finished` already set
+/// (private, so not readable from here), and a show inside that window would
+/// adopt a HUD on its way out — leaving the caller with no spinner. An owned
+/// reference, released at hide time, has neither problem.
 - (void)dw_showProgressHUDWithMessage:(nullable NSString *)message {
-    MBProgressHUD *hud = [MBProgressHUD HUDForView:self];
+    MBProgressHUD *hud = [self dw_progressHUD];
     if (!hud) {
         hud = [MBProgressHUD showHUDAddedTo:self animated:YES];
+        hud.removeFromSuperViewOnHide = YES;
         hud.label.font = [UIFont dw_fontForTextStyle:UIFontTextStyleCaption1];
         hud.label.adjustsFontForContentSizeCategory = YES;
         hud.label.numberOfLines = 0;
+        [self setDw_progressHUD:hud];
     }
     hud.label.text = message;
 }
 
 - (void)dw_hideProgressHUD {
-    [MBProgressHUD hideHUDForView:self animated:YES];
+    MBProgressHUD *hud = [self dw_progressHUD];
+    if (!hud) {
+        return;
+    }
+    // Released before the fade-out finishes, deliberately: a `dw_show…` during
+    // that window must build a fresh HUD instead of adopting this one.
+    [self setDw_progressHUD:nil];
+    [hud hideAnimated:YES];
 }
 
 - (void)dw_showInfoHUDWithText:(NSString *)text {
@@ -103,6 +130,17 @@ NSTimeInterval const DW_INFO_HUD_DISPLAY_TIME = 3.5;
 }
 
 #pragma mark - Private
+
+- (nullable MBProgressHUD *)dw_progressHUD {
+    return objc_getAssociatedObject(self, @selector(dw_progressHUD));
+}
+
+- (void)setDw_progressHUD:(nullable MBProgressHUD *)dw_progressHUD {
+    objc_setAssociatedObject(self,
+                             @selector(dw_progressHUD),
+                             dw_progressHUD,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
 
 - (nullable NSMutableArray<MBProgressHUD *> *)dw_infoHUDQueue {
     return objc_getAssociatedObject(self, @selector(dw_infoHUDQueue));

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -5855,3 +5855,6 @@
 "Node status" = "Node status";
 "Asking the evonode…" = "Asking the evonode…";
 "Request status" = "Request status";
+
+/* Receive: the QR image doubles as a copy control */
+"Copy QR code" = "Copy QR code";


### PR DESCRIPTION
## Issue being fixed or feature implemented

Second of the four stacked payments PRs. **Base: `split/1-advanced-mode` (#1101)** — retarget to `develop` once that merges.

The payments landing becomes one screen with three tabs, and the Receive flow is redesigned inside it.

## What was done?

**The shell.** The landing is rebuilt as a tabbed screen — hero selector, directional slide plus swipe between tabs, a close control, and a copied-toast that floats above the sheet instead of hiding behind the tab bar. It is presented as a large-detent sheet from the payments tab button; re-tapping the button while it is open re-roots it. The tab bar hides while the landing is up and comes back on the way out, including from its own pushed steps.

**Receive.** The tab's content is extracted into `PaymentsReceiveContent`; the request-amount step becomes SwiftUI (`RequestAmountScreen` / `RequestAmountHostingController`, `SpecifyAmountView`) on the DashUIKit keypad, replacing `DWRequestAmountViewController` on this path. The attended receive session survives its own pushed steps and sleeps under anything else; a payment arriving while the request sheet is up closes that sheet and leaves the receipt on the surface behind.

**Shared bits** the shell needed: the segmented control's icon variant, `TransientToastModifier`, `dw_firstTabBarController` (de-duplicated from two hosting controllers), and an owned-reference fix in `UIView+DWHUD`.

The **Internal transfer and Send tabs are unchanged here** — they embed the current forms through signatures that already exist, so every entry point works at this commit. Their redesigns are the next two PRs.

Two APIs land here dormant, with their first caller in the Send PR: `showContacts`/`contactsTabIndex` on the tab bar controller, and `canSendToUsername`/`canSwapToOtherCrypto` on the landing view model. They are final-tree code, kept whole rather than hunk-split.

## How Has This Been Tested?

Clean `dashpay` build (arm64 simulator) and a testnet pass on device: the sheet presentation and re-rooting; tab swipe and slide; copy (toast above the sheet), share, specify amount → request sheet → payment arrives → sheet closes onto the receipt; Done and "Receive another"; the receive network list is Core + Shielded with Advanced mode off and gains Platform with it on; the balance-row pinned receive/send sheets still work; the tab bar hides and restores around the landing and its pushed steps.

Regression-checked in the same pass: the Send tab still shows the existing form and a scan from it fills that form in place; the Internal tab is unchanged.

`scripts/a11y_audit.py --check` passes — one finding it raised is fixed here: the receive QR is a copy button and now says so to VoiceOver.

The unit-test target does not build on this branch (pre-existing), so no unit tests were added.

### Demo

https://github.com/user-attachments/assets/f59b2585-3819-4fb9-a237-a420d374f422


https://github.com/user-attachments/assets/20366436-1909-4cb5-90a3-2ff425ffd49b


**The shell** — the payments button presents the landing as a sheet, re-tapping re-roots it, tabs change by tap and by swipe. The Internal and Send tabs still show today's forms: this PR changes the chrome around them, not their insides.


**Receive** — network list follows Advanced mode; copy shows the toast above the sheet; share; specify amount opens the request sheet, and a payment arriving while it is up closes it onto the receipt.


## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Payments tab with Receive, Send, and Internal payment options.
  * Added Receive flows for QR codes, wallet addresses, usernames, network selection, amount requests, sharing, and payment status updates.
  * Added support for specifying requested amounts and copying QR codes.
  * Added icon-enabled segmented controls and reusable transient toast notifications.

* **Improvements**
  * Updated payment screens with improved navigation, sheet presentation, and tab transitions.
  * Refined numeric keyboard sizing and layout across payment, purchase, and swap screens.
  * Improved toast icon sizing and progress indicator handling.
  * Added English text for copying QR codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->