### PR TITLE
feat: export Core wallet diagnostics before log archive

### DIFF
--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -18,7 +18,6 @@
 import Intents
 import UIKit
 import MessageUI
-import SwiftDashSDK
 
 @objc
 extension UIViewController {
@@ -84,33 +83,16 @@ extension UIViewController {
     }
 
     @objc func presentSupportEmailController() {
-        // Zip the recent SwiftDashSDK log sessions off the main actor
-        // first (blocking file I/O), then compose. App logs stay as
-        // loose attachments — the support workflow already expects
-        // them — while the SDK sessions ride along as one zip. A
-        // failed/empty SDK export (e.g. first launch after the update
-        // that enabled file logging) just omits the zip.
-        let network = SwiftDashSDKHost.shared.runningNetwork.map { String(describing: $0) } ?? "unknown"
-        let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
-        let appVersion = "\(short) (\(build))"
-        let currentSession = LoggingPreferences.currentSessionDirectory
-
+        // Use the same snapshot -> flush -> single-archive path as Tools and
+        // About. If export fails, support remains reachable without silently
+        // substituting a different, partial set of loose log attachments.
         Task { [weak self] in
-            let sdkLogsZip = await Task.detached(priority: .userInitiated) { () -> URL? in
-                try? DiagnosticLogExporter.export(
-                    network: network,
-                    appVersion: appVersion,
-                    currentSession: currentSession,
-                    appLogFiles: [])
-            }.value
-            self?.presentSupportEmailController(sdkLogsZip: sdkLogsZip)
+            let logsArchive = await DiagnosticLogExporter.exportArchiveForSupport()
+            self?.presentSupportEmailController(logsArchive: logsArchive)
         }
     }
 
-    private func presentSupportEmailController(sdkLogsZip: URL?) {
-        let logFiles = DWLogger.sharedInstance().logFiles()
-
+    private func presentSupportEmailController(logsArchive: URL?) {
         if MFMailComposeViewController.canSendMail() {
             let mailComposer = MFMailComposeViewController()
             mailComposer.mailComposeDelegate = self as? MFMailComposeViewControllerDelegate
@@ -120,41 +102,11 @@ extension UIViewController {
             mailComposer.setToRecipients([email])
             mailComposer.setSubject(String(format: NSLocalizedString("iOS Dash Wallet: %@ Reported issue", comment: ""), version))
 
-            var totalSize: Int64 = 0
-            let maxSize: Int64 = 25 * 1024 * 1024 // 25MB in bytes
-
-            // SDK sessions first — one compressed zip; the app-log
-            // loop below fills the remaining attachment budget.
-            if let sdkLogsZip, let zipData = try? Data(contentsOf: sdkLogsZip) {
+            if let logsArchive, let zipData = try? Data(contentsOf: logsArchive) {
                 mailComposer.addAttachmentData(
                     zipData,
                     mimeType: "application/zip",
-                    fileName: sdkLogsZip.lastPathComponent)
-                totalSize += Int64(zipData.count)
-            }
-
-            // Sort log files by modification date, most recent first
-            let sortedLogFiles = logFiles.sorted { (url1, url2) -> Bool in
-                let date1 = try? url1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
-                let date2 = try? url2.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
-                return (date1 ?? .distantPast) > (date2 ?? .distantPast)
-            }
-
-            for logFileURL in sortedLogFiles {
-                guard let logData = try? Data(contentsOf: logFileURL) else {
-                    continue
-                }
-
-                // Break if this file would exceed the size limit
-                if totalSize + Int64(logData.count) > maxSize {
-                    break
-                }
-
-                let fileName = logFileURL.lastPathComponent
-                let mimeType = fileName.hasSuffix(".gz") ? "application/gzip" : "text/plain"
-                mailComposer.addAttachmentData(logData, mimeType: mimeType, fileName: fileName)
-
-                totalSize += Int64(logData.count)
+                    fileName: logsArchive.lastPathComponent)
             }
 
             present(mailComposer, animated: true)
@@ -174,9 +126,8 @@ extension UIViewController {
             if !email.isEmpty {
                 activityItems.append(SupportRecipientActivityItem(email: email, subject: subject))
             }
-            activityItems.append(contentsOf: logFiles)
-            if let sdkLogsZip {
-                activityItems.append(sdkLogsZip)
+            if let logsArchive {
+                activityItems.append(logsArchive)
             }
             dw_presentActivityViewController(activityItems: activityItems)
         }

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -109,10 +109,21 @@ extension UIViewController {
     /// Never compose silently without the logs the user believes are
     /// attached: say what is missing and let them decide. Reached from an
     /// export failure and from an archive that exists but could not be read.
+    ///
+    /// "Without logs" means without the archive, not without evidence: the
+    /// composer still attaches the app's own CocoaLumberjack files, which is
+    /// what the pre-archive build guaranteed. Say so, or the user declines a
+    /// report that would in fact have carried something to read.
     private func presentLogsNotAttachedAlert(message: String) {
+        var body = message
+        if !DWLogger.sharedInstance().logFiles().isEmpty {
+            body += "\n\n" + NSLocalizedString(
+                "The app's own logs will still be attached.",
+                comment: "Support")
+        }
         let alert = UIAlertController(
             title: NSLocalizedString("Logs could not be attached", comment: "Support"),
-            message: message,
+            message: body,
             preferredStyle: .alert)
         alert.addAction(UIAlertAction(
             title: NSLocalizedString("Send Without Logs", comment: "Support"),
@@ -127,6 +138,27 @@ extension UIViewController {
     /// the user has written the report — so larger archives go out through
     /// the share sheet, which hands the file over by URL.
     private static let maxMailAttachmentBytes: UInt64 = 25 * 1024 * 1024
+
+    /// Attach the app's own log files individually, newest-first under the
+    /// exporter's byte cap. The fallback when there is no archive; reads are
+    /// file I/O, so they happen off the main actor.
+    private func attachAppLogs(to composer: MFMailComposeViewController) async {
+        let files = DiagnosticLogExporter.selectAppLogs(DWLogger.sharedInstance().logFiles())
+        guard !files.isEmpty else { return }
+        let payloads = await Task.detached(priority: .userInitiated) {
+            files.compactMap { url -> (name: String, data: Data)? in
+                guard let data = try? Data(contentsOf: url) else { return nil }
+                return (name: url.lastPathComponent, data: data)
+            }
+        }.value
+        for payload in payloads {
+            composer.addAttachmentData(
+                payload.data,
+                mimeType: "text/plain",
+                fileName: payload.name)
+        }
+        DWLogger.log("Support composed without an archive; attached \(payloads.count) app log file(s)")
+    }
 
     private func presentSupportEmailController(logsArchive: URL?) async {
         let email = Bundle.main.infoDictionary?["SupportEmail"] as? String ?? ""
@@ -169,6 +201,14 @@ extension UIViewController {
                     zipData,
                     mimeType: "application/zip",
                     fileName: logsArchive.lastPathComponent)
+            } else {
+                // No archive: attach the app's own logs directly, which is
+                // what this screen did before the archive existed. Everything
+                // riding on one zip meant a single throw in `export()` — a
+                // rolled session directory, a full disk, `noLogsFound` on the
+                // first launch after an update — sent support a ticket with
+                // nothing in it, on the device where something had gone wrong.
+                await attachAppLogs(to: mailComposer)
             }
             present(mailComposer, animated: true)
         }
@@ -189,6 +229,11 @@ extension UIViewController {
             }
             if let logsArchive {
                 activityItems.append(logsArchive)
+            } else {
+                // Same fallback as the mail path: the share sheet takes the
+                // app log files by URL, so no read is needed here.
+                activityItems.append(contentsOf: DiagnosticLogExporter.selectAppLogs(
+                    DWLogger.sharedInstance().logFiles()))
             }
             dw_presentActivityViewController(activityItems: activityItems)
         }

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -19,12 +19,6 @@ import Intents
 import UIKit
 import MessageUI
 
-/// Stored state an extension cannot carry: whether a support export is in
-/// flight (see `presentSupportEmailController`).
-private enum SupportExport {
-    @MainActor static var inFlight = false
-}
-
 @objc
 extension UIViewController {
     /// The tab bar controller somewhere at or under this one, searching
@@ -89,19 +83,14 @@ extension UIViewController {
     }
 
     @objc func presentSupportEmailController() {
-        // One support export at a time. The lifecycle gate cannot close this
-        // window on its own: the overlay appears a turn after `tryBegin`, and
-        // a second tap in between would be refused straight into a log-less
-        // composer while the first export's composer is later dropped by
-        // UIKit as "already presenting".
-        // …but a cancelled export keeps running with its gate held and no card
-        // on screen, and this guard would then swallow every further tap in
-        // silence. Let those through: `exportArchive` refuses them, and that
-        // refusal is the only explanation the user can still be given.
-        guard !SupportExport.inFlight || DiagnosticLogExporter.waitWasCancelled else { return }
-        SupportExport.inFlight = true
+        // No screen-local re-entry flag. `exportArchive` owns the only fact
+        // that decides it — a snapshot still in flight — and holds it for the
+        // whole pass, past Cancel and past the gate's timeout, which a flag
+        // cleared when the export returns cannot match. Every tap therefore
+        // reaches the exporter: refused silently while its card is up (the
+        // card is the explanation), and refused into the alert once it is
+        // gone, which is the only feedback left at that point.
         Task { [weak self] in
-            defer { SupportExport.inFlight = false }
             let result = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: true)
             guard let self else { return }
             switch result {

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -94,7 +94,11 @@ extension UIViewController {
         // a second tap in between would be refused straight into a log-less
         // composer while the first export's composer is later dropped by
         // UIKit as "already presenting".
-        guard !SupportExport.inFlight else { return }
+        // …but a cancelled export keeps running with its gate held and no card
+        // on screen, and this guard would then swallow every further tap in
+        // silence. Let those through: `exportArchive` refuses them, and that
+        // refusal is the only explanation the user can still be given.
+        guard !SupportExport.inFlight || DiagnosticLogExporter.waitWasCancelled else { return }
         SupportExport.inFlight = true
         Task { [weak self] in
             defer { SupportExport.inFlight = false }

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -19,6 +19,12 @@ import Intents
 import UIKit
 import MessageUI
 
+/// Stored state an extension cannot carry: whether a support export is in
+/// flight (see `presentSupportEmailController`).
+private enum SupportExport {
+    @MainActor static var inFlight = false
+}
+
 @objc
 extension UIViewController {
     /// The tab bar controller somewhere at or under this one, searching
@@ -83,45 +89,83 @@ extension UIViewController {
     }
 
     @objc func presentSupportEmailController() {
-        // Use the same snapshot -> flush -> single-archive path as Tools and
-        // About. If export fails, support remains reachable without silently
-        // substituting a different, partial set of loose log attachments.
+        // One support export at a time. The lifecycle gate cannot close this
+        // window on its own: the overlay appears a turn after `tryBegin`, and
+        // a second tap in between would be refused straight into a log-less
+        // composer while the first export's composer is later dropped by
+        // UIKit as "already presenting".
+        guard !SupportExport.inFlight else { return }
+        SupportExport.inFlight = true
         Task { [weak self] in
-            let logsArchive = await DiagnosticLogExporter.exportArchiveForSupport()
-            self?.presentSupportEmailController(logsArchive: logsArchive)
+            defer { SupportExport.inFlight = false }
+            let result = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: true)
+            guard let self else { return }
+            switch result {
+            case .success(let archive):
+                await self.presentSupportEmailController(logsArchive: archive)
+            case .failure(let error):
+                if (error as? DiagnosticLogExportError) == .cancelled { return }
+                // Never compose silently without the logs the user believes
+                // are attached: say what is missing and let them decide.
+                let alert = UIAlertController(
+                    title: NSLocalizedString("Logs could not be attached", comment: "Support"),
+                    message: error.localizedDescription,
+                    preferredStyle: .alert)
+                alert.addAction(UIAlertAction(
+                    title: NSLocalizedString("Send Without Logs", comment: "Support"),
+                    style: .default) { [weak self] _ in
+                        Task { await self?.presentSupportEmailController(logsArchive: nil) }
+                    })
+                alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel))
+                self.present(alert, animated: true)
+            }
         }
     }
 
-    private func presentSupportEmailController(logsArchive: URL?) {
-        if MFMailComposeViewController.canSendMail() {
+    /// Mail rejects attachments over roughly this size at send time — after
+    /// the user has written the report — so larger archives go out through
+    /// the share sheet, which hands the file over by URL.
+    private static let maxMailAttachmentBytes: UInt64 = 25 * 1024 * 1024
+
+    private func presentSupportEmailController(logsArchive: URL?) async {
+        let email = Bundle.main.infoDictionary?["SupportEmail"] as? String ?? ""
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        let subject = String(format: NSLocalizedString("iOS Dash Wallet: %@ Reported issue", comment: ""), version)
+        let archiveBytes = logsArchive
+            .flatMap { try? $0.resourceValues(forKeys: [.fileSizeKey]).fileSize }
+            .map { UInt64(max(0, $0)) } ?? 0
+
+        if MFMailComposeViewController.canSendMail(), archiveBytes <= Self.maxMailAttachmentBytes {
+            // The read is file I/O of up to the cap: off the main actor.
+            var zipData: Data?
+            if let logsArchive {
+                zipData = await Task.detached(priority: .userInitiated) {
+                    try? Data(contentsOf: logsArchive)
+                }.value
+            }
             let mailComposer = MFMailComposeViewController()
             mailComposer.mailComposeDelegate = self as? MFMailComposeViewControllerDelegate
-
-            let email = Bundle.main.infoDictionary?["SupportEmail"] as? String ?? ""
-            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
             mailComposer.setToRecipients([email])
-            mailComposer.setSubject(String(format: NSLocalizedString("iOS Dash Wallet: %@ Reported issue", comment: ""), version))
-
-            if let logsArchive, let zipData = try? Data(contentsOf: logsArchive) {
+            mailComposer.setSubject(subject)
+            if let logsArchive, let zipData {
                 mailComposer.addAttachmentData(
                     zipData,
                     mimeType: "application/zip",
                     fileName: logsArchive.lastPathComponent)
             }
-
             present(mailComposer, animated: true)
         }
         else {
+            if archiveBytes > Self.maxMailAttachmentBytes {
+                DWLogger.log("Support archive is \(archiveBytes) bytes, over the mail attachment limit; sharing by URL instead")
+            }
             // No Apple Mail account configured (common when the customer lives in Gmail), so
-            // `MFMailComposeViewController` is unavailable and the logs go out through the share
-            // sheet instead. Lead with a mail item carrying the support address and subject:
-            // handlers that understand `mailto:` prefill the recipient from it, and the rest at
-            // least show the address in the composed body — the previous items were log files
-            // only, which is why reports arrived with an empty "To" field.
-            let email = Bundle.main.infoDictionary?["SupportEmail"] as? String ?? ""
-            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-            let subject = String(format: NSLocalizedString("iOS Dash Wallet: %@ Reported issue", comment: ""), version)
-
+            // `MFMailComposeViewController` is unavailable — or the archive is too large for
+            // it — and the logs go out through the share sheet instead. Lead with a mail item
+            // carrying the support address and subject: handlers that understand `mailto:`
+            // prefill the recipient from it, and the rest at least show the address in the
+            // composed body — the previous items were log files only, which is why reports
+            // arrived with an empty "To" field.
             var activityItems: [Any] = []
             if !email.isEmpty {
                 activityItems.append(SupportRecipientActivityItem(email: email, subject: subject))

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -104,7 +104,10 @@ extension UIViewController {
             case .success(let archive):
                 await self.presentSupportEmailController(logsArchive: archive)
             case .failure(let error):
-                if (error as? DiagnosticLogExportError) == .cancelled { return }
+                // Cancel is the user's own choice, and a refusal whose owner
+                // is still on screen is already explained by that card — this
+                // alert would be drawn under the overlay window either way.
+                if DiagnosticLogExporter.shouldStaySilent(about: error) { return }
                 self.presentLogsNotAttachedAlert(message: error.localizedDescription)
             }
         }

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -105,21 +105,26 @@ extension UIViewController {
                 await self.presentSupportEmailController(logsArchive: archive)
             case .failure(let error):
                 if (error as? DiagnosticLogExportError) == .cancelled { return }
-                // Never compose silently without the logs the user believes
-                // are attached: say what is missing and let them decide.
-                let alert = UIAlertController(
-                    title: NSLocalizedString("Logs could not be attached", comment: "Support"),
-                    message: error.localizedDescription,
-                    preferredStyle: .alert)
-                alert.addAction(UIAlertAction(
-                    title: NSLocalizedString("Send Without Logs", comment: "Support"),
-                    style: .default) { [weak self] _ in
-                        Task { await self?.presentSupportEmailController(logsArchive: nil) }
-                    })
-                alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel))
-                self.present(alert, animated: true)
+                self.presentLogsNotAttachedAlert(message: error.localizedDescription)
             }
         }
+    }
+
+    /// Never compose silently without the logs the user believes are
+    /// attached: say what is missing and let them decide. Reached from an
+    /// export failure and from an archive that exists but could not be read.
+    private func presentLogsNotAttachedAlert(message: String) {
+        let alert = UIAlertController(
+            title: NSLocalizedString("Logs could not be attached", comment: "Support"),
+            message: message,
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("Send Without Logs", comment: "Support"),
+            style: .default) { [weak self] _ in
+                Task { await self?.presentSupportEmailController(logsArchive: nil) }
+            })
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        present(alert, animated: true)
     }
 
     /// Mail rejects attachments over roughly this size at send time — after
@@ -131,17 +136,33 @@ extension UIViewController {
         let email = Bundle.main.infoDictionary?["SupportEmail"] as? String ?? ""
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
         let subject = String(format: NSLocalizedString("iOS Dash Wallet: %@ Reported issue", comment: ""), version)
-        let archiveBytes = logsArchive
-            .flatMap { try? $0.resourceValues(forKeys: [.fileSizeKey]).fileSize }
-            .map { UInt64(max(0, $0)) } ?? 0
+        // `nil` is "size unknown", which must land on the share-sheet side of
+        // the cap: an unreadable size on a large-wallet archive is exactly
+        // the case where an in-memory read and a mail attachment would fail
+        // — silently, and after the user has written the report.
+        let archiveBytes: UInt64? = logsArchive.flatMap {
+            (try? $0.resourceValues(forKeys: [.fileSizeKey]).fileSize).map { UInt64(max(0, $0)) }
+        }
+        let fitsInMail = logsArchive == nil
+            || (archiveBytes.map { $0 <= Self.maxMailAttachmentBytes } ?? false)
 
-        if MFMailComposeViewController.canSendMail(), archiveBytes <= Self.maxMailAttachmentBytes {
+        if MFMailComposeViewController.canSendMail(), fitsInMail {
             // The read is file I/O of up to the cap: off the main actor.
             var zipData: Data?
             if let logsArchive {
                 zipData = await Task.detached(priority: .userInitiated) {
                     try? Data(contentsOf: logsArchive)
                 }.value
+                // The archive exists but could not be read (memory pressure,
+                // temp file evicted): that is the log-less send the alert
+                // exists to prevent, not a case to fall through.
+                guard zipData != nil else {
+                    DWLogger.log("Support archive could not be read for attachment; asking before composing without it")
+                    presentLogsNotAttachedAlert(message: NSLocalizedString(
+                        "The diagnostic archive could not be read.",
+                        comment: "Support"))
+                    return
+                }
             }
             let mailComposer = MFMailComposeViewController()
             mailComposer.mailComposeDelegate = self as? MFMailComposeViewControllerDelegate
@@ -156,8 +177,8 @@ extension UIViewController {
             present(mailComposer, animated: true)
         }
         else {
-            if archiveBytes > Self.maxMailAttachmentBytes {
-                DWLogger.log("Support archive is \(archiveBytes) bytes, over the mail attachment limit; sharing by URL instead")
+            if let logsArchive, !fitsInMail {
+                DWLogger.log("Support archive \(archiveBytes.map { "is \($0) bytes, over" } ?? "has an unreadable size, treated as over") the mail attachment limit; sharing \(logsArchive.lastPathComponent) by URL instead")
             }
             // No Apple Mail account configured (common when the customer lives in Gmail), so
             // `MFMailComposeViewController` is unavailable — or the archive is too large for

--- a/DashWallet/Sources/Infrastructure/DWLogger.h
+++ b/DashWallet/Sources/Infrastructure/DWLogger.h
@@ -70,6 +70,13 @@ NSString *DWCurrentThreadName(void);
 
 - (NSArray<NSURL *> *)logFiles;
 
+/// Drains CocoaLumberjack's asynchronous log queue and the file logger's
+/// buffer so `logFiles` reflect every line logged so far. The diagnostic
+/// export copies those files moments after calling this; without it the
+/// newest lines — the ones a support ticket is about — are still in the
+/// queue when the copy is taken.
++ (void)flush;
+
 /** @fn log:
  *  @brief This method logs a message with default class name
  *  @param message Final message to log

--- a/DashWallet/Sources/Infrastructure/DWLogger.m
+++ b/DashWallet/Sources/Infrastructure/DWLogger.m
@@ -132,6 +132,10 @@ NSString *DWCurrentThreadName(void) {
     return [logFiles copy];
 }
 
++ (void)flush {
+    [DDLog flushLog];
+}
+
 + (void)log:(NSString *)message {
     DDLogInfo(@"%@", message);
 }

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -66,6 +66,27 @@ struct DiagnosticLogExporter {
         let bytes: UInt64
     }
 
+    private struct ExportContext: Sendable {
+        let network: String
+        let appVersion: String
+        let currentSession: URL?
+        let appLogFiles: [URL]
+    }
+
+    /// Keep the pre-export ordering explicit and independently testable.
+    /// Diagnostics are best-effort at the call site; flushing still runs when
+    /// there is no active SDK runtime to snapshot.
+    @MainActor
+    static func prepareLogsForExport<Context>(
+        emitDiagnostics: () async -> Void,
+        flush: () -> Void,
+        capture: () -> Context
+    ) async -> Context {
+        await emitDiagnostics()
+        flush()
+        return capture()
+    }
+
     /// Blocking (file I/O + compression) — call off the main actor.
     ///
     /// - Parameters:
@@ -185,24 +206,51 @@ struct DiagnosticLogExporter {
     /// About-screen shake gesture) so the capture rules live in one place.
     @MainActor
     static func exportArchive() async -> Result<URL, Error> {
-        let network = SwiftDashSDKHost.shared.runningNetwork.map { String(describing: $0) } ?? "unknown"
-        let bundle = Bundle.main
-        let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-        let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
-        let appVersion = "\(short) (\(build))"
-        // Authoritative record of which directory this run is writing
-        // to — timestamp sorting alone can be fooled by a clock
-        // rollback or a stale future-dated directory.
-        let currentSession = LoggingPreferences.currentSessionDirectory
-        let appLogFiles = DWLogger.sharedInstance().logFiles()
+        // Pin the runtime identity before the awaited snapshot. Main-actor
+        // reentrancy can otherwise switch networks while diagnostics are
+        // reading SwiftData, producing an archive labelled with a different
+        // network than the wallet that was actually inspected.
+        let manager = SwiftDashSDKHost.shared.manager
+        let walletId = SwiftDashSDKHost.shared.wallet?.walletId
+        let capturedNetwork = SwiftDashSDKHost.shared.runningNetwork
+            .map { String(describing: $0) } ?? "unknown"
+        let context = await prepareLogsForExport(
+            emitDiagnostics: {
+                // The SDK owns all diagnostic error handling. Missing runtime
+                // handles simply mean there is no live state to add; neither
+                // condition is allowed to prevent the existing logs export.
+                guard let manager, let walletId else {
+                    return
+                }
+                await manager.emitCoreWalletDiagnostics(for: walletId)
+            },
+            flush: {
+                // Make the structured Swift log durable before we capture the
+                // session directory and hand file copying to the detached task.
+                SDKLogger.flush()
+            },
+            capture: {
+                let bundle = Bundle.main
+                let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+                let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+                return ExportContext(
+                    network: capturedNetwork,
+                    appVersion: "\(short) (\(build))",
+                    // Authoritative record of which directory this run is
+                    // writing to; timestamp sorting can be fooled by a clock
+                    // rollback or a stale future-dated directory.
+                    currentSession: LoggingPreferences.currentSessionDirectory,
+                    appLogFiles: DWLogger.sharedInstance().logFiles()
+                )
+            })
 
         return await Task.detached(priority: .userInitiated) {
             Result {
                 try export(
-                    network: network,
-                    appVersion: appVersion,
-                    currentSession: currentSession,
-                    appLogFiles: appLogFiles
+                    network: context.network,
+                    appVersion: context.appVersion,
+                    currentSession: context.currentSession,
+                    appLogFiles: context.appLogFiles
                 )
             }
         }.value

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -256,6 +256,27 @@ struct DiagnosticLogExporter {
         }.value
     }
 
+    /// Shared best-effort bridge for the support composer. Support uses the
+    /// exact same archive as the Tools and About screens; a failed export is
+    /// reported locally and never falls back to a different attachment set.
+    @MainActor
+    static func exportArchiveForSupport(
+        using exporter: () async -> Result<URL, Error> = {
+            await DiagnosticLogExporter.exportArchive()
+        },
+        onFailure: (Error) -> Void = { error in
+            DWLogger.log("Support diagnostic archive export failed: \(error.localizedDescription)")
+        }
+    ) async -> URL? {
+        switch await exporter() {
+        case .success(let archiveURL):
+            return archiveURL
+        case .failure(let error):
+            onFailure(error)
+            return nil
+        }
+    }
+
     /// Pure SDK-session selection policy, split out for unit testing.
     ///
     /// The current session (when known) is always first and always

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -35,6 +35,11 @@ enum DiagnosticLogExportError: LocalizedError, Equatable {
     /// The lifecycle admission gate is held by a wallet switch, removal,
     /// creation or wipe; the export must not run under one.
     case anotherOperationInProgress
+    /// An earlier diagnostic collection has not returned. Distinct from
+    /// `anotherOperationInProgress` because no wallet operation is running and
+    /// "try again in a moment" would be a lie: the SDK snapshot is behind the
+    /// persistence queue, and a second one would only queue behind the first.
+    case snapshotStillRunning
     /// The user tapped Cancel on the overlay. Whatever the export produced
     /// afterwards is discarded; callers show nothing for this.
     case cancelled
@@ -44,6 +49,11 @@ enum DiagnosticLogExportError: LocalizedError, Equatable {
         case .anotherOperationInProgress:
             return NSLocalizedString(
                 "Another wallet operation is in progress. Try again in a moment.",
+                comment: "Log export")
+        case .snapshotStillRunning:
+            return NSLocalizedString(
+                "Collecting wallet diagnostics is still running from an earlier attempt. "
+                    + "Restart the app if this does not clear.",
                 comment: "Log export")
         case .cancelled:
             return NSLocalizedString("Log export cancelled.", comment: "Log export")
@@ -349,7 +359,7 @@ struct DiagnosticLogExporter {
         var generation: UInt64 = 0
         if includingWalletSnapshot {
             guard !snapshotInFlight else {
-                return .failure(DiagnosticLogExportError.anotherOperationInProgress)
+                return .failure(DiagnosticLogExportError.snapshotStillRunning)
             }
             WalletLifecycleOverlayPresenter.shared.ensureActive()
             nextExportGeneration += 1
@@ -448,7 +458,19 @@ struct DiagnosticLogExporter {
     /// wallet where the first one already failed to finish.
     ///
     /// This is also what makes a tap after the timeout audible: the export is
-    /// refused, no card is up, so `shouldStaySilent` lets the alert through.
+    /// refused, no card is up, so `shouldStaySilent` lets the alert through —
+    /// as `snapshotStillRunning`, which says what actually happened rather
+    /// than blaming a wallet operation that is not running.
+    ///
+    /// Deliberately NOT bounded the way the lifecycle phase is. The phase's
+    /// timeout exists to let *other* operations proceed, and they can. A
+    /// second snapshot cannot: `emitCoreWalletDiagnostics` runs on the SDK's
+    /// persistence serial queue, so releasing this flag would not start a
+    /// concurrent pass, it would enqueue one behind the wedged first — more
+    /// queued work, no new evidence, and a second admission held. When the
+    /// first pass never returns, the queue it is on is stuck, which is a
+    /// broken app rather than a busy one, and relaunching is the only real
+    /// remedy. The error text says that instead of inviting a retry loop.
     @MainActor private static var snapshotInFlight = false
 
     /// The gate's release timer, held so it can be cancelled when the export
@@ -518,6 +540,11 @@ struct DiagnosticLogExporter {
             return true
         case .anotherOperationInProgress:
             return WalletLifecycleOverlayPresenter.shared.isPresenting
+        case .snapshotStillRunning:
+            // No card can be up for this one — a running snapshot whose card
+            // is still showing would have blocked the tap — so it always
+            // shows, and it is the only explanation available.
+            return false
         default:
             return false
         }

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -27,6 +27,7 @@
 //
 
 import Foundation
+import UIKit
 import SwiftDashSDK
 
 enum DiagnosticLogExportError: LocalizedError {
@@ -200,12 +201,37 @@ struct DiagnosticLogExporter {
         return zipURL
     }
 
+    /// The export holds the SDK's persistence serial queue for its whole
+    /// duration (`PlatformWalletManager.emitCoreWalletDiagnostics(for:)`,
+    /// dashpay/platform#4580): any screen that reads wallet state through the
+    /// SDK meanwhile would stall the main thread behind it. A window-level
+    /// progress HUD — the same blocking HUD the app uses for sends and wallet
+    /// deletion — keeps the user from navigating into one, and from tapping
+    /// export twice, until the archive is ready. Anchored on the key window so
+    /// the view models that call this, which own no view, get it too.
+    @MainActor
+    static func exportArchive() async -> Result<URL, Error> {
+        await withBlockingProgress { await exportArchiveUnguarded() }
+    }
+
+    @MainActor
+    private static func withBlockingProgress<T>(_ body: () async -> T) async -> T {
+        let anchor = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
+        anchor?.dw_showProgressHUD(
+            withMessage: NSLocalizedString("Preparing logs…", comment: "Diagnostic log export in progress"))
+        defer { anchor?.dw_hideProgressHUD() }
+        return await body()
+    }
+
     /// Main-actor entry point: captures the context that must be read on
     /// the main actor, then runs the blocking staging + zip detached.
     /// Shared by every caller that offers a log export (Tools menu row,
     /// About-screen shake gesture) so the capture rules live in one place.
     @MainActor
-    static func exportArchive() async -> Result<URL, Error> {
+    private static func exportArchiveUnguarded() async -> Result<URL, Error> {
         // Pin the runtime identity before the awaited snapshot. Main-actor
         // reentrancy can otherwise switch networks while diagnostics are
         // reading SwiftData, producing an archive labelled with a different

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -29,12 +29,15 @@
 import Foundation
 import SwiftDashSDK
 
-enum DiagnosticLogExportError: LocalizedError {
+enum DiagnosticLogExportError: LocalizedError, Equatable {
     case noLogsFound
     case zipFailed(String)
     /// The lifecycle admission gate is held by a wallet switch, removal,
     /// creation or wipe; the export must not run under one.
     case anotherOperationInProgress
+    /// The user tapped Cancel on the overlay. Whatever the export produced
+    /// afterwards is discarded; callers show nothing for this.
+    case cancelled
 
     var errorDescription: String? {
         switch self {
@@ -42,6 +45,8 @@ enum DiagnosticLogExportError: LocalizedError {
             return NSLocalizedString(
                 "Another wallet operation is in progress. Try again in a moment.",
                 comment: "Log export")
+        case .cancelled:
+            return NSLocalizedString("Log export cancelled.", comment: "Log export")
         case .noLogsFound:
             return NSLocalizedString(
                 "No diagnostic logs were found on this device. Logs are written from the next launch onward.",
@@ -78,20 +83,6 @@ struct DiagnosticLogExporter {
         let appVersion: String
         let currentSession: URL?
         let appLogFiles: [URL]
-    }
-
-    /// Keep the pre-export ordering explicit and independently testable.
-    /// Diagnostics are best-effort at the call site; flushing still runs when
-    /// there is no active SDK runtime to snapshot.
-    @MainActor
-    static func prepareLogsForExport<Context>(
-        emitDiagnostics: () async -> Void,
-        flush: () -> Void,
-        capture: () -> Context
-    ) async -> Context {
-        await emitDiagnostics()
-        flush()
-        return capture()
     }
 
     /// Blocking (file I/O + compression) — call off the main actor.
@@ -207,39 +198,38 @@ struct DiagnosticLogExporter {
         return zipURL
     }
 
-    /// The export holds the SDK's persistence serial queue for its whole
-    /// duration (`PlatformWalletManager.emitCoreWalletDiagnostics(for:)`,
-    /// dashpay/platform#4580): any screen that reads wallet state through the
-    /// SDK meanwhile would stall the main thread behind it. So it runs behind
-    /// the app-wide lifecycle overlay — the same blocking window a wallet
-    /// switch or creation uses, hosted in its own `UIWindow`, so the view
-    /// models that call this need no view of their own — and under the same
-    /// admission gate: it cannot start under a switch in flight, and no switch
-    /// can start under it. A refused gate is reported to the caller, never
-    /// waited out.
+    /// The archive every export screen produces. `includingWalletSnapshot`
+    /// adds the SDK's Core-wallet diagnostics (`emitCoreWalletDiagnostics`,
+    /// dashpay/platform#4580) to the session log first; the support composer
+    /// asks for it, the About shake and the Tools row do not, because that
+    /// snapshot holds the SDK's persistence serial queue while it runs and on
+    /// a large wallet is the whole cost of the export.
+    ///
+    /// Runs behind the app-wide lifecycle overlay — the same blocking window a
+    /// wallet switch or creation uses, in its own `UIWindow` — under the same
+    /// admission gate: it cannot start under a switch in flight, and no
+    /// switch can start under it (a wipe can: the reset route stays open).
+    /// The queue is held only during the snapshot; the card stays up through
+    /// flush, capture and zip because the user is waiting for one result and
+    /// must not start a second. A refused gate is reported to the caller, not
+    /// waited out; Cancel on the card stops the wait and discards the result.
     @MainActor
-    static func exportArchive() async -> Result<URL, Error> {
+    static func exportArchive(includingWalletSnapshot: Bool) async -> Result<URL, Error> {
         WalletLifecycleOverlayPresenter.shared.ensureActive()
         let state = WalletLifecycleTransitionState.shared
         guard state.tryBegin(.exportingDiagnostics) else {
             return .failure(DiagnosticLogExportError.anotherOperationInProgress)
         }
+        let generation = waitGeneration
         defer {
-            // Phase-guarded like `finishWiping`: never clear a phase this
-            // export does not own.
-            if case .exportingDiagnostics = state.phase {
+            // Phase-guarded like `finishWiping`, and generation-guarded: a
+            // cancelled export must not clear the phase of the export the
+            // user may have started since.
+            if waitGeneration == generation, case .exportingDiagnostics = state.phase {
                 state.finish()
             }
         }
-        return await exportArchiveUnguarded()
-    }
 
-    /// Main-actor entry point: captures the context that must be read on
-    /// the main actor, then runs the blocking staging + zip detached.
-    /// Shared by every caller that offers a log export (Tools menu row,
-    /// About-screen shake gesture) so the capture rules live in one place.
-    @MainActor
-    private static func exportArchiveUnguarded() async -> Result<URL, Error> {
         // Pin the runtime identity before the awaited snapshot. Main-actor
         // reentrancy can otherwise switch networks while diagnostics are
         // reading SwiftData, producing an archive labelled with a different
@@ -248,37 +238,31 @@ struct DiagnosticLogExporter {
         let walletId = SwiftDashSDKHost.shared.wallet?.walletId
         let capturedNetwork = SwiftDashSDKHost.shared.runningNetwork
             .map { String(describing: $0) } ?? "unknown"
-        let context = await prepareLogsForExport(
-            emitDiagnostics: {
-                // The SDK owns all diagnostic error handling. Missing runtime
-                // handles simply mean there is no live state to add; neither
-                // condition is allowed to prevent the existing logs export.
-                guard let manager, let walletId else {
-                    return
-                }
-                await manager.emitCoreWalletDiagnostics(for: walletId)
-            },
-            flush: {
-                // Make the structured Swift log durable before we capture the
-                // session directory and hand file copying to the detached task.
-                SDKLogger.flush()
-            },
-            capture: {
-                let bundle = Bundle.main
-                let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-                let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
-                return ExportContext(
-                    network: capturedNetwork,
-                    appVersion: "\(short) (\(build))",
-                    // Authoritative record of which directory this run is
-                    // writing to; timestamp sorting can be fooled by a clock
-                    // rollback or a stale future-dated directory.
-                    currentSession: LoggingPreferences.currentSessionDirectory,
-                    appLogFiles: DWLogger.sharedInstance().logFiles()
-                )
-            })
+        // The SDK owns all diagnostic error handling. Missing runtime handles
+        // simply mean there is no live state to add; neither condition is
+        // allowed to prevent the existing logs export.
+        if includingWalletSnapshot, let manager, let walletId {
+            await manager.emitCoreWalletDiagnostics(for: walletId)
+        }
+        // Both log streams durable before the session directory and the app
+        // log files are captured and handed to the detached copy: the SDK's
+        // structured log, and CocoaLumberjack's queued app log.
+        SDKLogger.flush()
+        DWLogger.flush()
+        let bundle = Bundle.main
+        let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let context = ExportContext(
+            network: capturedNetwork,
+            appVersion: "\(short) (\(build))",
+            // Authoritative record of which directory this run is writing
+            // to; timestamp sorting can be fooled by a clock rollback or a
+            // stale future-dated directory.
+            currentSession: LoggingPreferences.currentSessionDirectory,
+            appLogFiles: DWLogger.sharedInstance().logFiles()
+        )
 
-        return await Task.detached(priority: .userInitiated) {
+        let result = await Task.detached(priority: .userInitiated) {
             Result {
                 try export(
                     network: context.network,
@@ -288,26 +272,26 @@ struct DiagnosticLogExporter {
                 )
             }
         }.value
+        guard waitGeneration == generation else {
+            return .failure(DiagnosticLogExportError.cancelled)
+        }
+        return result
     }
 
-    /// Shared best-effort bridge for the support composer. Support uses the
-    /// exact same archive as the Tools and About screens; a failed export is
-    /// reported locally and never falls back to a different attachment set.
+    /// Bumped by `cancelWaiting`. `exportArchive` captures it before its
+    /// awaits and compares after: a mismatch means the user stopped waiting,
+    /// and the result — which still arrives, since the SDK snapshot cannot be
+    /// interrupted — is discarded rather than presented late.
+    @MainActor private static var waitGeneration = 0
+
+    /// The overlay card's Cancel. Drops the card now; the export in flight
+    /// returns `.cancelled` when it completes.
     @MainActor
-    static func exportArchiveForSupport(
-        using exporter: () async -> Result<URL, Error> = {
-            await DiagnosticLogExporter.exportArchive()
-        },
-        onFailure: (Error) -> Void = { error in
-            DWLogger.log("Support diagnostic archive export failed: \(error.localizedDescription)")
-        }
-    ) async -> URL? {
-        switch await exporter() {
-        case .success(let archiveURL):
-            return archiveURL
-        case .failure(let error):
-            onFailure(error)
-            return nil
+    static func cancelWaiting() {
+        waitGeneration += 1
+        let state = WalletLifecycleTransitionState.shared
+        if case .exportingDiagnostics = state.phase {
+            state.finish()
         }
     }
 

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -166,7 +166,7 @@ struct DiagnosticLogExporter {
                 )
                 copiedCount += 1
             } catch {
-                skipped.append("sdk-session \(session.url.lastPathComponent): \(error.localizedDescription)")
+                skipped.append("sdk-session \(session.url.lastPathComponent): \(failureDetail(error))")
             }
         }
         if !selectedAppLogs.isEmpty {
@@ -181,16 +181,19 @@ struct DiagnosticLogExporter {
                         )
                         copiedCount += 1
                     } catch {
-                        skipped.append("app-log \(file.lastPathComponent): \(error.localizedDescription)")
+                        skipped.append("app-log \(file.lastPathComponent): \(failureDetail(error))")
                     }
                 }
             } catch {
-                skipped.append("app-logs directory: \(error.localizedDescription)")
+                skipped.append("app-logs directory: \(failureDetail(error))")
             }
         }
         guard copiedCount > 0 else {
-            throw DiagnosticLogExportError.zipFailed(
-                "nothing could be copied (\(skipped.joined(separator: "; ")))")
+            // This reason reaches a user-visible alert and there is one entry
+            // per failed item, so it is bounded rather than joined whole.
+            let head = skipped.prefix(3).joined(separator: "; ")
+            let rest = skipped.count > 3 ? "; +\(skipped.count - 3) more" : ""
+            throw DiagnosticLogExportError.zipFailed("nothing could be copied (\(head)\(rest))")
         }
 
         var summary = summaryText(
@@ -212,12 +215,46 @@ struct DiagnosticLogExporter {
             encoding: .utf8
         )
 
-        let zipURL = fm.temporaryDirectory.appendingPathComponent("\(archiveName).zip")
-        if fm.fileExists(atPath: zipURL.path) {
-            try? fm.removeItem(at: zipURL)
-        }
+        // Its own directory per export. `archiveName` derives from the SDK
+        // session stamp, which is fixed for the process lifetime, so a single
+        // path would be rewritten by every export in a launch — including
+        // under a live consumer, since the over-25 MB route hands this URL to
+        // the share sheet, which reads it lazily and by reference. The
+        // directory is also the unit `discardArchive` deletes.
+        let archiveDirectory = fm.temporaryDirectory
+            .appendingPathComponent("\(archiveDirectoryPrefix)\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
+        let zipURL = archiveDirectory.appendingPathComponent("\(archiveName).zip")
         try zipDirectory(at: staging, to: zipURL)
         return zipURL
+    }
+
+    /// Names the directory `export` writes its zip into.
+    private static let archiveDirectoryPrefix = "LogArchive-"
+
+    /// What a failed copy may say in a file that is mailed to support.
+    /// Cocoa's `localizedDescription` embeds the full sandbox path of the item
+    /// it failed on, and the SDK redacts store paths out of the very telemetry
+    /// this archive carries (`core_store_open_result` is emitted
+    /// `redacting: [storeURL.path]`); the host holds the same line. Domain and
+    /// code are what a triager acts on anyway.
+    private static func failureDetail(_ error: Error) -> String {
+        let nsError = error as NSError
+        return "\(nsError.domain) \(nsError.code)"
+    }
+
+    /// Delete an archive nobody will receive, with the per-export directory
+    /// holding it — up to the mail cap per undelivered export, on a device
+    /// whose disk pressure is one of the things the export exists to diagnose.
+    private static func discardArchive(at url: URL) {
+        let fm = FileManager.default
+        let directory = url.deletingLastPathComponent()
+        guard directory.lastPathComponent.hasPrefix(archiveDirectoryPrefix) else {
+            // Not one of ours: never take a directory down with the file.
+            try? fm.removeItem(at: url)
+            return
+        }
+        try? fm.removeItem(at: directory)
     }
 
     /// The archive every export screen produces. `includingWalletSnapshot`
@@ -307,6 +344,7 @@ struct DiagnosticLogExporter {
         guard case .exportingDiagnostics(dismissed: false, generation: let owner) = state.phase,
               owner == generation
         else {
+            if case .success(let archive) = result { discardArchive(at: archive) }
             return .failure(DiagnosticLogExportError.cancelled)
         }
         return result
@@ -316,15 +354,65 @@ struct DiagnosticLogExporter {
     /// be scoped to the export that took the phase.
     @MainActor private static var nextExportGeneration: UInt64 = 0
 
+    /// How long a dismissed export may keep the admission gate after its card
+    /// is gone. Past this the gate opens even though the export is still
+    /// running, because the gate is not what makes that safe: `shutdown()` —
+    /// which every wallet switch reaches through the runtime's stop/rebind —
+    /// cancels the diagnostics pass and drains its native op before taking the
+    /// handle (platform#4580), so a switch started here waits on that drain
+    /// instead of racing it. The gate exists to stop the user queueing a
+    /// second operation behind a visible one, and after Cancel there is
+    /// nothing visible left: a refusal would have no owner on screen to
+    /// explain it, and an export wedged behind the persistence queue would
+    /// otherwise hold every other operation out until the app is relaunched.
+    static let dismissedExportGateTimeout: Duration = .seconds(30)
+
     /// The overlay card's Cancel. Drops the card now; the export in flight
     /// keeps its admission and, seeing its phase dismissed when it returns,
-    /// discards its result as `.cancelled`. A no-op unless a card is showing.
+    /// discards its result as `.cancelled`. That hold is bounded by
+    /// `dismissedExportGateTimeout` — a stuck export degrades to a failed
+    /// export, not to a gate nothing can open. A no-op unless a card is
+    /// showing.
     @MainActor
     static func cancelWaiting() {
         let state = WalletLifecycleTransitionState.shared
         guard case .exportingDiagnostics(dismissed: false, generation: let owner) = state.phase
         else { return }
         state.advance(to: .exportingDiagnostics(dismissed: true, generation: owner))
+        Task { @MainActor in
+            try? await Task.sleep(for: dismissedExportGateTimeout)
+            // Only if this export still owns a dismissed phase: it may have
+            // returned and released, or been superseded by a wipe and a
+            // successor export, in which case the gate is not ours to open.
+            guard case .exportingDiagnostics(dismissed: true, generation: let stillOwner) = state.phase,
+                  stillOwner == owner
+            else { return }
+            DWLogger.log(
+                "🚦 LIFECYCLE releasing the gate of dismissed export #\(owner) after \(dismissedExportGateTimeout); the export has not returned")
+            state.finish()
+        }
+    }
+
+    /// Failures the asking screen must stay silent about.
+    ///
+    /// `.cancelled` is the user's own Cancel. `.anotherOperationInProgress` is
+    /// silent only while the operation that refused it is on screen: the
+    /// overlay window sits at `.alert + 1`, above the level
+    /// `UIAlertController` presents at, so an alert raised now is drawn under
+    /// the card — invisible while it is true, and stale by the time the card
+    /// drops. The card is the explanation. With no card up (a dismissed export
+    /// still holding the gate) the alert is the only explanation there is, and
+    /// it shows.
+    @MainActor
+    static func shouldStaySilent(about error: Error) -> Bool {
+        switch error as? DiagnosticLogExportError {
+        case .cancelled:
+            return true
+        case .anotherOperationInProgress:
+            return WalletLifecycleOverlayPresenter.shared.isPresenting
+        default:
+            return false
+        }
     }
 
     /// Pure SDK-session selection policy, split out for unit testing.

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -221,6 +221,13 @@ struct DiagnosticLogExporter {
         // under a live consumer, since the over-25 MB route hands this URL to
         // the share sheet, which reads it lazily and by reference. The
         // directory is also the unit `discardArchive` deletes.
+        // Nothing can delete an archive after delivery: the share sheet takes
+        // the URL by reference and may read it long after this returns. So the
+        // previous ones are swept here instead — the fixed path this replaced
+        // was self-cleaning by being overwritten, and without a sweep three
+        // support exports leave three archives of up to the mail cap behind,
+        // on a device whose free space is one of the things they diagnose.
+        pruneOldArchiveDirectories()
         let archiveDirectory = fm.temporaryDirectory
             .appendingPathComponent("\(archiveDirectoryPrefix)\(UUID().uuidString)", isDirectory: true)
         try fm.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
@@ -231,6 +238,22 @@ struct DiagnosticLogExporter {
 
     /// Names the directory `export` writes its zip into.
     private static let archiveDirectoryPrefix = "LogArchive-"
+
+    /// Remove the archive directories previous exports left in `tmp`. Best
+    /// effort per directory: one that is still open elsewhere must not stop
+    /// the rest being swept, and the OS reclaims `tmp` eventually anyway.
+    private static func pruneOldArchiveDirectories() {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: fm.temporaryDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return }
+        for entry in entries
+        where entry.lastPathComponent.hasPrefix(archiveDirectoryPrefix) {
+            try? fm.removeItem(at: entry)
+        }
+    }
 
     /// What a failed copy may say in a file that is mailed to support.
     /// Cocoa's `localizedDescription` embeds the full sandbox path of the item
@@ -264,10 +287,16 @@ struct DiagnosticLogExporter {
     /// snapshot holds the SDK's persistence serial queue while it runs and on
     /// a large wallet is the whole cost of the export.
     ///
-    /// Runs behind the app-wide lifecycle overlay — the same blocking window a
-    /// wallet switch or creation uses, in its own `UIWindow` — under the same
-    /// admission gate: it cannot start under a switch in flight, and no
-    /// switch can start under it (a wipe can: the reset route stays open).
+    /// The snapshot — and ONLY the snapshot — runs behind the app-wide
+    /// lifecycle overlay, the same blocking window a wallet switch or creation
+    /// uses, in its own `UIWindow`, under the same admission gate: it cannot
+    /// start under a switch in flight, and no switch can start under it (a
+    /// wipe can: the reset route stays open). `includingWalletSnapshot: false`
+    /// takes neither. Those callers copy log files and zip them; they never
+    /// touch the SDK's persistence queue, which is the gate's whole
+    /// justification, and freezing the app behind a full-screen scrim for a
+    /// directory copy — or refusing it because a switch is running, where the
+    /// pre-PR export simply ran — would be a cost with nothing bought.
     /// The queue is held only during the snapshot; the card stays up through
     /// flush, capture and zip because the user is waiting for one result and
     /// must not start a second. A refused gate is reported to the caller, not
@@ -281,16 +310,20 @@ struct DiagnosticLogExporter {
     /// of a wallet the wipe removed.
     @MainActor
     static func exportArchive(includingWalletSnapshot: Bool) async -> Result<URL, Error> {
-        WalletLifecycleOverlayPresenter.shared.ensureActive()
         let state = WalletLifecycleTransitionState.shared
-        nextExportGeneration += 1
-        let generation = nextExportGeneration
-        guard state.tryBegin(.exportingDiagnostics(dismissed: false, generation: generation)) else {
-            return .failure(DiagnosticLogExportError.anotherOperationInProgress)
+        var generation: UInt64 = 0
+        if includingWalletSnapshot {
+            WalletLifecycleOverlayPresenter.shared.ensureActive()
+            nextExportGeneration += 1
+            generation = nextExportGeneration
+            guard state.tryBegin(.exportingDiagnostics(dismissed: false, generation: generation)) else {
+                return .failure(DiagnosticLogExportError.anotherOperationInProgress)
+            }
         }
         defer {
             // Only this export's phase — never a `.wiping` admitted through
-            // it, and never a successor's export phase.
+            // it, and never a successor's export phase. `generation` is 0 for
+            // an ungated export, which no phase can carry.
             if case .exportingDiagnostics(_, let owner) = state.phase, owner == generation {
                 state.finish()
             }
@@ -340,7 +373,9 @@ struct DiagnosticLogExporter {
 
         // Deliver only if this export still owns an undismissed phase.
         // Cancel dismissed it; a wipe admitted through it moved the phase
-        // on, and the wallet the archive describes may be gone by now.
+        // on, and the wallet the archive describes may be gone by now. An
+        // ungated export took no phase and has nothing to lose it to.
+        guard includingWalletSnapshot else { return result }
         guard case .exportingDiagnostics(dismissed: false, generation: let owner) = state.phase,
               owner == generation
         else {
@@ -391,6 +426,20 @@ struct DiagnosticLogExporter {
                 "🚦 LIFECYCLE releasing the gate of dismissed export #\(owner) after \(dismissedExportGateTimeout); the export has not returned")
             state.finish()
         }
+    }
+
+    /// True while an export the user has abandoned is still running. Its gate
+    /// is still held, so a fresh attempt will be refused — but it has to be
+    /// allowed to *make* that attempt: the card is gone, so the refusal alert
+    /// is the only feedback left, and a screen whose own re-entry guard is
+    /// still closed swallows the tap and shows nothing at all.
+    @MainActor
+    static var waitWasCancelled: Bool {
+        if case .exportingDiagnostics(dismissed: true, generation: _) =
+            WalletLifecycleTransitionState.shared.phase {
+            return true
+        }
+        return false
     }
 
     /// Failures the asking screen must stay silent about.

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -212,20 +212,24 @@ struct DiagnosticLogExporter {
     /// The queue is held only during the snapshot; the card stays up through
     /// flush, capture and zip because the user is waiting for one result and
     /// must not start a second. A refused gate is reported to the caller, not
-    /// waited out; Cancel on the card stops the wait and discards the result.
+    /// waited out. Cancel on the card hides the card and discards the result;
+    /// the admission is held until this returns, because the snapshot may
+    /// still hold the persistence queue and the pinned manager — a switch
+    /// must not rebind under it. So no second export can overlap this one,
+    /// and the `defer` below needs only the phase guard.
     @MainActor
     static func exportArchive(includingWalletSnapshot: Bool) async -> Result<URL, Error> {
         WalletLifecycleOverlayPresenter.shared.ensureActive()
         let state = WalletLifecycleTransitionState.shared
-        guard state.tryBegin(.exportingDiagnostics) else {
+        guard state.tryBegin(.exportingDiagnostics(dismissed: false)) else {
             return .failure(DiagnosticLogExportError.anotherOperationInProgress)
         }
         let generation = waitGeneration
         defer {
-            // Phase-guarded like `finishWiping`, and generation-guarded: a
-            // cancelled export must not clear the phase of the export the
-            // user may have started since.
-            if waitGeneration == generation, case .exportingDiagnostics = state.phase {
+            // Phase-guarded like `finishWiping`: release the export phase,
+            // dismissed or not, and never a `.wiping` that was admitted
+            // through it.
+            if case .exportingDiagnostics = state.phase {
                 state.finish()
             }
         }
@@ -284,15 +288,15 @@ struct DiagnosticLogExporter {
     /// interrupted — is discarded rather than presented late.
     @MainActor private static var waitGeneration = 0
 
-    /// The overlay card's Cancel. Drops the card now; the export in flight
-    /// returns `.cancelled` when it completes.
+    /// The overlay card's Cancel. Drops the card now and marks the result
+    /// for discard; the export in flight keeps its admission and returns
+    /// `.cancelled` when it completes. A no-op unless a card is showing.
     @MainActor
     static func cancelWaiting() {
-        waitGeneration += 1
         let state = WalletLifecycleTransitionState.shared
-        if case .exportingDiagnostics = state.phase {
-            state.finish()
-        }
+        guard case .exportingDiagnostics(dismissed: false) = state.phase else { return }
+        waitGeneration += 1
+        state.advance(to: .exportingDiagnostics(dismissed: true))
     }
 
     /// Pure SDK-session selection policy, split out for unit testing.

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -538,13 +538,19 @@ struct DiagnosticLogExporter {
         switch error as? DiagnosticLogExportError {
         case .cancelled:
             return true
-        case .anotherOperationInProgress:
+        case .anotherOperationInProgress, .snapshotStillRunning:
+            // Same rule for both, and for the same reason: an alert raised
+            // while the overlay window is up at `.alert + 1` is drawn beneath
+            // it. Invisible is not the worst of it — an invisible
+            // presentation is still a presentation, so UIKit later drops the
+            // successful export's mail composer as "already presenting" and
+            // the good archive is thrown away with nothing on screen.
+            //
+            // A second Contact Support tap really can race the first export's
+            // card, so this is asked rather than assumed. With no card up (the
+            // post-cancel and post-timeout cases) the alert shows, which is
+            // the whole point of these two errors having distinct text.
             return WalletLifecycleOverlayPresenter.shared.isPresenting
-        case .snapshotStillRunning:
-            // No card can be up for this one — a running snapshot whose card
-            // is still showing would have blocked the tap — so it always
-            // shows, and it is the only explanation available.
-            return false
         default:
             return false
         }

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -78,13 +78,6 @@ struct DiagnosticLogExporter {
         let bytes: UInt64
     }
 
-    private struct ExportContext: Sendable {
-        let network: String
-        let appVersion: String
-        let currentSession: URL?
-        let appLogFiles: [URL]
-    }
-
     /// Blocking (file I/O + compression) — call off the main actor.
     ///
     /// - Parameters:
@@ -158,24 +151,49 @@ struct DiagnosticLogExporter {
         defer { try? fm.removeItem(at: scratch) }
 
         try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+        // Best effort per item. The SDK sessions and the app logs are
+        // independent evidence: a session directory pruned mid-copy, a name
+        // collision or a full disk must not take the other group down with
+        // it, and one bad file must not cost the archive. What could not be
+        // copied is named in `summary.txt`; only nothing at all is a failure.
+        var skipped: [String] = []
+        var copiedCount = 0
         for session in selectedSessions {
-            try fm.copyItem(
-                at: session.url,
-                to: staging.appendingPathComponent(session.url.lastPathComponent, isDirectory: true)
-            )
+            do {
+                try fm.copyItem(
+                    at: session.url,
+                    to: staging.appendingPathComponent(session.url.lastPathComponent, isDirectory: true)
+                )
+                copiedCount += 1
+            } catch {
+                skipped.append("sdk-session \(session.url.lastPathComponent): \(error.localizedDescription)")
+            }
         }
         if !selectedAppLogs.isEmpty {
             let appLogsDir = staging.appendingPathComponent("app-logs", isDirectory: true)
-            try fm.createDirectory(at: appLogsDir, withIntermediateDirectories: true)
-            for file in selectedAppLogs {
-                try fm.copyItem(
-                    at: file,
-                    to: appLogsDir.appendingPathComponent(file.lastPathComponent)
-                )
+            do {
+                try fm.createDirectory(at: appLogsDir, withIntermediateDirectories: true)
+                for file in selectedAppLogs {
+                    do {
+                        try fm.copyItem(
+                            at: file,
+                            to: appLogsDir.appendingPathComponent(file.lastPathComponent)
+                        )
+                        copiedCount += 1
+                    } catch {
+                        skipped.append("app-log \(file.lastPathComponent): \(error.localizedDescription)")
+                    }
+                }
+            } catch {
+                skipped.append("app-logs directory: \(error.localizedDescription)")
             }
         }
+        guard copiedCount > 0 else {
+            throw DiagnosticLogExportError.zipFailed(
+                "nothing could be copied (\(skipped.joined(separator: "; ")))")
+        }
 
-        let summary = summaryText(
+        var summary = summaryText(
             network: network,
             appVersion: appVersion,
             selectedSessions: selectedSessions,
@@ -184,6 +202,10 @@ struct DiagnosticLogExporter {
             appLogCount: selectedAppLogs.count,
             totalAppLogsOnDevice: appLogFiles.count
         )
+        if !skipped.isEmpty {
+            summary += "\n\nSkipped (could not be copied):\n"
+                + skipped.map { "  - \($0)" }.joined(separator: "\n") + "\n"
+        }
         try summary.write(
             to: staging.appendingPathComponent("summary.txt"),
             atomically: true,
@@ -212,24 +234,27 @@ struct DiagnosticLogExporter {
     /// The queue is held only during the snapshot; the card stays up through
     /// flush, capture and zip because the user is waiting for one result and
     /// must not start a second. A refused gate is reported to the caller, not
-    /// waited out. Cancel on the card hides the card and discards the result;
-    /// the admission is held until this returns, because the snapshot may
-    /// still hold the persistence queue and the pinned manager — a switch
-    /// must not rebind under it. So no second export can overlap this one,
-    /// and the `defer` below needs only the phase guard.
+    /// waited out. Cancel on the card hides the card; the admission is held
+    /// until this returns, because the snapshot may still hold the
+    /// persistence queue and the pinned manager — a switch must not rebind
+    /// under it. The phase carries this export's generation: release and
+    /// delivery happen only if the phase is still this export's own — a
+    /// cancelled export superseded by a wipe and a newer export must neither
+    /// open that export's gate when it finally returns nor deliver an archive
+    /// of a wallet the wipe removed.
     @MainActor
     static func exportArchive(includingWalletSnapshot: Bool) async -> Result<URL, Error> {
         WalletLifecycleOverlayPresenter.shared.ensureActive()
         let state = WalletLifecycleTransitionState.shared
-        guard state.tryBegin(.exportingDiagnostics(dismissed: false)) else {
+        nextExportGeneration += 1
+        let generation = nextExportGeneration
+        guard state.tryBegin(.exportingDiagnostics(dismissed: false, generation: generation)) else {
             return .failure(DiagnosticLogExportError.anotherOperationInProgress)
         }
-        let generation = waitGeneration
         defer {
-            // Phase-guarded like `finishWiping`: release the export phase,
-            // dismissed or not, and never a `.wiping` that was admitted
-            // through it.
-            if case .exportingDiagnostics = state.phase {
+            // Only this export's phase — never a `.wiping` admitted through
+            // it, and never a successor's export phase.
+            if case .exportingDiagnostics(_, let owner) = state.phase, owner == generation {
                 state.finish()
             }
         }
@@ -248,55 +273,58 @@ struct DiagnosticLogExporter {
         if includingWalletSnapshot, let manager, let walletId {
             await manager.emitCoreWalletDiagnostics(for: walletId)
         }
-        // Both log streams durable before the session directory and the app
-        // log files are captured and handed to the detached copy: the SDK's
-        // structured log, and CocoaLumberjack's queued app log.
-        SDKLogger.flush()
-        DWLogger.flush()
         let bundle = Bundle.main
         let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
-        let context = ExportContext(
-            network: capturedNetwork,
-            appVersion: "\(short) (\(build))",
-            // Authoritative record of which directory this run is writing
-            // to; timestamp sorting can be fooled by a clock rollback or a
-            // stale future-dated directory.
-            currentSession: LoggingPreferences.currentSessionDirectory,
-            appLogFiles: DWLogger.sharedInstance().logFiles()
-        )
+        let appVersion = "\(short) (\(build))"
+        // Authoritative record of which directory this run is writing to;
+        // timestamp sorting can be fooled by a clock rollback or a stale
+        // future-dated directory. A property read, not I/O.
+        let currentSession = LoggingPreferences.currentSessionDirectory
 
-        let result = await Task.detached(priority: .userInitiated) {
-            Result {
+        let result = await Task.detached(priority: .userInitiated) { () -> Result<URL, Error> in
+            // Both flushes block their calling thread on the loggers' queues
+            // — deepest right after the snapshot wrote its audit — and the
+            // app-log listing enumerates a directory. None of it belongs on
+            // the main actor; ordering is kept, since this body runs them
+            // before the copy.
+            SDKLogger.flush()
+            DWLogger.flush()
+            let appLogFiles = DWLogger.sharedInstance().logFiles()
+            return Result {
                 try export(
-                    network: context.network,
-                    appVersion: context.appVersion,
-                    currentSession: context.currentSession,
-                    appLogFiles: context.appLogFiles
+                    network: capturedNetwork,
+                    appVersion: appVersion,
+                    currentSession: currentSession,
+                    appLogFiles: appLogFiles
                 )
             }
         }.value
-        guard waitGeneration == generation else {
+
+        // Deliver only if this export still owns an undismissed phase.
+        // Cancel dismissed it; a wipe admitted through it moved the phase
+        // on, and the wallet the archive describes may be gone by now.
+        guard case .exportingDiagnostics(dismissed: false, generation: let owner) = state.phase,
+              owner == generation
+        else {
             return .failure(DiagnosticLogExportError.cancelled)
         }
         return result
     }
 
-    /// Bumped by `cancelWaiting`. `exportArchive` captures it before its
-    /// awaits and compares after: a mismatch means the user stopped waiting,
-    /// and the result — which still arrives, since the SDK snapshot cannot be
-    /// interrupted — is discarded rather than presented late.
-    @MainActor private static var waitGeneration = 0
+    /// Names each export. The phase carries it, so release and delivery can
+    /// be scoped to the export that took the phase.
+    @MainActor private static var nextExportGeneration: UInt64 = 0
 
-    /// The overlay card's Cancel. Drops the card now and marks the result
-    /// for discard; the export in flight keeps its admission and returns
-    /// `.cancelled` when it completes. A no-op unless a card is showing.
+    /// The overlay card's Cancel. Drops the card now; the export in flight
+    /// keeps its admission and, seeing its phase dismissed when it returns,
+    /// discards its result as `.cancelled`. A no-op unless a card is showing.
     @MainActor
     static func cancelWaiting() {
         let state = WalletLifecycleTransitionState.shared
-        guard case .exportingDiagnostics(dismissed: false) = state.phase else { return }
-        waitGeneration += 1
-        state.advance(to: .exportingDiagnostics(dismissed: true))
+        guard case .exportingDiagnostics(dismissed: false, generation: let owner) = state.phase
+        else { return }
+        state.advance(to: .exportingDiagnostics(dismissed: true, generation: owner))
     }
 
     /// Pure SDK-session selection policy, split out for unit testing.

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -227,9 +227,17 @@ struct DiagnosticLogExporter {
         // was self-cleaning by being overwritten, and without a sweep three
         // support exports leave three archives of up to the mail cap behind,
         // on a device whose free space is one of the things they diagnose.
-        pruneOldArchiveDirectories()
         let archiveDirectory = fm.temporaryDirectory
             .appendingPathComponent("\(archiveDirectoryPrefix)\(UUID().uuidString)", isDirectory: true)
+        // Claimed BEFORE the sweep and before the directory exists, so a
+        // concurrent export's sweep can already see it. Exports really can
+        // overlap: an ungated one (About, Tools) takes no lifecycle phase and
+        // blocks nothing on screen, so Tools → Export and Contact Support can
+        // be in flight together.
+        let archiveDirectoryName = archiveDirectory.lastPathComponent
+        claimArchiveDirectory(archiveDirectoryName)
+        defer { releaseArchiveDirectory(archiveDirectoryName) }
+        pruneOldArchiveDirectories()
         try fm.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
         let zipURL = archiveDirectory.appendingPathComponent("\(archiveName).zip")
         try zipDirectory(at: staging, to: zipURL)
@@ -239,18 +247,45 @@ struct DiagnosticLogExporter {
     /// Names the directory `export` writes its zip into.
     private static let archiveDirectoryPrefix = "LogArchive-"
 
-    /// Remove the archive directories previous exports left in `tmp`. Best
-    /// effort per directory: one that is still open elsewhere must not stop
-    /// the rest being swept, and the OS reclaims `tmp` eventually anyway.
+    /// Archive directories an export is currently writing into. `export` runs
+    /// off the main actor on a detached task and two can overlap, so this is
+    /// lock-guarded rather than actor-isolated.
+    private static let inFlightArchivesLock = NSLock()
+    private static var inFlightArchiveNames: Set<String> = []
+
+    private static func claimArchiveDirectory(_ name: String) {
+        inFlightArchivesLock.withLock { _ = inFlightArchiveNames.insert(name) }
+    }
+
+    private static func releaseArchiveDirectory(_ name: String) {
+        inFlightArchivesLock.withLock { _ = inFlightArchiveNames.remove(name) }
+    }
+
+    /// Remove the archive directories previous exports left in `tmp`, skipping
+    /// any an export is still writing into — deleting one mid-`zipDirectory`
+    /// would fail that export, or leave its share sheet holding a URL to a
+    /// file that is gone.
+    ///
+    /// A *delivered* archive is fair game, which is the deliberate part: it is
+    /// the only moment anything can collect them, since the share sheet takes
+    /// the URL by reference and may read it after this call returns. That
+    /// sheet is modal, so it has been dismissed before another export can
+    /// start — the cost of being wrong is one unreadable attachment, against a
+    /// leak of up to the mail cap per export otherwise.
+    ///
+    /// Best effort per directory: one that cannot be removed must not stop the
+    /// rest being swept.
     private static func pruneOldArchiveDirectories() {
         let fm = FileManager.default
+        let live = inFlightArchivesLock.withLock { inFlightArchiveNames }
         guard let entries = try? fm.contentsOfDirectory(
             at: fm.temporaryDirectory,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]
         ) else { return }
         for entry in entries
-        where entry.lastPathComponent.hasPrefix(archiveDirectoryPrefix) {
+        where entry.lastPathComponent.hasPrefix(archiveDirectoryPrefix)
+            && !live.contains(entry.lastPathComponent) {
             try? fm.removeItem(at: entry)
         }
     }
@@ -313,14 +348,24 @@ struct DiagnosticLogExporter {
         let state = WalletLifecycleTransitionState.shared
         var generation: UInt64 = 0
         if includingWalletSnapshot {
+            guard !snapshotInFlight else {
+                return .failure(DiagnosticLogExportError.anotherOperationInProgress)
+            }
             WalletLifecycleOverlayPresenter.shared.ensureActive()
             nextExportGeneration += 1
             generation = nextExportGeneration
             guard state.tryBegin(.exportingDiagnostics(dismissed: false, generation: generation)) else {
                 return .failure(DiagnosticLogExportError.anotherOperationInProgress)
             }
+            snapshotInFlight = true
         }
         defer {
+            if includingWalletSnapshot {
+                snapshotInFlight = false
+                // The gate's timer has nothing left to release.
+                dismissedGateTimer?.cancel()
+                dismissedGateTimer = nil
+            }
             // Only this export's phase — never a `.wiping` admitted through
             // it, and never a successor's export phase. `generation` is 0 for
             // an ungated export, which no phase can carry.
@@ -389,6 +434,28 @@ struct DiagnosticLogExporter {
     /// be scoped to the export that took the phase.
     @MainActor private static var nextExportGeneration: UInt64 = 0
 
+    /// True for the whole life of a snapshot export — through Cancel, and
+    /// through the gate's timeout.
+    ///
+    /// The lifecycle phase deliberately cannot carry this. That phase is
+    /// released at `dismissedExportGateTimeout` so the rest of the app can move
+    /// again, and a wallet switch started there is safe because it reaches
+    /// `manager.shutdown()`, which cancels the diagnostics pass and drains it
+    /// before taking the handle. A second SNAPSHOT is the one thing that is
+    /// not: it never goes through `shutdown()`, so it would run
+    /// `emitCoreWalletDiagnostics` against the same pinned manager and contend
+    /// with the first on the SDK's persistence serial queue — on the large
+    /// wallet where the first one already failed to finish.
+    ///
+    /// This is also what makes a tap after the timeout audible: the export is
+    /// refused, no card is up, so `shouldStaySilent` lets the alert through.
+    @MainActor private static var snapshotInFlight = false
+
+    /// The gate's release timer, held so it can be cancelled when the export
+    /// returns on its own. Unheld, it lingered its full delay poking the
+    /// shared phase after everything it guarded was over.
+    @MainActor private static var dismissedGateTimer: Task<Void, Never>?
+
     /// How long a dismissed export may keep the admission gate after its card
     /// is gone. Past this the gate opens even though the export is still
     /// running, because the gate is not what makes that safe: `shutdown()` —
@@ -400,6 +467,11 @@ struct DiagnosticLogExporter {
     /// nothing visible left: a refusal would have no owner on screen to
     /// explain it, and an export wedged behind the persistence queue would
     /// otherwise hold every other operation out until the app is relaunched.
+    ///
+    /// What the release does NOT permit is a second snapshot — the one
+    /// operation that reaches the SDK without passing through `shutdown()`.
+    /// `snapshotInFlight` keeps that refused for as long as the first pass
+    /// runs, whatever the phase says.
     static let dismissedExportGateTimeout: Duration = .seconds(30)
 
     /// The overlay card's Cancel. Drops the card now; the export in flight
@@ -414,7 +486,8 @@ struct DiagnosticLogExporter {
         guard case .exportingDiagnostics(dismissed: false, generation: let owner) = state.phase
         else { return }
         state.advance(to: .exportingDiagnostics(dismissed: true, generation: owner))
-        Task { @MainActor in
+        dismissedGateTimer?.cancel()
+        dismissedGateTimer = Task { @MainActor in
             try? await Task.sleep(for: dismissedExportGateTimeout)
             // Only if this export still owns a dismissed phase: it may have
             // returned and released, or been superseded by a wipe and a
@@ -426,20 +499,6 @@ struct DiagnosticLogExporter {
                 "🚦 LIFECYCLE releasing the gate of dismissed export #\(owner) after \(dismissedExportGateTimeout); the export has not returned")
             state.finish()
         }
-    }
-
-    /// True while an export the user has abandoned is still running. Its gate
-    /// is still held, so a fresh attempt will be refused — but it has to be
-    /// allowed to *make* that attempt: the card is gone, so the refusal alert
-    /// is the only feedback left, and a screen whose own re-entry guard is
-    /// still closed swallows the tap and shows nothing at all.
-    @MainActor
-    static var waitWasCancelled: Bool {
-        if case .exportingDiagnostics(dismissed: true, generation: _) =
-            WalletLifecycleTransitionState.shared.phase {
-            return true
-        }
-        return false
     }
 
     /// Failures the asking screen must stay silent about.

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -27,15 +27,21 @@
 //
 
 import Foundation
-import UIKit
 import SwiftDashSDK
 
 enum DiagnosticLogExportError: LocalizedError {
     case noLogsFound
     case zipFailed(String)
+    /// The lifecycle admission gate is held by a wallet switch, removal,
+    /// creation or wipe; the export must not run under one.
+    case anotherOperationInProgress
 
     var errorDescription: String? {
         switch self {
+        case .anotherOperationInProgress:
+            return NSLocalizedString(
+                "Another wallet operation is in progress. Try again in a moment.",
+                comment: "Log export")
         case .noLogsFound:
             return NSLocalizedString(
                 "No diagnostic logs were found on this device. Logs are written from the next launch onward.",
@@ -204,26 +210,28 @@ struct DiagnosticLogExporter {
     /// The export holds the SDK's persistence serial queue for its whole
     /// duration (`PlatformWalletManager.emitCoreWalletDiagnostics(for:)`,
     /// dashpay/platform#4580): any screen that reads wallet state through the
-    /// SDK meanwhile would stall the main thread behind it. A window-level
-    /// progress HUD — the same blocking HUD the app uses for sends and wallet
-    /// deletion — keeps the user from navigating into one, and from tapping
-    /// export twice, until the archive is ready. Anchored on the key window so
-    /// the view models that call this, which own no view, get it too.
+    /// SDK meanwhile would stall the main thread behind it. So it runs behind
+    /// the app-wide lifecycle overlay — the same blocking window a wallet
+    /// switch or creation uses, hosted in its own `UIWindow`, so the view
+    /// models that call this need no view of their own — and under the same
+    /// admission gate: it cannot start under a switch in flight, and no switch
+    /// can start under it. A refused gate is reported to the caller, never
+    /// waited out.
     @MainActor
     static func exportArchive() async -> Result<URL, Error> {
-        await withBlockingProgress { await exportArchiveUnguarded() }
-    }
-
-    @MainActor
-    private static func withBlockingProgress<T>(_ body: () async -> T) async -> T {
-        let anchor = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap(\.windows)
-            .first(where: \.isKeyWindow)
-        anchor?.dw_showProgressHUD(
-            withMessage: NSLocalizedString("Preparing logs…", comment: "Diagnostic log export in progress"))
-        defer { anchor?.dw_hideProgressHUD() }
-        return await body()
+        WalletLifecycleOverlayPresenter.shared.ensureActive()
+        let state = WalletLifecycleTransitionState.shared
+        guard state.tryBegin(.exportingDiagnostics) else {
+            return .failure(DiagnosticLogExportError.anotherOperationInProgress)
+        }
+        defer {
+            // Phase-guarded like `finishWiping`: never clear a phase this
+            // export does not own.
+            if case .exportingDiagnostics = state.phase {
+                state.finish()
+            }
+        }
+        return await exportArchiveUnguarded()
     }
 
     /// Main-actor entry point: captures the context that must be read on

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -59,6 +59,16 @@ final class ProcessNetworkValueCache<Value> {
     }
 }
 
+/// Filesystem facts captured before SwiftData opens a Core wallet store.
+/// Kept path-free so the same value can safely feed structured diagnostics.
+struct CoreStoreOpenMetadata: Equatable {
+    let existedBeforeOpen: Bool
+    let sizeBytesBefore: UInt64
+    let mainStoreSizeBytesBefore: UInt64
+    let walSizeBytesBefore: UInt64
+    let sharedMemorySizeBytesBefore: UInt64
+}
+
 /// Enforces the seed-safety ordering for wallet creation: persist and verify
 /// the mnemonic before making the wallet live in a manager. If creation then
 /// fails, only the provisional mnemonic is rolled back.
@@ -973,21 +983,77 @@ final class SwiftDashSDKHost {
         }
 
         let container: ModelContainer
+        let containerStarted = CFAbsoluteTimeGetCurrent()
+        var storeURL: URL?
+        var storeMetadata = CoreStoreOpenMetadata(
+            existedBeforeOpen: false,
+            sizeBytesBefore: 0,
+            mainStoreSizeBytesBefore: 0,
+            walSizeBytesBefore: 0,
+            sharedMemorySizeBytesBefore: 0)
         do {
             Self.logger.info("🪺 HOST :: stage 2/4 obtaining ModelContainer for \(network.rawValue, privacy: .public)")
             // Timed for the same reason as stage 1: main-thread work whose
             // real cost decides whether it ever needs to move off-main. The
             // cached (reused) path should be ~0ms; only the first build of a
             // network's container in the process pays the store-open cost.
-            let started = CFAbsoluteTimeGetCurrent()
+            let resolvedStoreURL = try modelStoreURL(for: network)
+            storeURL = resolvedStoreURL
+            storeMetadata = Self.storeOpenMetadata(at: resolvedStoreURL)
             let cached = try modelContainerCache.value(for: network.networkName) {
-                try buildModelContainer(for: network)
+                try buildModelContainer(at: resolvedStoreURL)
             }
-            let ms = Int((CFAbsoluteTimeGetCurrent() - started) * 1000)
+            let ms = max(0, Int((CFAbsoluteTimeGetCurrent() - containerStarted) * 1000))
             container = cached.value
+            SDKLogger.event(
+                "core_store_open_result",
+                category: .persistence,
+                fields: [
+                    "container_result": .publicText(cached.reused ? "reused" : "opened"),
+                    "container_reused": .boolean(cached.reused),
+                    "duration_ms": .unsignedInteger(UInt64(ms)),
+                    "migration_result": .publicText(
+                        cached.reused
+                            ? "not_run_reused_container"
+                            : (storeMetadata.existedBeforeOpen
+                                ? "store_open_succeeded"
+                                : "not_required_new_store")
+                    ),
+                    "network": .publicText(network.networkName),
+                    "result": .publicText("success"),
+                    "store_existed_before_open": .boolean(storeMetadata.existedBeforeOpen),
+                    "store_main_size_bytes_before": .unsignedInteger(storeMetadata.mainStoreSizeBytesBefore),
+                    "store_shm_size_bytes_before": .unsignedInteger(storeMetadata.sharedMemorySizeBytesBefore),
+                    "store_size_bytes_before": .unsignedInteger(storeMetadata.sizeBytesBefore),
+                    "store_wal_size_bytes_before": .unsignedInteger(storeMetadata.walSizeBytesBefore),
+                ])
             Self.logger.info("🪺 HOST :: stage 2/4 ModelContainer \(cached.reused ? "reused" : "created", privacy: .public) for \(network.rawValue, privacy: .public)")
             DWLogger.log("HOST stage 2/4 ModelContainer \(cached.reused ? "reused" : "created") for \(network.rawValue) in \(ms)ms")
         } catch {
+            let ms = max(0, Int((CFAbsoluteTimeGetCurrent() - containerStarted) * 1000))
+            SDKLogger.event(
+                "core_store_open_result",
+                category: .persistence,
+                severity: .error,
+                fields: [
+                    "container_result": .publicText("open_failed"),
+                    "container_reused": .boolean(false),
+                    "duration_ms": .unsignedInteger(UInt64(ms)),
+                    "migration_result": .publicText(
+                        storeMetadata.existedBeforeOpen
+                            ? "store_open_or_migration_failed"
+                            : "not_attempted_new_store_create_failed"
+                    ),
+                    "network": .publicText(network.networkName),
+                    "result": .publicText("failure"),
+                    "store_existed_before_open": .boolean(storeMetadata.existedBeforeOpen),
+                    "store_main_size_bytes_before": .unsignedInteger(storeMetadata.mainStoreSizeBytesBefore),
+                    "store_shm_size_bytes_before": .unsignedInteger(storeMetadata.sharedMemorySizeBytesBefore),
+                    "store_size_bytes_before": .unsignedInteger(storeMetadata.sizeBytesBefore),
+                    "store_wal_size_bytes_before": .unsignedInteger(storeMetadata.walSizeBytesBefore),
+                ],
+                error: error,
+                redacting: storeURL.map { [$0.path] } ?? [])
             Self.logger.error("🪺 HOST :: ModelContainer build failed: \(String(describing: error), privacy: .public)")
             throw HostError.modelContainerFailed(error)
         }
@@ -1290,7 +1356,33 @@ final class SwiftDashSDKHost {
 
     // MARK: - ModelContainer
 
-    private func buildModelContainer(for network: Network) throws -> ModelContainer {
+    nonisolated static func storeOpenMetadata(
+        at url: URL,
+        fileManager: FileManager = .default
+    ) -> CoreStoreOpenMetadata {
+        func fileSize(at candidate: URL) -> UInt64 {
+            let attributes = try? fileManager.attributesOfItem(atPath: candidate.path)
+            return (attributes?[.size] as? NSNumber)?.uint64Value ?? 0
+        }
+
+        let existed = fileManager.fileExists(atPath: url.path)
+        let mainSize = fileSize(at: url)
+        let walSize = fileSize(at: URL(fileURLWithPath: url.path + "-wal"))
+        let sharedMemorySize = fileSize(at: URL(fileURLWithPath: url.path + "-shm"))
+        let totalSize = [mainSize, walSize, sharedMemorySize].reduce(UInt64(0)) {
+            partial, value in
+            let (sum, overflow) = partial.addingReportingOverflow(value)
+            return overflow ? UInt64.max : sum
+        }
+        return CoreStoreOpenMetadata(
+            existedBeforeOpen: existed,
+            sizeBytesBefore: totalSize,
+            mainStoreSizeBytesBefore: mainSize,
+            walSizeBytesBefore: walSize,
+            sharedMemorySizeBytesBefore: sharedMemorySize)
+    }
+
+    private func modelStoreURL(for network: Network) throws -> URL {
         let documents = try FileManager.default.url(
             for: .documentDirectory,
             in: .userDomainMask,
@@ -1303,8 +1395,10 @@ final class SwiftDashSDKHost {
         try FileManager.default.createDirectory(
             at: dir,
             withIntermediateDirectories: true)
-        let url = dir.appendingPathComponent("DashModel.sqlite", isDirectory: false)
+        return dir.appendingPathComponent("DashModel.sqlite", isDirectory: false)
+    }
 
+    private func buildModelContainer(at url: URL) throws -> ModelContainer {
         let configuration = ModelConfiguration(
             schema: DashModelContainer.schema,
             url: url,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -59,16 +59,6 @@ final class ProcessNetworkValueCache<Value> {
     }
 }
 
-/// Filesystem facts captured before SwiftData opens a Core wallet store.
-/// Kept path-free so the same value can safely feed structured diagnostics.
-struct CoreStoreOpenMetadata: Equatable {
-    let existedBeforeOpen: Bool
-    let sizeBytesBefore: UInt64
-    let mainStoreSizeBytesBefore: UInt64
-    let walSizeBytesBefore: UInt64
-    let sharedMemorySizeBytesBefore: UInt64
-}
-
 /// Enforces the seed-safety ordering for wallet creation: persist and verify
 /// the mnemonic before making the wallet live in a manager. If creation then
 /// fails, only the provisional mnemonic is rolled back.
@@ -983,77 +973,27 @@ final class SwiftDashSDKHost {
         }
 
         let container: ModelContainer
-        let containerStarted = CFAbsoluteTimeGetCurrent()
-        var storeURL: URL?
-        var storeMetadata = CoreStoreOpenMetadata(
-            existedBeforeOpen: false,
-            sizeBytesBefore: 0,
-            mainStoreSizeBytesBefore: 0,
-            walSizeBytesBefore: 0,
-            sharedMemorySizeBytesBefore: 0)
         do {
             Self.logger.info("🪺 HOST :: stage 2/4 obtaining ModelContainer for \(network.rawValue, privacy: .public)")
             // Timed for the same reason as stage 1: main-thread work whose
             // real cost decides whether it ever needs to move off-main. The
             // cached (reused) path should be ~0ms; only the first build of a
             // network's container in the process pays the store-open cost.
-            let resolvedStoreURL = try modelStoreURL(for: network)
-            storeURL = resolvedStoreURL
-            storeMetadata = Self.storeOpenMetadata(at: resolvedStoreURL)
+            //
+            // Store-open telemetry (`core_store_open_result` with sizes,
+            // duration and `migration_path`, plus
+            // `core_store_staged_migration_failed`) is the SDK's, emitted from
+            // `DashModelContainer.open` once per real open. A cache hit emits
+            // nothing, which is the truthful shape: no store was opened.
+            let started = CFAbsoluteTimeGetCurrent()
             let cached = try modelContainerCache.value(for: network.networkName) {
-                try buildModelContainer(at: resolvedStoreURL)
+                try buildModelContainer(at: try modelStoreURL(for: network))
             }
-            let ms = max(0, Int((CFAbsoluteTimeGetCurrent() - containerStarted) * 1000))
+            let ms = max(0, Int((CFAbsoluteTimeGetCurrent() - started) * 1000))
             container = cached.value
-            SDKLogger.event(
-                "core_store_open_result",
-                category: .persistence,
-                fields: [
-                    "container_result": .publicText(cached.reused ? "reused" : "opened"),
-                    "container_reused": .boolean(cached.reused),
-                    "duration_ms": .unsignedInteger(UInt64(ms)),
-                    "migration_result": .publicText(
-                        cached.reused
-                            ? "not_run_reused_container"
-                            : (storeMetadata.existedBeforeOpen
-                                ? "store_open_succeeded"
-                                : "not_required_new_store")
-                    ),
-                    "network": .publicText(network.networkName),
-                    "result": .publicText("success"),
-                    "store_existed_before_open": .boolean(storeMetadata.existedBeforeOpen),
-                    "store_main_size_bytes_before": .unsignedInteger(storeMetadata.mainStoreSizeBytesBefore),
-                    "store_shm_size_bytes_before": .unsignedInteger(storeMetadata.sharedMemorySizeBytesBefore),
-                    "store_size_bytes_before": .unsignedInteger(storeMetadata.sizeBytesBefore),
-                    "store_wal_size_bytes_before": .unsignedInteger(storeMetadata.walSizeBytesBefore),
-                ])
             Self.logger.info("🪺 HOST :: stage 2/4 ModelContainer \(cached.reused ? "reused" : "created", privacy: .public) for \(network.rawValue, privacy: .public)")
             DWLogger.log("HOST stage 2/4 ModelContainer \(cached.reused ? "reused" : "created") for \(network.rawValue) in \(ms)ms")
         } catch {
-            let ms = max(0, Int((CFAbsoluteTimeGetCurrent() - containerStarted) * 1000))
-            SDKLogger.event(
-                "core_store_open_result",
-                category: .persistence,
-                severity: .error,
-                fields: [
-                    "container_result": .publicText("open_failed"),
-                    "container_reused": .boolean(false),
-                    "duration_ms": .unsignedInteger(UInt64(ms)),
-                    "migration_result": .publicText(
-                        storeMetadata.existedBeforeOpen
-                            ? "store_open_or_migration_failed"
-                            : "not_attempted_new_store_create_failed"
-                    ),
-                    "network": .publicText(network.networkName),
-                    "result": .publicText("failure"),
-                    "store_existed_before_open": .boolean(storeMetadata.existedBeforeOpen),
-                    "store_main_size_bytes_before": .unsignedInteger(storeMetadata.mainStoreSizeBytesBefore),
-                    "store_shm_size_bytes_before": .unsignedInteger(storeMetadata.sharedMemorySizeBytesBefore),
-                    "store_size_bytes_before": .unsignedInteger(storeMetadata.sizeBytesBefore),
-                    "store_wal_size_bytes_before": .unsignedInteger(storeMetadata.walSizeBytesBefore),
-                ],
-                error: error,
-                redacting: storeURL.map { [$0.path] } ?? [])
             Self.logger.error("🪺 HOST :: ModelContainer build failed: \(String(describing: error), privacy: .public)")
             throw HostError.modelContainerFailed(error)
         }
@@ -1356,32 +1296,6 @@ final class SwiftDashSDKHost {
 
     // MARK: - ModelContainer
 
-    nonisolated static func storeOpenMetadata(
-        at url: URL,
-        fileManager: FileManager = .default
-    ) -> CoreStoreOpenMetadata {
-        func fileSize(at candidate: URL) -> UInt64 {
-            let attributes = try? fileManager.attributesOfItem(atPath: candidate.path)
-            return (attributes?[.size] as? NSNumber)?.uint64Value ?? 0
-        }
-
-        let existed = fileManager.fileExists(atPath: url.path)
-        let mainSize = fileSize(at: url)
-        let walSize = fileSize(at: URL(fileURLWithPath: url.path + "-wal"))
-        let sharedMemorySize = fileSize(at: URL(fileURLWithPath: url.path + "-shm"))
-        let totalSize = [mainSize, walSize, sharedMemorySize].reduce(UInt64(0)) {
-            partial, value in
-            let (sum, overflow) = partial.addingReportingOverflow(value)
-            return overflow ? UInt64.max : sum
-        }
-        return CoreStoreOpenMetadata(
-            existedBeforeOpen: existed,
-            sizeBytesBefore: totalSize,
-            mainStoreSizeBytesBefore: mainSize,
-            walSizeBytesBefore: walSize,
-            sharedMemorySizeBytesBefore: sharedMemorySize)
-    }
-
     private func modelStoreURL(for network: Network) throws -> URL {
         let documents = try FileManager.default.url(
             for: .documentDirectory,
@@ -1398,15 +1312,20 @@ final class SwiftDashSDKHost {
         return dir.appendingPathComponent("DashModel.sqlite", isDirectory: false)
     }
 
+    /// Through `DashModelContainer.open` rather than a bare
+    /// `ModelContainer(for:configurations:)`: that is where the SDK records
+    /// the open (`core_store_open_result`) and where a store the staged
+    /// migration plan rejects as an unknown version — every v4.2.0-dev.1
+    /// store, until the remaining V1/V2 shapes are frozen — is opened through
+    /// inferred migration instead of throwing into a launch crash. See
+    /// dashpay/platform#4580.
     private func buildModelContainer(at url: URL) throws -> ModelContainer {
-        let configuration = ModelConfiguration(
-            schema: DashModelContainer.schema,
-            url: url,
-            allowsSave: true,
-            cloudKitDatabase: .none)
-        return try ModelContainer(
-            for: DashModelContainer.schema,
-            configurations: [configuration])
+        try DashModelContainer.open(
+            ModelConfiguration(
+                schema: DashModelContainer.schema,
+                url: url,
+                allowsSave: true,
+                cloudKitDatabase: .none))
     }
 
     /// Filesystem path for the per-network shielded Orchard commitment-tree

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -994,7 +994,14 @@ final class SwiftDashSDKHost {
             Self.logger.info("🪺 HOST :: stage 2/4 ModelContainer \(cached.reused ? "reused" : "created", privacy: .public) for \(network.rawValue, privacy: .public)")
             DWLogger.log("HOST stage 2/4 ModelContainer \(cached.reused ? "reused" : "created") for \(network.rawValue) in \(ms)ms")
         } catch {
-            Self.logger.error("🪺 HOST :: ModelContainer build failed: \(String(describing: error), privacy: .public)")
+            if case DashModelContainerError.storeFromNewerBuild(let reason) = error {
+                // Deliberate SDK refusal, not a corrupt store: this build cannot
+                // open a database a newer build wrote without losing data.
+                Self.logger.error("🪺 HOST :: store written by a newer build; refusing to open it (\(reason, privacy: .public))")
+                DWLogger.log("HOST store written by a newer build; refusing to open it (\(reason))")
+            } else {
+                Self.logger.error("🪺 HOST :: ModelContainer build failed: \(String(describing: error), privacy: .public)")
+            }
             throw HostError.modelContainerFailed(error)
         }
 
@@ -1314,10 +1321,14 @@ final class SwiftDashSDKHost {
 
     /// Through `DashModelContainer.open` rather than a bare
     /// `ModelContainer(for:configurations:)`: that is where the SDK records
-    /// the open (`core_store_open_result`) and where a store the staged
-    /// migration plan rejects as an unknown version — every v4.2.0-dev.1
-    /// store, until the remaining V1/V2 shapes are frozen — is opened through
-    /// inferred migration instead of throwing into a launch crash. See
+    /// the open (`core_store_open_result`, `store_verdict`), and where a
+    /// store written by a registered version whose live models have since
+    /// drifted — every v4.2.0-dev.1 store, until the remaining V1/V2 shapes
+    /// are frozen — is opened through inferred migration instead of throwing
+    /// into a launch crash. A store written by a NEWER build is refused with
+    /// `DashModelContainerError.storeFromNewerBuild` (the bare container used
+    /// to open it and drop what that build wrote); the error's message tells
+    /// the user to update or reset, and the reset route stays reachable. See
     /// dashpay/platform#4580.
     private func buildModelContainer(at url: URL) throws -> ModelContainer {
         try DashModelContainer.open(
@@ -1330,7 +1341,7 @@ final class SwiftDashSDKHost {
 
     /// Filesystem path for the per-network shielded Orchard commitment-tree
     /// SQLite file, handed to `PlatformWalletManager.configureShielded(dbPath:)`.
-    /// Mirrors `buildModelContainer`'s `documents/SwiftDashSDK/<subsystem>/<network>/`
+    /// Mirrors `modelStoreURL(for:)`'s `documents/SwiftDashSDK/<subsystem>/<network>/`
     /// convention in a sibling `Shielded/` directory; creates the directory if
     /// needed. The manager is rebuilt per network (`buildRuntime`), so a
     /// per-network path keeps `configureShielded` idempotent — it throws only

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -994,14 +994,11 @@ final class SwiftDashSDKHost {
             Self.logger.info("🪺 HOST :: stage 2/4 ModelContainer \(cached.reused ? "reused" : "created", privacy: .public) for \(network.rawValue, privacy: .public)")
             DWLogger.log("HOST stage 2/4 ModelContainer \(cached.reused ? "reused" : "created") for \(network.rawValue) in \(ms)ms")
         } catch {
-            if case DashModelContainerError.storeFromNewerBuild(let reason) = error {
-                // Deliberate SDK refusal, not a corrupt store: this build cannot
-                // open a database a newer build wrote without losing data.
-                Self.logger.error("🪺 HOST :: store written by a newer build; refusing to open it (\(reason, privacy: .public))")
-                DWLogger.log("HOST store written by a newer build; refusing to open it (\(reason))")
-            } else {
-                Self.logger.error("🪺 HOST :: ModelContainer build failed: \(String(describing: error), privacy: .public)")
-            }
+            // The SDK no longer distinguishes a refusal it can explain from a
+            // plain failure: nothing observable about a store says which build
+            // wrote it, so `core_store_open_result`'s `store_verdict` carries
+            // whatever was determined and this stays one message.
+            Self.logger.error("🪺 HOST :: ModelContainer build failed: \(String(describing: error), privacy: .public)")
             throw HostError.modelContainerFailed(error)
         }
 
@@ -1325,10 +1322,11 @@ final class SwiftDashSDKHost {
     /// store written by a registered version whose live models have since
     /// drifted — every v4.2.0-dev.1 store, until the remaining V1/V2 shapes
     /// are frozen — is opened through inferred migration instead of throwing
-    /// into a launch crash. A store written by a NEWER build is refused with
-    /// `DashModelContainerError.storeFromNewerBuild` (the bare container used
-    /// to open it and drop what that build wrote); the error's message tells
-    /// the user to update or reset, and the reset route stays reachable. See
+    /// into a launch crash. Every other store the plan cannot place is
+    /// refused, with SwiftData's own error passed through: the SDK does not
+    /// claim a store came from a newer build, because nothing it can observe
+    /// tells older from newer (an entity this schema lacks may be a rename it
+    /// performed itself). The verdict is in `core_store_open_result`. See
     /// dashpay/platform#4580.
     private func buildModelContainer(at url: URL) throws -> ModelContainer {
         try DashModelContainer.open(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
@@ -69,7 +69,14 @@ final class WalletLifecycleTransitionState: ObservableObject {
         /// admitted from here like from every failure phase: an export can
         /// never wall the user off from Reset. No failure phase — a failed
         /// export is reported by the screen that asked for it.
-        case exportingDiagnostics
+        ///
+        /// `dismissed` is Cancel's effect: the card is gone and the result
+        /// will be discarded, but the export is still running — its snapshot
+        /// may still hold the persistence queue and its pinned manager — so
+        /// the phase stays busy, and the admission with it, until
+        /// `exportArchive()` returns. Visibility and admission are two
+        /// different things; only the first ends at Cancel.
+        case exportingDiagnostics(dismissed: Bool)
 
         /// Compact form for gate/telemetry log lines (no wallet ids beyond
         /// what the operation logs themselves already include).
@@ -84,7 +91,8 @@ final class WalletLifecycleTransitionState: ObservableObject {
             case .failedWalletSwitch: return "failedWalletSwitch"
             case .failedWalletRemoval: return "failedWalletRemoval"
             case .wiping: return "wiping"
-            case .exportingDiagnostics: return "exportingDiagnostics"
+            case .exportingDiagnostics(let dismissed):
+                return dismissed ? "exportingDiagnostics(dismissed)" : "exportingDiagnostics"
             }
         }
     }
@@ -111,7 +119,7 @@ final class WalletLifecycleTransitionState: ObservableObject {
              (.idle, .removingWallet),
              (.idle, .addingWallet),
              (.idle, .wiping),
-             (.idle, .exportingDiagnostics),
+             (.idle, .exportingDiagnostics(dismissed: false)),
              (.failedNetworkSwitch, .switchingNetwork),
              (.failedWalletSwitch, .switchingWallet),
              // Composite add → switch: the add flow's own continuation into
@@ -129,8 +137,10 @@ final class WalletLifecycleTransitionState: ObservableObject {
              (.failedWalletRemoval, .wiping),
              // An export is the one busy phase whose wall time is not the
              // app's to bound (the SDK snapshot on a large wallet), so the
-             // reset route stays open through it too. Shutdown cancels the
-             // snapshot's remaining native reads (platform#4580).
+             // reset route stays open through it too — dismissed or not.
+             // Shutdown cancels the snapshot's remaining native reads
+             // (platform#4580). Nothing else is admitted from a dismissed
+             // export: the snapshot may still hold the queue.
              (.exportingDiagnostics, .wiping):
             phase = next
             return true

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
@@ -59,6 +59,14 @@ final class WalletLifecycleTransitionState: ObservableObject {
         /// "Deleting Wallet…"). Failure alerts stay UIKit (shown after
         /// `finish()`), so there is no failed-wipe phase.
         case wiping(title: String?)
+        /// A diagnostic log export in flight (`DiagnosticLogExporter`). Not a
+        /// lifecycle operation, but it holds the SDK's persistence serial
+        /// queue for its duration (dashpay/platform#4580), so it takes the
+        /// same blocking card and the same admission gate: no wallet switch
+        /// may start under it, and it may not start under one. Finishes on
+        /// its own; there is no failure phase — a failed export is reported
+        /// by the screen that asked for it.
+        case exportingDiagnostics
 
         /// Compact form for gate/telemetry log lines (no wallet ids beyond
         /// what the operation logs themselves already include).
@@ -73,6 +81,7 @@ final class WalletLifecycleTransitionState: ObservableObject {
             case .failedWalletSwitch: return "failedWalletSwitch"
             case .failedWalletRemoval: return "failedWalletRemoval"
             case .wiping: return "wiping"
+            case .exportingDiagnostics: return "exportingDiagnostics"
             }
         }
     }
@@ -99,6 +108,7 @@ final class WalletLifecycleTransitionState: ObservableObject {
              (.idle, .removingWallet),
              (.idle, .addingWallet),
              (.idle, .wiping),
+             (.idle, .exportingDiagnostics),
              (.failedNetworkSwitch, .switchingNetwork),
              (.failedWalletSwitch, .switchingWallet),
              // Composite add → switch: the add flow's own continuation into

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
@@ -76,7 +76,12 @@ final class WalletLifecycleTransitionState: ObservableObject {
         /// the phase stays busy, and the admission with it, until
         /// `exportArchive()` returns. Visibility and admission are two
         /// different things; only the first ends at Cancel.
-        case exportingDiagnostics(dismissed: Bool)
+        ///
+        /// `generation` names the export that owns the phase. A cancelled
+        /// export can be superseded — wipe admitted through it, then a new
+        /// export — while it is still running; when it finally returns it
+        /// must release and deliver only if the phase is still its own.
+        case exportingDiagnostics(dismissed: Bool, generation: UInt64)
 
         /// Compact form for gate/telemetry log lines (no wallet ids beyond
         /// what the operation logs themselves already include).
@@ -91,8 +96,8 @@ final class WalletLifecycleTransitionState: ObservableObject {
             case .failedWalletSwitch: return "failedWalletSwitch"
             case .failedWalletRemoval: return "failedWalletRemoval"
             case .wiping: return "wiping"
-            case .exportingDiagnostics(let dismissed):
-                return dismissed ? "exportingDiagnostics(dismissed)" : "exportingDiagnostics"
+            case .exportingDiagnostics(let dismissed, let generation):
+                return "exportingDiagnostics#\(generation)" + (dismissed ? "(dismissed)" : "")
             }
         }
     }
@@ -119,7 +124,7 @@ final class WalletLifecycleTransitionState: ObservableObject {
              (.idle, .removingWallet),
              (.idle, .addingWallet),
              (.idle, .wiping),
-             (.idle, .exportingDiagnostics(dismissed: false)),
+             (.idle, .exportingDiagnostics(dismissed: false, generation: _)),
              (.failedNetworkSwitch, .switchingNetwork),
              (.failedWalletSwitch, .switchingWallet),
              // Composite add → switch: the add flow's own continuation into

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
@@ -60,12 +60,15 @@ final class WalletLifecycleTransitionState: ObservableObject {
         /// `finish()`), so there is no failed-wipe phase.
         case wiping(title: String?)
         /// A diagnostic log export in flight (`DiagnosticLogExporter`). Not a
-        /// lifecycle operation, but it holds the SDK's persistence serial
-        /// queue for its duration (dashpay/platform#4580), so it takes the
-        /// same blocking card and the same admission gate: no wallet switch
-        /// may start under it, and it may not start under one. Finishes on
-        /// its own; there is no failure phase — a failed export is reported
-        /// by the screen that asked for it.
+        /// lifecycle operation, but its wallet snapshot holds the SDK's
+        /// persistence serial queue while it runs (dashpay/platform#4580),
+        /// so a wallet switch must not start under it and it must not start
+        /// under one; the card stays up for the rest of the export — flush,
+        /// capture, zip — only because the user is waiting for one result and
+        /// must not start a second. The card offers Cancel, and `.wiping` is
+        /// admitted from here like from every failure phase: an export can
+        /// never wall the user off from Reset. No failure phase — a failed
+        /// export is reported by the screen that asked for it.
         case exportingDiagnostics
 
         /// Compact form for gate/telemetry log lines (no wallet ids beyond
@@ -123,7 +126,12 @@ final class WalletLifecycleTransitionState: ObservableObject {
              // with reinstalling as the only exit.
              (.failedNetworkSwitch, .wiping),
              (.failedWalletSwitch, .wiping),
-             (.failedWalletRemoval, .wiping):
+             (.failedWalletRemoval, .wiping),
+             // An export is the one busy phase whose wall time is not the
+             // app's to bound (the SDK snapshot on a large wallet), so the
+             // reset route stays open through it too. Shutdown cancels the
+             // snapshot's remaining native reads (platform#4580).
+             (.exportingDiagnostics, .wiping):
             phase = next
             return true
         default:

--- a/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
+++ b/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
@@ -59,13 +59,16 @@ final class WalletLifecycleOverlayPresenter {
 
     private func apply(_ phase: WalletLifecycleTransitionState.Phase) {
         switch phase {
-        case .idle:
+        case .idle, .exportingDiagnostics(dismissed: true):
+            // A dismissed export is still busy for admission purposes — see
+            // the phase doc — but the user has asked to stop waiting, so the
+            // window goes; a wipe admitted from here brings a new one.
             overlayWindow?.isHidden = true
             overlayWindow = nil
         case .switchingNetwork, .failedNetworkSwitch,
              .switchingWallet, .removingWallet, .addingWallet,
              .failedWalletSwitch, .failedWalletRemoval,
-             .wiping, .exportingDiagnostics:
+             .wiping, .exportingDiagnostics(dismissed: false):
             presentIfNeeded()
         }
     }
@@ -169,9 +172,10 @@ final class WalletLifecycleOverlayViewModel: ObservableObject {
         WalletLifecycleTransitionState.shared.finish()
     }
 
-    /// Stop waiting for the export. The SDK snapshot cannot be interrupted;
-    /// the exporter discards its result when it arrives instead of
-    /// presenting it late.
+    /// Stop waiting for the export: the card goes, the result is discarded
+    /// when it arrives. The export itself keeps running and keeps its
+    /// admission until it returns — the SDK snapshot cannot be interrupted
+    /// and may still hold the persistence queue.
     func cancelDiagnosticsExport() {
         DiagnosticLogExporter.cancelWaiting()
     }
@@ -217,7 +221,11 @@ struct WalletLifecycleOverlayView: View {
                 progressCard(
                     title: title ?? NSLocalizedString("Deleting All Wallets…", comment: ""),
                     subtitle: nil)
-            case .exportingDiagnostics:
+            case .exportingDiagnostics(dismissed: true):
+                // No window exists for this phase (the presenter tears it
+                // down); nothing to draw if a view is ever asked.
+                EmptyView()
+            case .exportingDiagnostics(dismissed: false):
                 // The one busy phase whose duration the app cannot bound, so
                 // the one busy card with a way out.
                 card {

--- a/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
+++ b/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
@@ -64,14 +64,30 @@ final class WalletLifecycleOverlayPresenter {
             }
     }
 
+    /// True while a lifecycle card is on screen. The overlay owns a window at
+    /// `.alert + 1`, above the level `UIAlertController` presents at, so a
+    /// caller about to raise an alert can ask whether it would be drawn under
+    /// the card.
+    var isPresenting: Bool { overlayWindow != nil }
+
     private func apply(_ phase: WalletLifecycleTransitionState.Phase) {
         switch phase {
         case .idle, .exportingDiagnostics(dismissed: true, generation: _):
             // A dismissed export is still busy for admission purposes — see
             // the phase doc — but the user has asked to stop waiting, so the
             // window goes; a wipe admitted from here brings a new one.
-            overlayWindow?.isHidden = true
+            //
+            // Hidden now (that same-turn teardown is the whole point of
+            // applying synchronously), released next turn. This runs on the
+            // caller's stack, and for the card's own buttons that stack is the
+            // SwiftUI action closure of the view graph this window owns —
+            // dropping the last reference here would free the hosting view,
+            // and the `@StateObject` view model, out from under the touch
+            // still being handled.
+            guard let window = overlayWindow else { return }
             overlayWindow = nil
+            window.isHidden = true
+            DispatchQueue.main.async { withExtendedLifetime(window) {} }
         case .switchingNetwork, .failedNetworkSwitch,
              .switchingWallet, .removingWallet, .addingWallet,
              .failedWalletSwitch, .failedWalletRemoval,
@@ -145,9 +161,20 @@ final class WalletLifecycleOverlayViewModel: ObservableObject {
     /// Seeded from the phase the presenter is applying, not from the state:
     /// this can be created inside `@Published`'s `willSet`, where the state
     /// still holds the previous phase and the projected publisher replays
-    /// that previous value to a new subscriber — hence `dropFirst()`, which
-    /// skips exactly that replay (outside `willSet` it skips a value equal
-    /// to the seed) and leaves every later change flowing.
+    /// that previous value to a new subscriber. `dropFirst()` skips exactly
+    /// that stale replay.
+    ///
+    /// It cannot be the whole answer, because this initializer does not
+    /// reliably run inside `willSet`: `StateObject.init(wrappedValue:)` takes
+    /// an autoclosure that SwiftUI evaluates lazily, at the view's first body
+    /// render, which is a later runloop turn. By then the replayed value is
+    /// the committed phase — usually the seed, but a LATER phase whenever the
+    /// operation already moved on (a wallet switch that fails before its first
+    /// real suspension does exactly this), and dropping that would strand the
+    /// card on a progress spinner behind a blocking scrim with no way out.
+    /// So the committed phase is re-read once the current turn is over: a
+    /// no-op in the `willSet` case, and the change that was dropped in the
+    /// lazy one.
     init(initialPhase: WalletLifecycleTransitionState.Phase) {
         phase = initialPhase
         phaseCancellable = WalletLifecycleTransitionState.shared.$phase
@@ -155,6 +182,13 @@ final class WalletLifecycleOverlayViewModel: ObservableObject {
             .sink { [weak self] phase in
                 self?.phase = phase
             }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let committed = WalletLifecycleTransitionState.shared.phase
+            if committed != self.phase {
+                self.phase = committed
+            }
+        }
     }
 
     func retryNetworkSwitch(to target: WalletEnvironment.NetworkKind) {

--- a/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
+++ b/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
@@ -44,7 +44,14 @@ final class WalletLifecycleOverlayPresenter {
         guard phaseCancellable == nil else { return }
         phaseCancellable = WalletLifecycleTransitionState.shared.$phase
             .sink { phase in
-                Task { @MainActor in
+                // `phase` is only ever set on the main actor (the state is
+                // MainActor-bound) and `@Published` delivers synchronously on
+                // the setting thread, so this IS the main actor. Applying
+                // here rather than on a hopped Task means `.idle` tears the
+                // window down before the caller's next statement runs — a
+                // screen presented right after `finish()` never lands under
+                // the scrim and is never hidden mid-transition.
+                MainActor.assumeIsolated {
                     WalletLifecycleOverlayPresenter.shared.apply(phase)
                 }
             }
@@ -161,6 +168,13 @@ final class WalletLifecycleOverlayViewModel: ObservableObject {
     func dismissRemovalFailure() {
         WalletLifecycleTransitionState.shared.finish()
     }
+
+    /// Stop waiting for the export. The SDK snapshot cannot be interrupted;
+    /// the exporter discards its result when it arrives instead of
+    /// presenting it late.
+    func cancelDiagnosticsExport() {
+        DiagnosticLogExporter.cancelWaiting()
+    }
 }
 
 struct WalletLifecycleOverlayView: View {
@@ -204,11 +218,23 @@ struct WalletLifecycleOverlayView: View {
                     title: title ?? NSLocalizedString("Deleting All Wallets…", comment: ""),
                     subtitle: nil)
             case .exportingDiagnostics:
-                progressCard(
-                    title: NSLocalizedString("Preparing logs…", comment: "Diagnostic log export overlay"),
-                    subtitle: NSLocalizedString(
+                // The one busy phase whose duration the app cannot bound, so
+                // the one busy card with a way out.
+                card {
+                    SwiftUI.ProgressView()
+                        .controlSize(.large)
+                    Text(NSLocalizedString("Preparing logs…", comment: "Diagnostic log export overlay"))
+                        .font(.headline)
+                    Text(NSLocalizedString(
                         "Collecting wallet diagnostics. This may take a few seconds.",
                         comment: "Diagnostic log export overlay"))
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                    actionButton(NSLocalizedString("Cancel", comment: ""), prominent: false) {
+                        viewModel.cancelDiagnosticsExport()
+                    }
+                }
             case let .failedNetworkSwitch(from, target, message):
                 card {
                     failureHeader(

--- a/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
+++ b/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
@@ -282,8 +282,11 @@ struct WalletLifecycleOverlayView: View {
                 // down); nothing to draw if a view is ever asked.
                 EmptyView()
             case .exportingDiagnostics(dismissed: false, generation: _):
-                // The one busy phase whose duration the app cannot bound, so
-                // the one busy card with a way out.
+                // Only the support export takes this phase — the About and
+                // Tools exports collect no diagnostics and are not gated — so
+                // the copy can say what is actually happening. The one busy
+                // phase whose duration the app cannot bound, hence the one
+                // busy card with a way out.
                 card {
                     SwiftUI.ProgressView()
                         .controlSize(.large)

--- a/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
+++ b/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
@@ -58,7 +58,7 @@ final class WalletLifecycleOverlayPresenter {
         case .switchingNetwork, .failedNetworkSwitch,
              .switchingWallet, .removingWallet, .addingWallet,
              .failedWalletSwitch, .failedWalletRemoval,
-             .wiping:
+             .wiping, .exportingDiagnostics:
             presentIfNeeded()
         }
     }
@@ -203,6 +203,12 @@ struct WalletLifecycleOverlayView: View {
                 progressCard(
                     title: title ?? NSLocalizedString("Deleting All Wallets…", comment: ""),
                     subtitle: nil)
+            case .exportingDiagnostics:
+                progressCard(
+                    title: NSLocalizedString("Preparing logs…", comment: "Diagnostic log export overlay"),
+                    subtitle: NSLocalizedString(
+                        "Collecting wallet diagnostics. This may take a few seconds.",
+                        comment: "Diagnostic log export overlay"))
             case let .failedNetworkSwitch(from, target, message):
                 card {
                     failureHeader(

--- a/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
+++ b/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
@@ -44,22 +44,29 @@ final class WalletLifecycleOverlayPresenter {
         guard phaseCancellable == nil else { return }
         phaseCancellable = WalletLifecycleTransitionState.shared.$phase
             .sink { phase in
-                // `phase` is only ever set on the main actor (the state is
-                // MainActor-bound) and `@Published` delivers synchronously on
-                // the setting thread, so this IS the main actor. Applying
-                // here rather than on a hopped Task means `.idle` tears the
-                // window down before the caller's next statement runs — a
-                // screen presented right after `finish()` never lands under
-                // the scrim and is never hidden mid-transition.
-                MainActor.assumeIsolated {
-                    WalletLifecycleOverlayPresenter.shared.apply(phase)
+                // Apply synchronously when the emission is already on the
+                // main thread — every Swift caller of the state is
+                // MainActor-bound — so `.idle` tears the window down before
+                // the caller's next statement runs and a screen presented
+                // right after `finish()` never lands under the scrim. The
+                // Obj-C bridge (`beginWiping` / `finishWiping`) has no
+                // compile-time isolation, so an off-main emission hops rather
+                // than traps; it merely loses the same-turn teardown.
+                if Thread.isMainThread {
+                    MainActor.assumeIsolated {
+                        WalletLifecycleOverlayPresenter.shared.apply(phase)
+                    }
+                } else {
+                    Task { @MainActor in
+                        WalletLifecycleOverlayPresenter.shared.apply(phase)
+                    }
                 }
             }
     }
 
     private func apply(_ phase: WalletLifecycleTransitionState.Phase) {
         switch phase {
-        case .idle, .exportingDiagnostics(dismissed: true):
+        case .idle, .exportingDiagnostics(dismissed: true, generation: _):
             // A dismissed export is still busy for admission purposes — see
             // the phase doc — but the user has asked to stop waiting, so the
             // window goes; a wipe admitted from here brings a new one.
@@ -68,12 +75,16 @@ final class WalletLifecycleOverlayPresenter {
         case .switchingNetwork, .failedNetworkSwitch,
              .switchingWallet, .removingWallet, .addingWallet,
              .failedWalletSwitch, .failedWalletRemoval,
-             .wiping, .exportingDiagnostics(dismissed: false):
-            presentIfNeeded()
+             .wiping, .exportingDiagnostics(dismissed: false, generation: _):
+            presentIfNeeded(for: phase)
         }
     }
 
-    private func presentIfNeeded() {
+    /// `phase` is the value being applied, passed down rather than re-read:
+    /// `@Published` emits from `willSet`, so the state still holds the
+    /// previous phase while this runs, and a view seeded from it would draw
+    /// the previous card (or no card, over a full scrim).
+    private func presentIfNeeded(for phase: WalletLifecycleTransitionState.Phase) {
         guard overlayWindow == nil else { return }
         let scene = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
@@ -82,7 +93,8 @@ final class WalletLifecycleOverlayPresenter {
 
         let window = scene.map { UIWindow(windowScene: $0) } ?? UIWindow(frame: UIScreen.main.bounds)
         window.windowLevel = .alert + 1
-        window.rootViewController = UIHostingController(rootView: WalletLifecycleOverlayView())
+        window.rootViewController = UIHostingController(
+            rootView: WalletLifecycleOverlayView(initialPhase: phase))
         window.rootViewController?.view.backgroundColor = .clear
         window.backgroundColor = .clear
         window.isHidden = false
@@ -130,10 +142,16 @@ final class WalletLifecycleOverlayViewModel: ObservableObject {
 
     private var phaseCancellable: AnyCancellable?
 
-    init() {
-        let transitionState = WalletLifecycleTransitionState.shared
-        phase = transitionState.phase
-        phaseCancellable = transitionState.$phase
+    /// Seeded from the phase the presenter is applying, not from the state:
+    /// this can be created inside `@Published`'s `willSet`, where the state
+    /// still holds the previous phase and the projected publisher replays
+    /// that previous value to a new subscriber — hence `dropFirst()`, which
+    /// skips exactly that replay (outside `willSet` it skips a value equal
+    /// to the seed) and leaves every later change flowing.
+    init(initialPhase: WalletLifecycleTransitionState.Phase) {
+        phase = initialPhase
+        phaseCancellable = WalletLifecycleTransitionState.shared.$phase
+            .dropFirst()
             .sink { [weak self] phase in
                 self?.phase = phase
             }
@@ -182,7 +200,11 @@ final class WalletLifecycleOverlayViewModel: ObservableObject {
 }
 
 struct WalletLifecycleOverlayView: View {
-    @StateObject private var viewModel = WalletLifecycleOverlayViewModel()
+    @StateObject private var viewModel: WalletLifecycleOverlayViewModel
+
+    init(initialPhase: WalletLifecycleTransitionState.Phase) {
+        _viewModel = StateObject(wrappedValue: WalletLifecycleOverlayViewModel(initialPhase: initialPhase))
+    }
 
     var body: some View {
         ZStack {
@@ -221,11 +243,11 @@ struct WalletLifecycleOverlayView: View {
                 progressCard(
                     title: title ?? NSLocalizedString("Deleting All Wallets…", comment: ""),
                     subtitle: nil)
-            case .exportingDiagnostics(dismissed: true):
+            case .exportingDiagnostics(dismissed: true, generation: _):
                 // No window exists for this phase (the presenter tears it
                 // down); nothing to draw if a view is ever asked.
                 EmptyView()
-            case .exportingDiagnostics(dismissed: false):
+            case .exportingDiagnostics(dismissed: false, generation: _):
                 // The one busy phase whose duration the app cannot bound, so
                 // the one busy card with a way out.
                 card {

--- a/DashWallet/Sources/UI/Menu/Settings/About/AboutDashViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/About/AboutDashViewModel.swift
@@ -145,6 +145,8 @@ final class AboutDashViewModel: ObservableObject {
             case .success(let url):
                 self.exportedLogsURL = url
             case .failure(let error):
+                // The overlay's Cancel is the user's choice, not a failure.
+                if (error as? DiagnosticLogExportError) == .cancelled { return }
                 self.logExportErrorMessage = error.localizedDescription
             }
         }

--- a/DashWallet/Sources/UI/Menu/Settings/About/AboutDashViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/About/AboutDashViewModel.swift
@@ -138,7 +138,7 @@ final class AboutDashViewModel: ObservableObject {
         isExportingLogs = true
 
         Task { [weak self] in
-            let result = await DiagnosticLogExporter.exportArchive()
+            let result = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: false)
             guard let self else { return }
             self.isExportingLogs = false
             switch result {

--- a/DashWallet/Sources/UI/Menu/Settings/About/AboutDashViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/About/AboutDashViewModel.swift
@@ -145,8 +145,9 @@ final class AboutDashViewModel: ObservableObject {
             case .success(let url):
                 self.exportedLogsURL = url
             case .failure(let error):
-                // The overlay's Cancel is the user's choice, not a failure.
-                if (error as? DiagnosticLogExportError) == .cancelled { return }
+                // The overlay's Cancel is the user's choice, not a failure,
+                // and a refusal explained by a card on screen is not an alert.
+                if DiagnosticLogExporter.shouldStaySilent(about: error) { return }
                 self.logExportErrorMessage = error.localizedDescription
             }
         }

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
@@ -188,7 +188,7 @@ class ToolsMenuViewModel: ObservableObject {
         isExportingLogs = true
 
         Task { [weak self] in
-            let result = await DiagnosticLogExporter.exportArchive()
+            let result = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: false)
             guard let self else { return }
             self.isExportingLogs = false
             switch result {

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
@@ -195,8 +195,9 @@ class ToolsMenuViewModel: ObservableObject {
             case .success(let url):
                 self.exportedLogsURL = url
             case .failure(let error):
-                // The overlay's Cancel is the user's choice, not a failure.
-                if (error as? DiagnosticLogExportError) == .cancelled { return }
+                // The overlay's Cancel is the user's choice, not a failure,
+                // and a refusal explained by a card on screen is not an alert.
+                if DiagnosticLogExporter.shouldStaySilent(about: error) { return }
                 self.logExportErrorMessage = error.localizedDescription
             }
         }

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
@@ -195,6 +195,8 @@ class ToolsMenuViewModel: ObservableObject {
             case .success(let url):
                 self.exportedLogsURL = url
             case .failure(let error):
+                // The overlay's Cancel is the user's choice, not a failure.
+                if (error as? DiagnosticLogExportError) == .cancelled { return }
                 self.logExportErrorMessage = error.localizedDescription
             }
         }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -5890,3 +5890,7 @@
 /* Log export */
 "Another wallet operation is in progress. Try again in a moment." = "Another wallet operation is in progress. Try again in a moment.";
 "Log export cancelled." = "Log export cancelled.";
+
+/* Support: composing without the diagnostic archive */
+"The app's own logs will still be attached." = "The app's own logs will still be attached.";
+"Collecting wallet diagnostics is still running from an earlier attempt. Restart the app if this does not clear." = "Collecting wallet diagnostics is still running from an earlier attempt. Restart the app if this does not clear.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -5858,3 +5858,16 @@
 
 /* Receive: the QR image doubles as a copy control */
 "Copy QR code" = "Copy QR code";
+
+/* Diagnostic log export overlay */
+"Preparing logs…" = "Preparing logs…";
+"Collecting wallet diagnostics. This may take a few seconds." = "Collecting wallet diagnostics. This may take a few seconds.";
+
+/* Support: the diagnostic archive could not be produced or read */
+"Logs could not be attached" = "Logs could not be attached";
+"Send Without Logs" = "Send Without Logs";
+"The diagnostic archive could not be read." = "The diagnostic archive could not be read.";
+
+/* Log export */
+"Another wallet operation is in progress. Try again in a moment." = "Another wallet operation is in progress. Try again in a moment.";
+"Log export cancelled." = "Log export cancelled.";

--- a/DashWalletTests/DiagnosticLogExporterTests.swift
+++ b/DashWalletTests/DiagnosticLogExporterTests.swift
@@ -42,6 +42,45 @@ final class DiagnosticLogExporterTests: XCTestCase {
 
     // MARK: - SDK session selection
 
+    @MainActor
+    func testPreparationSnapshotsThenFlushesBeforeCopy() async {
+        var events: [String] = []
+
+        let captured = await DiagnosticLogExporter.prepareLogsForExport(
+            emitDiagnostics: {
+                events.append("snapshot-start")
+                await Task.yield()
+                events.append("snapshot-finished")
+            },
+            flush: {
+                events.append("flush")
+            },
+            capture: {
+                events.append("copy")
+                return "captured"
+            })
+
+        XCTAssertEqual(captured, "captured")
+        XCTAssertEqual(events, [
+            "snapshot-start",
+            "snapshot-finished",
+            "flush",
+            "copy",
+        ])
+    }
+
+    @MainActor
+    func testPreparationStillFlushesWhenThereIsNoRuntimeToSnapshot() async {
+        var events: [String] = []
+
+        _ = await DiagnosticLogExporter.prepareLogsForExport(
+            emitDiagnostics: {},
+            flush: { events.append("flush") },
+            capture: { events.append("copy") })
+
+        XCTAssertEqual(events, ["flush", "copy"])
+    }
+
     func testCurrentSessionIsFirstEvenWhenOlderStampedThanOthers() {
         // A stale future-dated directory sorts lexicographically after
         // the real current session. It must not displace it.

--- a/DashWalletTests/DiagnosticLogExporterTests.swift
+++ b/DashWalletTests/DiagnosticLogExporterTests.swift
@@ -81,6 +81,32 @@ final class DiagnosticLogExporterTests: XCTestCase {
         XCTAssertEqual(events, ["flush", "copy"])
     }
 
+    @MainActor
+    func testSupportExportUsesTheSharedArchiveOnSuccess() async {
+        let expected = URL(fileURLWithPath: "/tmp/diagnostics.zip")
+        var failureWasReported = false
+
+        let archive = await DiagnosticLogExporter.exportArchiveForSupport(
+            using: { .success(expected) },
+            onFailure: { _ in failureWasReported = true })
+
+        XCTAssertEqual(archive, expected)
+        XCTAssertFalse(failureWasReported)
+    }
+
+    @MainActor
+    func testSupportExportFailureHasNoAlternativeAttachment() async {
+        struct ExportFailure: Error {}
+        var failureWasReported = false
+
+        let archive = await DiagnosticLogExporter.exportArchiveForSupport(
+            using: { .failure(ExportFailure()) },
+            onFailure: { _ in failureWasReported = true })
+
+        XCTAssertNil(archive)
+        XCTAssertTrue(failureWasReported)
+    }
+
     func testCurrentSessionIsFirstEvenWhenOlderStampedThanOthers() {
         // A stale future-dated directory sorts lexicographically after
         // the real current session. It must not displace it.

--- a/DashWalletTests/DiagnosticLogExporterTests.swift
+++ b/DashWalletTests/DiagnosticLogExporterTests.swift
@@ -40,9 +40,6 @@ final class DiagnosticLogExporterTests: XCTestCase {
         )
     }
 
-    // MARK: - SDK session selection
-
-    @MainActor
     // MARK: - Lifecycle gate
 
     /// The gate is what makes "no switch under an export" a guarantee: a
@@ -73,24 +70,31 @@ final class DiagnosticLogExporterTests: XCTestCase {
         XCTAssertEqual(state.phase, .idle)
     }
 
-    /// Cancel drops the card now (phase-guarded, so it never clears a phase
-    /// the export does not own) and is a no-op when nothing is exporting.
+    /// Cancel hides the card but keeps the admission: the phase moves to
+    /// `dismissed`, not to idle, so no switch can start under a snapshot that
+    /// may still hold the queue. It is a no-op unless a card is showing.
     @MainActor
-    func testCancelWaitingReleasesOnlyAnExportPhase() {
+    func testCancelWaitingHidesTheCardButKeepsTheAdmission() {
         let state = WalletLifecycleTransitionState.shared
         XCTAssertEqual(state.phase, .idle, "test precondition")
         DiagnosticLogExporter.cancelWaiting()
-        XCTAssertEqual(state.phase, .idle)
+        XCTAssertEqual(state.phase, .idle, "no card, nothing to cancel")
 
-        XCTAssertTrue(state.tryBegin(.exportingDiagnostics))
+        XCTAssertTrue(state.tryBegin(.exportingDiagnostics(dismissed: false)))
         DiagnosticLogExporter.cancelWaiting()
-        XCTAssertEqual(state.phase, .idle)
+        XCTAssertEqual(state.phase, .exportingDiagnostics(dismissed: true))
+        XCTAssertFalse(state.tryBegin(.switchingWallet(targetName: "A")), "still busy after cancel")
+        DiagnosticLogExporter.cancelWaiting()
+        XCTAssertEqual(state.phase, .exportingDiagnostics(dismissed: true), "a second cancel changes nothing")
+        state.finish()
 
         XCTAssertTrue(state.tryBegin(.removingWallet))
         DiagnosticLogExporter.cancelWaiting()
         XCTAssertEqual(state.phase, .removingWallet, "cancel must not touch another operation's phase")
         state.finish()
     }
+
+    // MARK: - SDK session selection
 
     func testCurrentSessionIsFirstEvenWhenOlderStampedThanOthers() {
         // A stale future-dated directory sorts lexicographically after

--- a/DashWalletTests/DiagnosticLogExporterTests.swift
+++ b/DashWalletTests/DiagnosticLogExporterTests.swift
@@ -45,6 +45,11 @@ final class DiagnosticLogExporterTests: XCTestCase {
     /// The gate is what makes "no switch under an export" a guarantee: a
     /// busy lifecycle phase refuses the export, and the refusal must leave
     /// that phase untouched.
+    ///
+    /// `includingWalletSnapshot: true` is the only configuration this can be
+    /// asked of, and the only one where it means anything: the gate exists
+    /// because the snapshot holds the SDK's persistence queue, so an export
+    /// that takes no snapshot takes no phase either and runs regardless.
     @MainActor
     func testExportIsRefusedWhileAnotherLifecycleOperationIsBusy() async {
         let state = WalletLifecycleTransitionState.shared
@@ -52,7 +57,7 @@ final class DiagnosticLogExporterTests: XCTestCase {
         XCTAssertTrue(state.tryBegin(.switchingWallet(targetName: "A")))
         defer { state.finish() }
 
-        let result = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: false)
+        let result = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: true)
         guard case .failure(let error) = result else {
             return XCTFail("an export under a wallet switch must be refused")
         }
@@ -66,8 +71,30 @@ final class DiagnosticLogExporterTests: XCTestCase {
     func testExportReleasesTheGateWhenItReturns() async {
         let state = WalletLifecycleTransitionState.shared
         XCTAssertEqual(state.phase, .idle, "test precondition")
-        _ = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: false)
+        _ = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: true)
         XCTAssertEqual(state.phase, .idle)
+    }
+
+    /// An export that takes no snapshot takes no phase: it never touches the
+    /// SDK's persistence queue, so gating it would freeze the app behind a
+    /// scrim for a directory copy and refuse it under any switch — which is
+    /// what the About and Tools exports did before this branch, and do again.
+    @MainActor
+    func testAnExportWithoutASnapshotIsNeitherGatedNorGating() async {
+        let state = WalletLifecycleTransitionState.shared
+        XCTAssertEqual(state.phase, .idle, "test precondition")
+        XCTAssertTrue(state.tryBegin(.switchingWallet(targetName: "A")))
+        defer { state.finish() }
+
+        let result = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: false)
+        if case .failure(let error) = result {
+            XCTAssertNotEqual(
+                error as? DiagnosticLogExportError,
+                .anotherOperationInProgress,
+                "an ungated export must never consult the lifecycle gate"
+            )
+        }
+        XCTAssertEqual(state.phase, .switchingWallet(targetName: "A"), "and must not touch it")
     }
 
     /// Cancel hides the card but keeps the admission: the phase moves to

--- a/DashWalletTests/DiagnosticLogExporterTests.swift
+++ b/DashWalletTests/DiagnosticLogExporterTests.swift
@@ -80,12 +80,12 @@ final class DiagnosticLogExporterTests: XCTestCase {
         DiagnosticLogExporter.cancelWaiting()
         XCTAssertEqual(state.phase, .idle, "no card, nothing to cancel")
 
-        XCTAssertTrue(state.tryBegin(.exportingDiagnostics(dismissed: false)))
+        XCTAssertTrue(state.tryBegin(.exportingDiagnostics(dismissed: false, generation: 7)))
         DiagnosticLogExporter.cancelWaiting()
-        XCTAssertEqual(state.phase, .exportingDiagnostics(dismissed: true))
+        XCTAssertEqual(state.phase, .exportingDiagnostics(dismissed: true, generation: 7), "same owner, now dismissed")
         XCTAssertFalse(state.tryBegin(.switchingWallet(targetName: "A")), "still busy after cancel")
         DiagnosticLogExporter.cancelWaiting()
-        XCTAssertEqual(state.phase, .exportingDiagnostics(dismissed: true), "a second cancel changes nothing")
+        XCTAssertEqual(state.phase, .exportingDiagnostics(dismissed: true, generation: 7), "a second cancel changes nothing")
         state.finish()
 
         XCTAssertTrue(state.tryBegin(.removingWallet))

--- a/DashWalletTests/DiagnosticLogExporterTests.swift
+++ b/DashWalletTests/DiagnosticLogExporterTests.swift
@@ -43,68 +43,53 @@ final class DiagnosticLogExporterTests: XCTestCase {
     // MARK: - SDK session selection
 
     @MainActor
-    func testPreparationSnapshotsThenFlushesBeforeCopy() async {
-        var events: [String] = []
+    // MARK: - Lifecycle gate
 
-        let captured = await DiagnosticLogExporter.prepareLogsForExport(
-            emitDiagnostics: {
-                events.append("snapshot-start")
-                await Task.yield()
-                events.append("snapshot-finished")
-            },
-            flush: {
-                events.append("flush")
-            },
-            capture: {
-                events.append("copy")
-                return "captured"
-            })
+    /// The gate is what makes "no switch under an export" a guarantee: a
+    /// busy lifecycle phase refuses the export, and the refusal must leave
+    /// that phase untouched.
+    @MainActor
+    func testExportIsRefusedWhileAnotherLifecycleOperationIsBusy() async {
+        let state = WalletLifecycleTransitionState.shared
+        XCTAssertEqual(state.phase, .idle, "test precondition")
+        XCTAssertTrue(state.tryBegin(.switchingWallet(targetName: "A")))
+        defer { state.finish() }
 
-        XCTAssertEqual(captured, "captured")
-        XCTAssertEqual(events, [
-            "snapshot-start",
-            "snapshot-finished",
-            "flush",
-            "copy",
-        ])
+        let result = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: false)
+        guard case .failure(let error) = result else {
+            return XCTFail("an export under a wallet switch must be refused")
+        }
+        XCTAssertEqual(error as? DiagnosticLogExportError, .anotherOperationInProgress)
+        XCTAssertEqual(state.phase, .switchingWallet(targetName: "A"))
     }
 
+    /// Whatever the export returns — an archive, or `noLogsFound` on a host
+    /// with no sessions — the phase it took is released when it returns.
     @MainActor
-    func testPreparationStillFlushesWhenThereIsNoRuntimeToSnapshot() async {
-        var events: [String] = []
-
-        _ = await DiagnosticLogExporter.prepareLogsForExport(
-            emitDiagnostics: {},
-            flush: { events.append("flush") },
-            capture: { events.append("copy") })
-
-        XCTAssertEqual(events, ["flush", "copy"])
+    func testExportReleasesTheGateWhenItReturns() async {
+        let state = WalletLifecycleTransitionState.shared
+        XCTAssertEqual(state.phase, .idle, "test precondition")
+        _ = await DiagnosticLogExporter.exportArchive(includingWalletSnapshot: false)
+        XCTAssertEqual(state.phase, .idle)
     }
 
+    /// Cancel drops the card now (phase-guarded, so it never clears a phase
+    /// the export does not own) and is a no-op when nothing is exporting.
     @MainActor
-    func testSupportExportUsesTheSharedArchiveOnSuccess() async {
-        let expected = URL(fileURLWithPath: "/tmp/diagnostics.zip")
-        var failureWasReported = false
+    func testCancelWaitingReleasesOnlyAnExportPhase() {
+        let state = WalletLifecycleTransitionState.shared
+        XCTAssertEqual(state.phase, .idle, "test precondition")
+        DiagnosticLogExporter.cancelWaiting()
+        XCTAssertEqual(state.phase, .idle)
 
-        let archive = await DiagnosticLogExporter.exportArchiveForSupport(
-            using: { .success(expected) },
-            onFailure: { _ in failureWasReported = true })
+        XCTAssertTrue(state.tryBegin(.exportingDiagnostics))
+        DiagnosticLogExporter.cancelWaiting()
+        XCTAssertEqual(state.phase, .idle)
 
-        XCTAssertEqual(archive, expected)
-        XCTAssertFalse(failureWasReported)
-    }
-
-    @MainActor
-    func testSupportExportFailureHasNoAlternativeAttachment() async {
-        struct ExportFailure: Error {}
-        var failureWasReported = false
-
-        let archive = await DiagnosticLogExporter.exportArchiveForSupport(
-            using: { .failure(ExportFailure()) },
-            onFailure: { _ in failureWasReported = true })
-
-        XCTAssertNil(archive)
-        XCTAssertTrue(failureWasReported)
+        XCTAssertTrue(state.tryBegin(.removingWallet))
+        DiagnosticLogExporter.cancelWaiting()
+        XCTAssertEqual(state.phase, .removingWallet, "cancel must not touch another operation's phase")
+        state.finish()
     }
 
     func testCurrentSessionIsFirstEvenWhenOlderStampedThanOthers() {

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -135,6 +135,43 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertFalse(mainnetFirst.value === testnet.value)
     }
 
+    func testStoreOpenMetadataReportsMissingStoreWithoutInventingSize() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("DashModel.sqlite")
+
+        XCTAssertEqual(
+            SwiftDashSDKHost.storeOpenMetadata(at: url),
+            CoreStoreOpenMetadata(
+                existedBeforeOpen: false,
+                sizeBytesBefore: 0,
+                mainStoreSizeBytesBefore: 0,
+                walSizeBytesBefore: 0,
+                sharedMemorySizeBytesBefore: 0))
+    }
+
+    func testStoreOpenMetadataReportsExistingStoreSize() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CoreStoreOpenMetadataTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("DashModel.sqlite")
+        try Data(repeating: 0x5a, count: 37).write(to: url)
+        try Data(repeating: 0x5b, count: 11).write(to: URL(fileURLWithPath: url.path + "-wal"))
+        try Data(repeating: 0x5c, count: 7).write(to: URL(fileURLWithPath: url.path + "-shm"))
+
+        XCTAssertEqual(
+            SwiftDashSDKHost.storeOpenMetadata(at: url),
+            CoreStoreOpenMetadata(
+                existedBeforeOpen: true,
+                sizeBytesBefore: 55,
+                mainStoreSizeBytesBefore: 37,
+                walSizeBytesBefore: 11,
+                sharedMemorySizeBytesBefore: 7))
+    }
+
     func testSameSeedIdentityRecoveryDiscoversRefreshesAndAdoptsInOneRun() async throws {
         let identityId = Data(repeating: 0x16, count: 32)
         var storedIdentityIds: [Data] = []

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -135,43 +135,6 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertFalse(mainnetFirst.value === testnet.value)
     }
 
-    func testStoreOpenMetadataReportsMissingStoreWithoutInventingSize() {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-            .appendingPathComponent("DashModel.sqlite")
-
-        XCTAssertEqual(
-            SwiftDashSDKHost.storeOpenMetadata(at: url),
-            CoreStoreOpenMetadata(
-                existedBeforeOpen: false,
-                sizeBytesBefore: 0,
-                mainStoreSizeBytesBefore: 0,
-                walSizeBytesBefore: 0,
-                sharedMemorySizeBytesBefore: 0))
-    }
-
-    func testStoreOpenMetadataReportsExistingStoreSize() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("CoreStoreOpenMetadataTests-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        try FileManager.default.createDirectory(
-            at: directory,
-            withIntermediateDirectories: true)
-        let url = directory.appendingPathComponent("DashModel.sqlite")
-        try Data(repeating: 0x5a, count: 37).write(to: url)
-        try Data(repeating: 0x5b, count: 11).write(to: URL(fileURLWithPath: url.path + "-wal"))
-        try Data(repeating: 0x5c, count: 7).write(to: URL(fileURLWithPath: url.path + "-shm"))
-
-        XCTAssertEqual(
-            SwiftDashSDKHost.storeOpenMetadata(at: url),
-            CoreStoreOpenMetadata(
-                existedBeforeOpen: true,
-                sizeBytesBefore: 55,
-                mainStoreSizeBytesBefore: 37,
-                walSizeBytesBefore: 11,
-                sharedMemorySizeBytesBefore: 7))
-    }
-
     func testSameSeedIdentityRecoveryDiscoversRefreshesAndAdoptsInOneRun() async throws {
         let identityId = Data(repeating: 0x16, count: 32)
         var storedIdentityIds: [Data] = []

--- a/DashWalletTests/WalletLifecycleTransitionStateTests.swift
+++ b/DashWalletTests/WalletLifecycleTransitionStateTests.swift
@@ -25,7 +25,7 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
         ("removingWallet", .removingWallet),
         ("addingWallet", .addingWallet(isImport: false)),
         ("wiping", .wiping(title: nil)),
-        ("exportingDiagnostics", .exportingDiagnostics(dismissed: false)),
+        ("exportingDiagnostics", .exportingDiagnostics(dismissed: false, generation: 0)),
     ]
 
     private static let failures: [(label: String, phase: Phase)] = [
@@ -105,8 +105,8 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
     /// still busy: nothing begins under it except the reset route.
     func testDismissedExportStaysBusyExceptForWipe() {
         for (nextLabel, next) in Self.begins {
-            let state = makeState(in: .exportingDiagnostics(dismissed: false))
-            state.advance(to: .exportingDiagnostics(dismissed: true))
+            let state = makeState(in: .exportingDiagnostics(dismissed: false, generation: 0))
+            state.advance(to: .exportingDiagnostics(dismissed: true, generation: 0))
             XCTAssertEqual(
                 state.tryBegin(next), nextLabel == "wiping",
                 "dismissed export → \(nextLabel)")

--- a/DashWalletTests/WalletLifecycleTransitionStateTests.swift
+++ b/DashWalletTests/WalletLifecycleTransitionStateTests.swift
@@ -25,6 +25,7 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
         ("removingWallet", .removingWallet),
         ("addingWallet", .addingWallet(isImport: false)),
         ("wiping", .wiping(title: nil)),
+        ("exportingDiagnostics", .exportingDiagnostics),
     ]
 
     private static let failures: [(label: String, phase: Phase)] = [
@@ -39,7 +40,8 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
         switch phase {
         case .idle:
             break
-        case .switchingNetwork, .switchingWallet, .removingWallet, .wiping:
+        case .switchingNetwork, .switchingWallet, .removingWallet, .addingWallet,
+             .wiping, .exportingDiagnostics:
             XCTAssertTrue(state.tryBegin(phase), "test setup: begin from idle must admit")
         case .failedNetworkSwitch, .failedWalletSwitch, .failedWalletRemoval:
             state.fail(phase)

--- a/DashWalletTests/WalletLifecycleTransitionStateTests.swift
+++ b/DashWalletTests/WalletLifecycleTransitionStateTests.swift
@@ -60,12 +60,14 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
     }
 
     /// No begin is admitted while any operation is busy — except the add
-    /// flow's own composite continuation into its post-add switch.
+    /// flow's own composite continuation into its post-add switch, and the
+    /// reset route out of an export, whose duration the app cannot bound.
     func testBusyPhasesRejectEveryBegin() {
         for (busyLabel, busy) in Self.begins {
             for (nextLabel, next) in Self.begins {
                 let state = makeState(in: busy)
-                let expected = busyLabel == "addingWallet" && nextLabel == "switchingWallet"
+                let expected = (busyLabel == "addingWallet" && nextLabel == "switchingWallet")
+                    || (busyLabel == "exportingDiagnostics" && nextLabel == "wiping")
                 XCTAssertEqual(
                     state.tryBegin(next), expected,
                     "\(busyLabel) → \(nextLabel): expected admitted=\(expected)")

--- a/DashWalletTests/WalletLifecycleTransitionStateTests.swift
+++ b/DashWalletTests/WalletLifecycleTransitionStateTests.swift
@@ -25,7 +25,7 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
         ("removingWallet", .removingWallet),
         ("addingWallet", .addingWallet(isImport: false)),
         ("wiping", .wiping(title: nil)),
-        ("exportingDiagnostics", .exportingDiagnostics),
+        ("exportingDiagnostics", .exportingDiagnostics(dismissed: false)),
     ]
 
     private static let failures: [(label: String, phase: Phase)] = [
@@ -98,6 +98,18 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
                     state.tryBegin(next), expected,
                     "\(failureLabel) → \(nextLabel): expected admitted=\(expected)")
             }
+        }
+    }
+
+    /// A dismissed export — the card gone, the export still running — is
+    /// still busy: nothing begins under it except the reset route.
+    func testDismissedExportStaysBusyExceptForWipe() {
+        for (nextLabel, next) in Self.begins {
+            let state = makeState(in: .exportingDiagnostics(dismissed: false))
+            state.advance(to: .exportingDiagnostics(dismissed: true))
+            XCTAssertEqual(
+                state.tryBegin(next), nextLabel == "wiping",
+                "dismissed export → \(nextLabel)")
         }
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Adds the DashWallet integration needed to capture Core wallet diagnostics from the affected device immediately before support logs are archived.

Depends on dashpay/platform#4580.

## What was done?

- Pins the active SDK manager, wallet ID, and network before the asynchronous diagnostic snapshot.
- Calls `emitCoreWalletDiagnostics(for:)`, flushes `swift/run.log`, and only then captures and copies the log files.
- Opens the app-owned SwiftData store through `DashModelContainer.open(_:)` (public since platform `e27c0249`) instead of a bare `ModelContainer(for:configurations:)`. That is where the SDK emits `core_store_open_result` (existence, main/WAL/SHM sizes, duration, `migration_path`) and `core_store_staged_migration_failed`, once per real open; the host no longer emits its own copy of that event. It is also what lets a v4.2.0-dev.1 store — rejected by the staged plan as an unknown version until the remaining V1/V2 shapes are frozen — open through inferred migration instead of failing at launch.
- Runs the export behind the app-wide wallet-lifecycle overlay (`WalletLifecycleOverlayPresenter`, new phase `.exportingDiagnostics`) — the same blocking window a wallet switch or creation uses, under the same admission gate: the export cannot start under a switch in flight and no switch can start under it; a refused gate surfaces as `DiagnosticLogExportError.anotherOperationInProgress`. The card has **Cancel**: it hides the card, but the phase moves to `.exportingDiagnostics(dismissed: true, generation:)` and stays busy — the admission is released only when `exportArchive()` returns, because the snapshot may still hold the persistence queue and the pinned manager. The phase carries the export's generation: release and delivery happen only if the phase is still that export's own undismissed phase, so a cancelled export superseded by a wipe neither opens a successor's gate when it returns nor delivers an archive of a wallet the wipe removed. `.wiping` is admitted from the export phase, dismissed or not, so Reset stays reachable. The SDK persistence queue is held only during the wallet snapshot; the card covers the rest of the export so the user does not start a second one. The overlay presenter now applies phases synchronously on the main actor, so a screen presented right after `finish()` never lands under the scrim.
- The Core-wallet snapshot is support-only: `exportArchive(includingWalletSnapshot:)` is `true` from the support composer and `false` from the About shake and the Tools row, which are back to plain file copy + zip.
- Support composer: a re-entrancy guard; on export failure an alert with the error and **Send Without Logs** / **Cancel** instead of a silent log-less email; archives over 25 MB — or of unreadable size — go through the share sheet by URL instead of a mail attachment that fails at send time; the attachment read runs off the main actor, and a failed read gets the same alert instead of a log-less composer.
- Both log streams are flushed before capture, off the main actor: `SDKLogger.flush()` and the new `DWLogger.flush()` (`[DDLog flushLog]`) run in the detached task together with the app-log listing. Copies are best-effort per item, with anything skipped named in `summary.txt`; only nothing copied at all is a failure.
- A store written by a newer build is refused by the SDK as `DashModelContainerError.storeFromNewerBuild` (platform `7fd84c0b`), whose message tells the user to update or reset; the host logs it as a deliberate refusal.
- Tests cover the lifecycle gate (refused under a busy phase and the phase left untouched; released on return; Cancel releases only an export phase) and the admission matrix including the export phase. The store-metadata tests went with the host-side measurement they covered; the SDK's `Dev1StoreUpgradeTests` pin the open path.
- Does not add repair UI, rescan behavior, or future-sweep tracing.

## How Has This Been Tested?

- `git diff --check` passed.
- All changed Swift sources and tests passed Swift parse checks.
- The linked SwiftDashSDK build-for-testing and 12 targeted diagnostic tests passed.
- The canonical `dashpay` build from `CLAUDE.md` (`-sdk iphonesimulator -destination 'generic/platform=iOS Simulator' ARCHS=arm64`) succeeds with the `DashModelContainer.open` and lifecycle-overlay changes; the only warnings in the touched host file are two pre-existing `logger` isolation warnings outside the changed hunks.
- The `dashwallet` scheme is blocked before app compilation on this Mac by the embedded Watch app's watchOS runtime requirement, and the unit-test target is documented as broken on this branch, so the removed store-metadata tests are verified by the absence of any remaining reference rather than by a run. Not done here: the testnet smoke of the export flow, which needs a device with a wallet. The TestFlight workflow provides the archive validation.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cancellable progress feedback during diagnostic archive creation.
  - Support exports can optionally include a wallet snapshot; standard log exports exclude it.
  - Archives are routed to email or the share sheet based on size, with oversized files shared directly.
  - Added a “Send Without Logs” option when archive creation fails.

- **Bug Fixes**
  - Prevented overlapping diagnostic exports and wallet transitions.
  - Improved archive reliability by ensuring the latest log entries are included.
  - Cancelled exports now end cleanly without displaying an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




