### PR TITLE
fix(wallet): log the two wallet-startup outcomes added by the SDK

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -94,6 +94,29 @@ enum DashPayContactAddressReadiness {
                 👥 DP-READY :: identity discovery failed locally after \
                 \(seconds, privacy: .public)s; starting SPV without DashPay state
                 """)
+        case .seedBindingUnverified:
+            // The signer handed to the call belongs to a different wallet, so
+            // the drain derived nothing rather than write contact addresses
+            // from the wrong seed. A rerun with the right signer completes the
+            // work, which stays queued — hence warning, not error.
+            logger.warning(
+                """
+                👥 DP-READY :: contact crypto could not verify this wallet's seed \
+                after \(seconds, privacy: .public)s; starting SPV, contact accounts \
+                stay queued for a run with the matching signer
+                """)
+        case .identityScanIncomplete:
+            // Every later step ran for the identity that is known, but the
+            // gap-limit scan left indices unanswered, so the identity set is
+            // not established. The verdict stays on record and the next launch
+            // re-scans instead of taking the warm shortcut.
+            logger.warning(
+                """
+                👥 DP-READY :: identity scan left indices unanswered after \
+                \(seconds, privacy: .public)s \
+                scans=\(outcome.discoveryAttempts, privacy: .public); \
+                starting SPV, the next start re-scans
+                """)
         }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

`develop` does not compile against the current `v4.2-dev`. `WalletStartupStatus` gained two cases — `seedBindingUnverified` and `identityScanIncomplete` — and the DashPay readiness log switches over it exhaustively:

```
DashPayContactAddressReadiness.swift:61:9: error: switch must be exhaustive
```

Reproduced by building `develop`'s copy of the file against `v4.2-dev` head; restoring this change is what makes the build pass again.

## What was done?

Logs the two new outcomes, in the shape the neighbouring cases already use.

Both are warnings rather than errors. `discoveryFailed` next to them is logged at error precisely because it is a local fault that nothing in this session or the next will clear on its own; these two are not that:

- `seedBindingUnverified` — the signer handed to the call belongs to a different wallet, so the contact-account drain derived nothing rather than write receiving addresses from the wrong seed. The work stays queued and a rerun with the matching signer completes it.
- `identityScanIncomplete` — the contact sync and drain both ran for the identity that is known, but the gap-limit scan left indices unanswered, so the identity set is not established. The verdict stays on record and the next launch re-scans instead of taking the warm shortcut.

## How Has This Been Tested?

`xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator ARCHS=arm64` against `v4.2-dev` head: fails with the error above using `develop`'s file, succeeds with this change. No behaviour outside the log statements is touched.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [ ] I have assigned this pull request to a milestone
