### PR TITLE
perf(wallet): stop scanning Platform identity twice on wallet switch

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -22,10 +22,15 @@ import SwiftDashSDK
 /// contacts and contact accounts up first means the very first filter set
 /// already covers them.
 ///
-/// The sequence itself — including the discovery retry policy and the budget —
-/// lives in the SDK (`PlatformWalletManager.startWalletSubsystems`), so iOS and
-/// Android share one implementation and one set of tests. This file is the call
-/// site and its logging; it deliberately holds no ordering logic of its own.
+/// The sequence itself — including the discovery retry policy and the default
+/// budget — lives in the SDK (`PlatformWalletManager.startWalletSubsystems`),
+/// so iOS and Android share one implementation and one set of tests. This
+/// file holds no ordering logic of its own; what it does decide, app-side, is
+/// the budget handed to that sequence for a wallet generated on this device
+/// (`StartupIdentityRecoveryPolicy`, keyed on `GeneratedWalletIdentityMarker`)
+/// and the handoff of the outcome to `DWSameSeedIdentityRecoveryCoordinator`.
+/// TODO(platform-wallet): carry "generated on this device" on the wallet
+/// record so the short-budget probe moves into the shared Rust sequence.
 ///
 /// `reconcile_dashpay_rescan` (DIP-15 §12.6) stays load-bearing regardless:
 /// contacts established later in a session, or on a later day, always arrive
@@ -47,24 +52,38 @@ enum DashPayContactAddressReadiness {
         network: Network
     ) async {
         // A mnemonic generated on this device with no local identity gets a
-        // short budget instead of the SDK default; the verdict then goes to
-        // the same-seed recovery coordinator so the BLAST-side backstop does
-        // not repeat the discovery this pass just ran.
+        // short budget instead of the SDK default. That budget caps the
+        // whole sequence, so it only serves as a probe: when the probe DOES
+        // find an identity, the marker is dropped and the sequence runs
+        // again with the default budget — the identity is local by then, so
+        // the second run skips discovery and spends its budget on the
+        // contact sync and the contact-account drain that the first one cut
+        // short. The final verdict goes to the same-seed recovery
+        // coordinator so the BLAST-side backstop does not repeat the
+        // discovery this pass just ran.
         let recovery = DWSameSeedIdentityRecoveryCoordinator.shared
-        let budget = SwiftDashSDKHost.shared.modelContainer.flatMap {
-            recovery.startupBudget(walletId: wallet.walletId, modelContainer: $0)
+        let walletId = wallet.walletId
+        let probeBudget = SwiftDashSDKHost.shared.modelContainer.flatMap {
+            recovery.startupBudget(walletId: walletId, modelContainer: $0)
         }
-        if let budget {
+        if let probeBudget {
             logger.info(
-                "👥 DP-READY :: wallet generated on this device, no local identity — budget \(Int(budget), privacy: .public)s")
+                "👥 DP-READY :: wallet generated on this device, no local identity — budget \(Int(probeBudget), privacy: .public)s")
         }
         do {
-            let outcome = try await manager.startWalletSubsystems(wallet: wallet, budget: budget)
+            var outcome = try await manager.startWalletSubsystems(wallet: wallet, budget: probeBudget)
             log(outcome, network: network)
+            if probeBudget != nil, outcome.identityId != nil {
+                GeneratedWalletIdentityMarker.clear(walletId: walletId)
+                logger.info(
+                    "👥 DP-READY :: probe found an identity for a generated wallet — re-running with the default budget")
+                outcome = try await manager.startWalletSubsystems(wallet: wallet)
+                log(outcome, network: network)
+            }
             recovery.recordStartupDiscovery(
                 status: outcome.status,
                 identityId: outcome.identityId,
-                walletId: wallet.walletId,
+                walletId: walletId,
                 network: network)
         } catch {
             logger.warning(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -46,9 +46,26 @@ enum DashPayContactAddressReadiness {
         wallet: ManagedPlatformWallet,
         network: Network
     ) async {
+        // A mnemonic generated on this device with no local identity gets a
+        // short budget instead of the SDK default; the verdict then goes to
+        // the same-seed recovery coordinator so the BLAST-side backstop does
+        // not repeat the discovery this pass just ran.
+        let recovery = DWSameSeedIdentityRecoveryCoordinator.shared
+        let budget = SwiftDashSDKHost.shared.modelContainer.flatMap {
+            recovery.startupBudget(walletId: wallet.walletId, modelContainer: $0)
+        }
+        if let budget {
+            logger.info(
+                "👥 DP-READY :: wallet generated on this device, no local identity — budget \(Int(budget), privacy: .public)s")
+        }
         do {
-            let outcome = try await manager.startWalletSubsystems(wallet: wallet)
+            let outcome = try await manager.startWalletSubsystems(wallet: wallet, budget: budget)
             log(outcome, network: network)
+            recovery.recordStartupDiscovery(
+                status: outcome.status,
+                identityId: outcome.identityId,
+                walletId: wallet.walletId,
+                network: network)
         } catch {
             logger.warning(
                 "👥 DP-READY :: bring-up failed; starting SPV anyway: \(String(describing: error), privacy: .public)")

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -91,7 +91,16 @@ enum DashPayContactAddressReadiness {
                 GeneratedWalletIdentityMarker.clear(walletId: walletId)
                 if StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
                     identityFound: true,
-                    budgetExhausted: outcome.elapsed >= probeBudget - 0.5,
+                    // No slack on purpose: the SDK reports no "deadline
+                    // fired" flag, so this is an approximation, and the two
+                    // ways it can be wrong are not equal. A false positive
+                    // costs a second full-budget sequence on the switch
+                    // path; a false negative leaves the contact steps to the
+                    // DIP-15 rescan, the fallback this pass documents
+                    // anyway. Erring towards the cheap side.
+                    // TODO(platform-wallet): expose a deadline-fired flag on
+                    // `WalletStartupOutcome` and use it here.
+                    budgetExhausted: outcome.elapsed >= probeBudget,
                     dashPaySyncRan: outcome.dashPaySyncRan,
                     contactAccountsPending: outcome.contactAccountsPending,
                     seedBindingUnverified: outcome.seedBindingUnverified,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -131,7 +131,12 @@ enum DashPayContactAddressReadiness {
             recovery.recordStartupDiscovery(
                 status: outcome.status,
                 identityId: outcome.identityId,
-                discoveredThisStart: outcome.identityId != nil && hadLocalIdentity != true,
+                // `hadLocalIdentity == false`, not `!= true`: an
+                // inconclusive lookup must not be read as "the wallet had
+                // none", which would claim a first sight and send every
+                // later switch past the settled memo into the DPNS refresh.
+                // Same conservative reading `startupBudget` uses.
+                discoveredThisStart: outcome.identityId != nil && hadLocalIdentity == false,
                 walletId: walletId,
                 network: network)
         } catch {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -72,6 +72,11 @@ enum DashPayContactAddressReadiness {
         }
         do {
             var outcome = try await manager.startWalletSubsystems(wallet: wallet, budget: probeBudget)
+            // Captured before a re-run can replace `outcome`: the re-run reuses
+            // the identity the probe just persisted (`discoveryAttempts == 0`),
+            // and the coordinator must still see this start as the identity's
+            // first sight on this install.
+            var discoveredThisStart = outcome.discoveryAttempts > 0
             if probeBudget != nil, outcome.identityId != nil {
                 // The seed owns an identity after all: the probe budget must
                 // never apply to this wallet again, whether or not the probe
@@ -85,13 +90,14 @@ enum DashPayContactAddressReadiness {
                     logger.info(
                         "👥 DP-READY :: probe found an identity but was cut short — re-running with the default budget")
                     outcome = try await manager.startWalletSubsystems(wallet: wallet)
+                    discoveredThisStart = discoveredThisStart || outcome.discoveryAttempts > 0
                 }
             }
             log(outcome, network: network, phase: .verdict)
             recovery.recordStartupDiscovery(
                 status: outcome.status,
                 identityId: outcome.identityId,
-                discoveredThisStart: outcome.discoveryAttempts > 0,
+                discoveredThisStart: discoveredThisStart,
                 walletId: walletId,
                 network: network)
         } catch {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -86,12 +86,21 @@ enum DashPayContactAddressReadiness {
                 if StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
                     identityFound: true,
                     dashPaySyncRan: outcome.dashPaySyncRan,
-                    contactAccountsPending: outcome.contactAccountsPending) {
+                    contactAccountsPending: outcome.contactAccountsPending,
+                    seedBindingUnverified: outcome.seedBindingUnverified) {
                     log(outcome, network: network, phase: .probe)
                     logger.info(
                         "👥 DP-READY :: probe found an identity but was cut short — re-running with the default budget")
-                    outcome = try await manager.startWalletSubsystems(wallet: wallet)
-                    discoveredThisStart = discoveredThisStart || outcome.discoveryAttempts > 0
+                    // A re-run that throws (a manager unconfigured mid-switch,
+                    // a locked Keychain) must not cost the probe's verdict:
+                    // the identity it found is still the start's answer.
+                    do {
+                        outcome = try await manager.startWalletSubsystems(wallet: wallet)
+                        discoveredThisStart = discoveredThisStart || outcome.discoveryAttempts > 0
+                    } catch {
+                        logger.warning(
+                            "👥 DP-READY :: default-budget re-run failed; keeping the probe verdict: \(String(describing: error), privacy: .public)")
+                    }
                 }
             }
             log(outcome, network: network, phase: .verdict)
@@ -132,13 +141,14 @@ enum DashPayContactAddressReadiness {
                 "\(tag, privacy: .public)no identity for this seed; nothing to prepare before SPV")
         case .partialNoIdentity:
             // Not an error: Platform (or the scan key) was unreachable, so the
-            // question is still open; the same-seed recovery backstop asks
-            // again in this start, and the next runtime start asks again too.
+            // question is still open. The same-seed recovery backstop asks
+            // again in this start unless this wallet was already settled in
+            // this process; every runtime start asks the SDK again.
             logger.warning(
                 """
                 \(tag, privacy: .public)could not reach Platform in \(seconds, privacy: .public)s \
                 after \(outcome.discoveryAttempts, privacy: .public) scan(s); \
-                starting SPV, the same-seed recovery backstop retries in this start
+                starting SPV, the recovery backstop retries unless already settled this process
                 """)
         case .partialAccountsPending:
             logger.warning(
@@ -150,13 +160,14 @@ enum DashPayContactAddressReadiness {
         case .discoveryFailed:
             // A local wallet/persistence fault, not the network. Logged at
             // error because a retry of the same sequence will not clear it;
-            // the same-seed recovery backstop still tries its own discovery
-            // entry point in this start.
+            // the same-seed recovery backstop tries its own discovery entry
+            // point in this start unless this wallet was already settled in
+            // this process.
             logger.error(
                 """
                 \(tag, privacy: .public)identity discovery failed locally after \
-                \(seconds, privacy: .public)s; starting SPV, the same-seed recovery \
-                backstop retries with its own scan
+                \(seconds, privacy: .public)s; starting SPV, the recovery backstop \
+                retries with its own scan unless already settled this process
                 """)
         case .seedBindingUnverified:
             // Never derive contact addresses when the available seed cannot be

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -72,17 +72,26 @@ enum DashPayContactAddressReadiness {
         }
         do {
             var outcome = try await manager.startWalletSubsystems(wallet: wallet, budget: probeBudget)
-            log(outcome, network: network)
             if probeBudget != nil, outcome.identityId != nil {
+                // The seed owns an identity after all: the probe budget must
+                // never apply to this wallet again, whether or not the probe
+                // itself completed.
                 GeneratedWalletIdentityMarker.clear(walletId: walletId)
-                logger.info(
-                    "👥 DP-READY :: probe found an identity for a generated wallet — re-running with the default budget")
-                outcome = try await manager.startWalletSubsystems(wallet: wallet)
-                log(outcome, network: network)
+                if StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
+                    identityFound: true,
+                    dashPaySyncRan: outcome.dashPaySyncRan,
+                    contactAccountsPending: outcome.contactAccountsPending) {
+                    log(outcome, network: network, phase: .probe)
+                    logger.info(
+                        "👥 DP-READY :: probe found an identity but was cut short — re-running with the default budget")
+                    outcome = try await manager.startWalletSubsystems(wallet: wallet)
+                }
             }
+            log(outcome, network: network, phase: .verdict)
             recovery.recordStartupDiscovery(
                 status: outcome.status,
                 identityId: outcome.identityId,
+                discoveredThisStart: outcome.discoveryAttempts > 0,
                 walletId: walletId,
                 network: network)
         } catch {
@@ -91,33 +100,42 @@ enum DashPayContactAddressReadiness {
         }
     }
 
-    private static func log(_ outcome: WalletStartupOutcome, network: Network) {
+    /// Which pass a DP-READY line describes: the start's verdict, or the
+    /// short-budget probe that preceded a default-budget re-run. One start
+    /// logs at most one `.verdict` line.
+    private enum LogPhase {
+        case verdict
+        case probe
+    }
+
+    private static func log(_ outcome: WalletStartupOutcome, network: Network, phase: LogPhase) {
         let seconds = String(format: "%.1f", outcome.elapsed)
+        let tag = phase == .probe ? "👥 DP-READY (probe) :: " : "👥 DP-READY :: "
 
         switch outcome.status {
         case .ready:
             logger.info(
                 """
-                👥 DP-READY :: ready for SPV in \(seconds, privacy: .public)s \
+                \(tag, privacy: .public)ready for SPV in \(seconds, privacy: .public)s \
                 scans=\(outcome.discoveryAttempts, privacy: .public) \
                 drained=\(outcome.contactAccountsDrained, privacy: .public)
                 """)
         case .noIdentity:
             logger.info(
-                "👥 DP-READY :: no identity for this seed; nothing to prepare before SPV")
+                "\(tag, privacy: .public)no identity for this seed; nothing to prepare before SPV")
         case .partialNoIdentity:
             // Not an error: Platform was unreachable, so the question is still
             // open and the next runtime start asks again.
             logger.warning(
                 """
-                👥 DP-READY :: could not reach Platform in \(seconds, privacy: .public)s \
+                \(tag, privacy: .public)could not reach Platform in \(seconds, privacy: .public)s \
                 after \(outcome.discoveryAttempts, privacy: .public) scan(s); \
                 starting SPV, identity recovery retries on the next start
                 """)
         case .partialAccountsPending:
             logger.warning(
                 """
-                👥 DP-READY :: \(outcome.contactAccountsPending, privacy: .public) contact \
+                \(tag, privacy: .public)\(outcome.contactAccountsPending, privacy: .public) contact \
                 account build(s) still queued after \(seconds, privacy: .public)s; \
                 starting SPV, the DIP-15 rescan will backfill
                 """)
@@ -127,7 +145,7 @@ enum DashPayContactAddressReadiness {
             // session or the next will clear it on its own.
             logger.error(
                 """
-                👥 DP-READY :: identity discovery failed locally after \
+                \(tag, privacy: .public)identity discovery failed locally after \
                 \(seconds, privacy: .public)s; starting SPV without DashPay state
                 """)
         case .seedBindingUnverified:
@@ -136,7 +154,7 @@ enum DashPayContactAddressReadiness {
             // later run with the correct Keychain mapping.
             logger.error(
                 """
-                👥 DP-READY :: wallet seed binding could not be verified; \
+                \(tag, privacy: .public)wallet seed binding could not be verified; \
                 starting SPV without deriving contact accounts
                 """)
         case .identityScanIncomplete:
@@ -145,7 +163,7 @@ enum DashPayContactAddressReadiness {
             // of treating the local identity set as complete.
             logger.warning(
                 """
-                👥 DP-READY :: identity scan incomplete after \
+                \(tag, privacy: .public)identity scan incomplete after \
                 \(outcome.discoveryAttempts, privacy: .public) scan(s) and \
                 \(seconds, privacy: .public)s; starting SPV, discovery retries \
                 on the next start
@@ -153,7 +171,7 @@ enum DashPayContactAddressReadiness {
         @unknown default:
             logger.warning(
                 """
-                👥 DP-READY :: unknown wallet startup status \
+                \(tag, privacy: .public)unknown wallet startup status \
                 \(outcome.status.rawValue, privacy: .public) after \
                 \(seconds, privacy: .public)s; starting SPV without assuming \
                 DashPay readiness

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -75,9 +75,9 @@ enum DashPayContactAddressReadiness {
         let hadLocalIdentity = container.flatMap {
             DWSameSeedIdentityRecoveryCoordinator.hasLocalIdentity(walletId: walletId, modelContainer: $0)
         }
-        let probeBudget = container.flatMap {
-            recovery.startupBudget(walletId: walletId, modelContainer: $0)
-        }
+        // Reuses the reading above — this runs on the pre-SPV main-thread
+        // path, so the store is not asked twice.
+        let probeBudget = recovery.startupBudget(walletId: walletId, hasLocalIdentity: hadLocalIdentity)
         if let probeBudget {
             logger.info(
                 "👥 DP-READY :: wallet generated on this device, no local identity — budget \(Int(probeBudget), privacy: .public)s")

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -67,7 +67,15 @@ enum DashPayContactAddressReadiness {
         // anything to do in this start (`StartupIdentityRecoveryPolicy`).
         let recovery = DWSameSeedIdentityRecoveryCoordinator.shared
         let walletId = wallet.walletId
-        let probeBudget = SwiftDashSDKHost.shared.modelContainer.flatMap {
+        let container = SwiftDashSDKHost.shared.modelContainer
+        // "First sight" is measured from the store, before the pass: the SDK
+        // increments `discoveryAttempts` for a rescan of an identity already
+        // on file too, so that counter cannot tell a new identity from a
+        // re-confirmed one.
+        let hadLocalIdentity = container.flatMap {
+            DWSameSeedIdentityRecoveryCoordinator.hasLocalIdentity(walletId: walletId, modelContainer: $0)
+        }
+        let probeBudget = container.flatMap {
             recovery.startupBudget(walletId: walletId, modelContainer: $0)
         }
         if let probeBudget {
@@ -76,18 +84,14 @@ enum DashPayContactAddressReadiness {
         }
         do {
             var outcome = try await manager.startWalletSubsystems(wallet: wallet, budget: probeBudget)
-            // Captured before a re-run can replace `outcome`: the re-run reuses
-            // the identity the probe just persisted (`discoveryAttempts == 0`),
-            // and the coordinator must still see this start as the identity's
-            // first sight on this install.
-            var discoveredThisStart = outcome.discoveryAttempts > 0
-            if probeBudget != nil, outcome.identityId != nil {
+            if let probeBudget, outcome.identityId != nil {
                 // The seed owns an identity after all: the probe budget must
                 // never apply to this wallet again, whether or not the probe
                 // itself completed.
                 GeneratedWalletIdentityMarker.clear(walletId: walletId)
                 if StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
                     identityFound: true,
+                    budgetExhausted: outcome.elapsed >= probeBudget - 0.5,
                     dashPaySyncRan: outcome.dashPaySyncRan,
                     contactAccountsPending: outcome.contactAccountsPending,
                     seedBindingUnverified: outcome.seedBindingUnverified,
@@ -95,12 +99,19 @@ enum DashPayContactAddressReadiness {
                     log(outcome, network: network, phase: .probe)
                     logger.info(
                         "👥 DP-READY :: probe found an identity but was cut short — re-running with the default budget")
-                    // A re-run that throws (a manager unconfigured mid-switch,
-                    // a locked Keychain) must not cost the probe's verdict:
-                    // the identity it found is still the start's answer.
+                    // The probe's identity is the start's answer unless the
+                    // re-run also has one: a re-run that throws, or comes
+                    // back without an identity (Platform went away, scan key
+                    // unavailable), must not cost it.
                     do {
-                        outcome = try await manager.startWalletSubsystems(wallet: wallet)
-                        discoveredThisStart = discoveredThisStart || outcome.discoveryAttempts > 0
+                        let rerun = try await manager.startWalletSubsystems(wallet: wallet)
+                        if rerun.identityId != nil {
+                            outcome = rerun
+                        } else {
+                            log(rerun, network: network, phase: .probe)
+                            logger.warning(
+                                "👥 DP-READY :: default-budget re-run lost the identity; keeping the probe verdict")
+                        }
                     } catch {
                         logger.warning(
                             "👥 DP-READY :: default-budget re-run failed; keeping the probe verdict: \(String(describing: error), privacy: .public)")
@@ -111,7 +122,7 @@ enum DashPayContactAddressReadiness {
             recovery.recordStartupDiscovery(
                 status: outcome.status,
                 identityId: outcome.identityId,
-                discoveredThisStart: discoveredThisStart,
+                discoveredThisStart: outcome.identityId != nil && hadLocalIdentity != true,
                 walletId: walletId,
                 network: network)
         } catch {
@@ -163,15 +174,15 @@ enum DashPayContactAddressReadiness {
                 """)
         case .discoveryFailed:
             // A local wallet/persistence fault, not the network. Logged at
-            // error because a retry of the same sequence will not clear it;
-            // the same-seed recovery backstop tries its own discovery entry
-            // point in this start unless this wallet was already settled in
-            // this process.
+            // error because a rescan cannot clear it; the same-seed recovery
+            // backstop adopts whatever identity rows exist locally without
+            // scanning, unless this wallet was already settled in this
+            // process. The next runtime start asks the SDK again.
             logger.error(
                 """
                 \(tag, privacy: .public)identity discovery failed locally after \
                 \(seconds, privacy: .public)s; starting SPV, the recovery backstop \
-                retries with its own scan unless already settled this process
+                adopts local rows without a scan
                 """)
         case .seedBindingUnverified:
             // Never derive contact addresses when the available seed cannot be

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -54,14 +54,17 @@ enum DashPayContactAddressReadiness {
         // A mnemonic generated on this device with no local identity gets a
         // short budget instead of the SDK default. That budget caps the
         // whole sequence, so it only serves as a probe: when the probe finds
-        // an identity the marker is dropped, and if the probe was also cut
-        // short (`probeNeedsFullRerun`: contact sync or contact-account
-        // drain unfinished) the sequence runs again with the default budget
-        // — the identity is local by then, so the second run skips discovery
-        // and spends its budget on the steps the first one cut short. The
-        // final verdict goes to the same-seed recovery coordinator, which
-        // decides whether its backstop still has anything to do in this
-        // start (`StartupIdentityRecoveryPolicy.decision`).
+        // an identity the marker is dropped, and if the probe completed its
+        // scan but was cut short before the contact steps
+        // (`probeNeedsFullRerun`) the sequence runs again with the default
+        // budget — with a complete scan on record the SDK reuses the local
+        // identity, so the second run spends its budget on the steps the
+        // first one cut short. A probe whose own scan was cut off is not
+        // re-run: the SDK would rescan from scratch, so that start leaves
+        // the contact steps to the DIP-15 rescan and the next start asks
+        // again. The final verdict goes to the same-seed recovery
+        // coordinator, which decides whether its backstop still has
+        // anything to do in this start (`StartupIdentityRecoveryPolicy`).
         let recovery = DWSameSeedIdentityRecoveryCoordinator.shared
         let walletId = wallet.walletId
         let probeBudget = SwiftDashSDKHost.shared.modelContainer.flatMap {
@@ -87,7 +90,8 @@ enum DashPayContactAddressReadiness {
                     identityFound: true,
                     dashPaySyncRan: outcome.dashPaySyncRan,
                     contactAccountsPending: outcome.contactAccountsPending,
-                    seedBindingUnverified: outcome.seedBindingUnverified) {
+                    seedBindingUnverified: outcome.seedBindingUnverified,
+                    identityScanIncomplete: outcome.identityScanIncomplete) {
                     log(outcome, network: network, phase: .probe)
                     logger.info(
                         "👥 DP-READY :: probe found an identity but was cut short — re-running with the default budget")

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayContactAddressReadiness.swift
@@ -53,14 +53,15 @@ enum DashPayContactAddressReadiness {
     ) async {
         // A mnemonic generated on this device with no local identity gets a
         // short budget instead of the SDK default. That budget caps the
-        // whole sequence, so it only serves as a probe: when the probe DOES
-        // find an identity, the marker is dropped and the sequence runs
-        // again with the default budget — the identity is local by then, so
-        // the second run skips discovery and spends its budget on the
-        // contact sync and the contact-account drain that the first one cut
-        // short. The final verdict goes to the same-seed recovery
-        // coordinator so the BLAST-side backstop does not repeat the
-        // discovery this pass just ran.
+        // whole sequence, so it only serves as a probe: when the probe finds
+        // an identity the marker is dropped, and if the probe was also cut
+        // short (`probeNeedsFullRerun`: contact sync or contact-account
+        // drain unfinished) the sequence runs again with the default budget
+        // — the identity is local by then, so the second run skips discovery
+        // and spends its budget on the steps the first one cut short. The
+        // final verdict goes to the same-seed recovery coordinator, which
+        // decides whether its backstop still has anything to do in this
+        // start (`StartupIdentityRecoveryPolicy.decision`).
         let recovery = DWSameSeedIdentityRecoveryCoordinator.shared
         let walletId = wallet.walletId
         let probeBudget = SwiftDashSDKHost.shared.modelContainer.flatMap {
@@ -130,13 +131,14 @@ enum DashPayContactAddressReadiness {
             logger.info(
                 "\(tag, privacy: .public)no identity for this seed; nothing to prepare before SPV")
         case .partialNoIdentity:
-            // Not an error: Platform was unreachable, so the question is still
-            // open and the next runtime start asks again.
+            // Not an error: Platform (or the scan key) was unreachable, so the
+            // question is still open; the same-seed recovery backstop asks
+            // again in this start, and the next runtime start asks again too.
             logger.warning(
                 """
                 \(tag, privacy: .public)could not reach Platform in \(seconds, privacy: .public)s \
                 after \(outcome.discoveryAttempts, privacy: .public) scan(s); \
-                starting SPV, identity recovery retries on the next start
+                starting SPV, the same-seed recovery backstop retries in this start
                 """)
         case .partialAccountsPending:
             logger.warning(
@@ -147,12 +149,14 @@ enum DashPayContactAddressReadiness {
                 """)
         case .discoveryFailed:
             // A local wallet/persistence fault, not the network. Logged at
-            // error because unlike every other outcome here, nothing in this
-            // session or the next will clear it on its own.
+            // error because a retry of the same sequence will not clear it;
+            // the same-seed recovery backstop still tries its own discovery
+            // entry point in this start.
             logger.error(
                 """
                 \(tag, privacy: .public)identity discovery failed locally after \
-                \(seconds, privacy: .public)s; starting SPV without DashPay state
+                \(seconds, privacy: .public)s; starting SPV, the same-seed recovery \
+                backstop retries with its own scan
                 """)
         case .seedBindingUnverified:
             // Never derive contact addresses when the available seed cannot be
@@ -164,15 +168,16 @@ enum DashPayContactAddressReadiness {
                 starting SPV without deriving contact accounts
                 """)
         case .identityScanIncomplete:
-            // An identity was found, but the scan left indices unanswered.
-            // The SDK records that verdict so the next launch retries instead
-            // of treating the local identity set as complete.
+            // An identity was found (the backstop adopts it in this start),
+            // but the scan left indices unanswered. The SDK records that
+            // verdict so the next runtime start rescans instead of treating
+            // the local identity set as complete.
             logger.warning(
                 """
                 \(tag, privacy: .public)identity scan incomplete after \
                 \(outcome.discoveryAttempts, privacy: .public) scan(s) and \
-                \(seconds, privacy: .public)s; starting SPV, discovery retries \
-                on the next start
+                \(seconds, privacy: .public)s; starting SPV, the gap rescan \
+                runs on the next start
                 """)
         @unknown default:
             logger.warning(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -635,6 +635,49 @@ enum SameSeedIdentityRecoveryPipeline {
     }
 }
 
+/// Decides what the BLAST-side same-seed recovery backstop still has to do
+/// after the pre-SPV readiness pass (`DashPayContactAddressReadiness` →
+/// `startWalletSubsystems`) already ran for the same runtime start. Pure so
+/// the rules stay regression-testable.
+enum StartupIdentityRecoveryPolicy {
+    /// Budget handed to the SDK's startup sequence for a wallet whose
+    /// mnemonic was generated on this device and that has no local identity:
+    /// a proof of absence settles on the first discovery pass (seconds), and
+    /// an unreachable Platform then costs this much instead of the SDK
+    /// default. A short budget rather than a skip on purpose — the same seed
+    /// can still own an identity registered from another device.
+    static let generatedWalletStartupBudget: TimeInterval = 5
+
+    /// `nil` status = no readiness pass ran in this start (a Platform-sync
+    /// re-arm, the storage explorer's direct BLAST start): the backstop runs
+    /// as before. A known identity keeps it running too — the pipeline then
+    /// skips discovery and only refreshes names + adopts. No identity after a
+    /// readiness pass (`.noIdentity`, `.partialNoIdentity`,
+    /// `.discoveryFailed`) means that pass WAS the discovery, with the SDK's
+    /// backoff schedule; repeating it unbudgeted is what cost a wallet switch
+    /// 31 s.
+    static func shouldRunBackstop(
+        readinessStatus: WalletStartupStatus?,
+        readinessIdentityId: Data?
+    ) -> Bool {
+        guard readinessStatus != nil else { return true }
+        return readinessIdentityId != nil
+    }
+
+    /// Only a Platform-confirmed absence settles the context for the rest of
+    /// the process (the pipeline's own "scanned, found nothing" completion).
+    /// An unreachable Platform stays retryable on the next runtime start.
+    static func marksContextCompleted(readinessStatus: WalletStartupStatus) -> Bool {
+        readinessStatus == .noIdentity
+    }
+
+    /// `nil` = the SDK default budget.
+    static func startupBudget(isGeneratedOnDevice: Bool, hasLocalIdentity: Bool) -> TimeInterval? {
+        guard isGeneratedOnDevice, !hasLocalIdentity else { return nil }
+        return generatedWalletStartupBudget
+    }
+}
+
 /// Best-effort startup recovery for an identity created by the same seed on a
 /// different device/install. One successful attempt is enough per
 /// network-scoped wallet and process; failures remain retryable on the next
@@ -649,8 +692,36 @@ final class DWSameSeedIdentityRecoveryCoordinator {
 
     private var completedContexts: Set<String> = []
     private var activeContexts: Set<String> = []
+    /// Readiness verdicts recorded by `DashPayContactAddressReadiness` for
+    /// the current runtime start, consumed (removed) by `recoverIfNeeded`.
+    private var startupVerdicts: [String: (status: WalletStartupStatus, identityId: Data?)] = [:]
 
     private init() {}
+
+    /// Hand over the pre-SPV readiness verdict for `walletId` on `network`
+    /// so the backstop below can tell a fresh discovery from a repeat.
+    func recordStartupDiscovery(
+        status: WalletStartupStatus,
+        identityId: Data?,
+        walletId: Data,
+        network: Network
+    ) {
+        startupVerdicts[Self.contextKey(walletId: walletId, network: network)] = (status, identityId)
+    }
+
+    /// Drop every recorded verdict; runtime teardown calls this so a verdict
+    /// can never outlive the start that produced it.
+    func clearStartupVerdicts() {
+        startupVerdicts.removeAll()
+    }
+
+    /// Startup budget for the SDK's pre-SPV sequence, or `nil` for the SDK
+    /// default — see `StartupIdentityRecoveryPolicy.startupBudget`.
+    func startupBudget(walletId: Data, modelContainer: ModelContainer) -> TimeInterval? {
+        StartupIdentityRecoveryPolicy.startupBudget(
+            isGeneratedOnDevice: GeneratedWalletIdentityMarker.isMarked(walletId: walletId),
+            hasLocalIdentity: !Self.localIdentityIds(walletId: walletId, modelContainer: modelContainer).isEmpty)
+    }
 
     func recoverIfNeeded(
         wallet: ManagedPlatformWallet,
@@ -658,13 +729,31 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         network: Network
     ) async {
         let walletId = wallet.walletId
-        let walletHex = walletId.map { String(format: "%02x", $0) }.joined()
-        let contextKey = "\(network.rawValue):\(walletHex)"
+        let contextKey = Self.contextKey(walletId: walletId, network: network)
 
         guard !completedContexts.contains(contextKey),
               !activeContexts.contains(contextKey)
         else {
             return
+        }
+
+        if let verdict = startupVerdicts.removeValue(forKey: contextKey) {
+            if StartupIdentityRecoveryPolicy.marksContextCompleted(readinessStatus: verdict.status) {
+                completedContexts.insert(contextKey)
+                Self.logger.info(
+                    "🪪 IDENT-RECOVERY :: skipped — startup readiness proved this seed owns no identity")
+                return
+            }
+            if !StartupIdentityRecoveryPolicy.shouldRunBackstop(
+                readinessStatus: verdict.status,
+                readinessIdentityId: verdict.identityId) {
+                Self.logger.info(
+                    """
+                    🪪 IDENT-RECOVERY :: skipped — startup readiness already scanned \
+                    (status=\(verdict.status.rawValue, privacy: .public)); retries on the next runtime start
+                    """)
+                return
+            }
         }
 
         activeContexts.insert(contextKey)
@@ -732,7 +821,13 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         }
     }
 
-    private static func localIdentityIds(
+    private static func contextKey(walletId: Data, network: Network) -> String {
+        "\(network.rawValue):" + walletId.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Internal (was private): shared with the startup-budget decision above
+    /// — reuse, not a copy, per the repo's no-copy-then-adapt guardrail.
+    static func localIdentityIds(
         walletId: Data,
         modelContainer: ModelContainer
     ) -> [Data] {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -652,16 +652,27 @@ enum StartupIdentityRecoveryPolicy {
     /// re-arm, the storage explorer's direct BLAST start): the backstop runs
     /// as before. A known identity keeps it running too — the pipeline then
     /// skips discovery and only refreshes names + adopts. No identity after a
-    /// readiness pass (`.noIdentity`, `.partialNoIdentity`,
-    /// `.discoveryFailed`) means that pass WAS the discovery, with the SDK's
-    /// backoff schedule; repeating it unbudgeted is what cost a wallet switch
-    /// 31 s.
+    /// readiness pass that ended in one of the three discovery verdicts
+    /// (`.noIdentity`, `.partialNoIdentity`, `.discoveryFailed`) means that
+    /// pass WAS the discovery, with the SDK's backoff schedule; repeating it
+    /// unbudgeted is what cost a wallet switch 31 s. Every other status —
+    /// including `.seedBindingUnverified` and any status this build does not
+    /// know — leaves the identity question to the backstop, which fails safe
+    /// towards running.
     static func shouldRunBackstop(
         readinessStatus: WalletStartupStatus?,
         readinessIdentityId: Data?
     ) -> Bool {
-        guard readinessStatus != nil else { return true }
-        return readinessIdentityId != nil
+        guard let readinessStatus else { return true }
+        if readinessIdentityId != nil { return true }
+        switch readinessStatus {
+        case .noIdentity, .partialNoIdentity, .discoveryFailed:
+            return false
+        case .ready, .partialAccountsPending, .seedBindingUnverified, .identityScanIncomplete:
+            return true
+        @unknown default:
+            return true
+        }
     }
 
     /// Only a Platform-confirmed absence settles the context for the rest of

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -641,45 +641,43 @@ enum SameSeedIdentityRecoveryPipeline {
 /// the rules stay regression-testable.
 enum StartupIdentityRecoveryPolicy {
     /// Budget handed to the SDK's startup sequence for a wallet whose
-    /// mnemonic was generated on this device and that has no local identity:
-    /// a proof of absence settles on the first discovery pass (seconds), and
-    /// an unreachable Platform then costs this much instead of the SDK
-    /// default. A short budget rather than a skip on purpose — the same seed
-    /// can still own an identity registered from another device.
+    /// mnemonic was generated on this device and that has no local identity.
+    /// It caps the WHOLE sequence, so it is only ever used as a first probe:
+    /// a proof of absence settles on the first discovery pass (seconds), an
+    /// unreachable Platform costs this much instead of the SDK default, and
+    /// a found identity makes `DashPayContactAddressReadiness` re-run the
+    /// sequence with the default budget so the contact sync and the
+    /// contact-account drain are not cut short.
     static let generatedWalletStartupBudget: TimeInterval = 5
 
     /// `nil` status = no readiness pass ran in this start (a Platform-sync
     /// re-arm, the storage explorer's direct BLAST start): the backstop runs
     /// as before. A known identity keeps it running too — the pipeline then
-    /// skips discovery and only refreshes names + adopts. No identity after a
-    /// readiness pass that ended in one of the three discovery verdicts
-    /// (`.noIdentity`, `.partialNoIdentity`, `.discoveryFailed`) means that
-    /// pass WAS the discovery, with the SDK's backoff schedule; repeating it
-    /// unbudgeted is what cost a wallet switch 31 s. Every other status —
-    /// including `.seedBindingUnverified` and any status this build does not
-    /// know — leaves the identity question to the backstop, which fails safe
-    /// towards running.
+    /// skips discovery and only refreshes names + adopts. `.noIdentity` and
+    /// `.discoveryFailed` settle the question for this start (retrying the
+    /// unbudgeted scan is what cost a wallet switch 31 s). A pass that
+    /// never reached Platform (`.partialNoIdentity`, which is also what the
+    /// SDK decodes an unrecognised FFI status into) keeps the backstop as
+    /// the in-session retry — except for a wallet generated on this device,
+    /// where the next runtime start retries instead. Every other status
+    /// leaves the question to the backstop.
     static func shouldRunBackstop(
         readinessStatus: WalletStartupStatus?,
-        readinessIdentityId: Data?
+        readinessIdentityId: Data?,
+        isGeneratedOnDevice: Bool
     ) -> Bool {
         guard let readinessStatus else { return true }
         if readinessIdentityId != nil { return true }
         switch readinessStatus {
-        case .noIdentity, .partialNoIdentity, .discoveryFailed:
+        case .noIdentity, .discoveryFailed:
             return false
-        case .ready, .partialAccountsPending, .seedBindingUnverified, .identityScanIncomplete:
+        case .partialNoIdentity, .identityScanIncomplete:
+            return !isGeneratedOnDevice
+        case .ready, .partialAccountsPending, .seedBindingUnverified:
             return true
         @unknown default:
             return true
         }
-    }
-
-    /// Only a Platform-confirmed absence settles the context for the rest of
-    /// the process (the pipeline's own "scanned, found nothing" completion).
-    /// An unreachable Platform stays retryable on the next runtime start.
-    static func marksContextCompleted(readinessStatus: WalletStartupStatus) -> Bool {
-        readinessStatus == .noIdentity
     }
 
     /// `nil` = the SDK default budget.
@@ -704,7 +702,9 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     private var completedContexts: Set<String> = []
     private var activeContexts: Set<String> = []
     /// Readiness verdicts recorded by `DashPayContactAddressReadiness` for
-    /// the current runtime start, consumed (removed) by `recoverIfNeeded`.
+    /// the current runtime start. `recoverIfNeeded` removes the verdict for
+    /// its context on entry, before any early return, so one verdict is
+    /// consulted at most once.
     private var startupVerdicts: [String: (status: WalletStartupStatus, identityId: Data?)] = [:]
 
     private init() {}
@@ -720,17 +720,23 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         startupVerdicts[Self.contextKey(walletId: walletId, network: network)] = (status, identityId)
     }
 
-    /// Drop every recorded verdict; runtime teardown calls this so a verdict
-    /// can never outlive the start that produced it.
-    func clearStartupVerdicts() {
+    /// Runtime teardown (`SwiftDashSDKWalletRuntime.fullReset`) calls this
+    /// so nothing recorded here outlives the start that produced it: the
+    /// readiness verdicts, and the completed contexts — walletIds are
+    /// deterministic per mnemonic+network, so a wallet removed and
+    /// re-imported in the same session must get its recovery attempt back.
+    func resetForRuntimeTeardown() {
         startupVerdicts.removeAll()
+        completedContexts.removeAll()
     }
 
     /// Startup budget for the SDK's pre-SPV sequence, or `nil` for the SDK
-    /// default — see `StartupIdentityRecoveryPolicy.startupBudget`.
+    /// default — see `StartupIdentityRecoveryPolicy.startupBudget`. The
+    /// SwiftData fetch only runs for a marked wallet.
     func startupBudget(walletId: Data, modelContainer: ModelContainer) -> TimeInterval? {
-        StartupIdentityRecoveryPolicy.startupBudget(
-            isGeneratedOnDevice: GeneratedWalletIdentityMarker.isMarked(walletId: walletId),
+        guard GeneratedWalletIdentityMarker.isMarked(walletId: walletId) else { return nil }
+        return StartupIdentityRecoveryPolicy.startupBudget(
+            isGeneratedOnDevice: true,
             hasLocalIdentity: !Self.localIdentityIds(walletId: walletId, modelContainer: modelContainer).isEmpty)
     }
 
@@ -741,6 +747,9 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     ) async {
         let walletId = wallet.walletId
         let contextKey = Self.contextKey(walletId: walletId, network: network)
+        // Consumed first: a verdict belongs to exactly one backstop decision,
+        // whichever branch below takes it.
+        let verdict = startupVerdicts.removeValue(forKey: contextKey)
 
         guard !completedContexts.contains(contextKey),
               !activeContexts.contains(contextKey)
@@ -748,23 +757,17 @@ final class DWSameSeedIdentityRecoveryCoordinator {
             return
         }
 
-        if let verdict = startupVerdicts.removeValue(forKey: contextKey) {
-            if StartupIdentityRecoveryPolicy.marksContextCompleted(readinessStatus: verdict.status) {
-                completedContexts.insert(contextKey)
-                Self.logger.info(
-                    "🪪 IDENT-RECOVERY :: skipped — startup readiness proved this seed owns no identity")
-                return
-            }
-            if !StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                readinessStatus: verdict.status,
-                readinessIdentityId: verdict.identityId) {
-                Self.logger.info(
-                    """
-                    🪪 IDENT-RECOVERY :: skipped — startup readiness already scanned \
-                    (status=\(verdict.status.rawValue, privacy: .public)); retries on the next runtime start
-                    """)
-                return
-            }
+        if let verdict,
+           !StartupIdentityRecoveryPolicy.shouldRunBackstop(
+               readinessStatus: verdict.status,
+               readinessIdentityId: verdict.identityId,
+               isGeneratedOnDevice: GeneratedWalletIdentityMarker.isMarked(walletId: walletId)) {
+            Self.logger.info(
+                """
+                🪪 IDENT-RECOVERY :: skipped — startup readiness already ran discovery \
+                (status=\(verdict.status.rawValue, privacy: .public))
+                """)
+            return
         }
 
         activeContexts.insert(contextKey)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -613,8 +613,12 @@ enum SameSeedIdentityRecoveryPipeline {
     /// and persisted in this start. They stand in for an empty local read —
     /// the persister normally lands the rows before the readiness call
     /// returns, but a lagging store must not trigger a second discovery scan.
+    /// `allowDiscovery: false` adopts and refreshes whatever identity rows
+    /// exist locally without ever scanning — for a readiness verdict that
+    /// says a scan cannot succeed (`.discoveryFailed`).
     static func run(
         knownIdentityIds: [Data] = [],
+        allowDiscovery: Bool = true,
         localIdentityIds: () -> [Data],
         discover: () async throws -> [Data],
         refreshNames: ([Data]) async throws -> Void,
@@ -627,7 +631,7 @@ enum SameSeedIdentityRecoveryPipeline {
             identityIds = knownIdentityIds
         }
 
-        if identityIds.isEmpty {
+        if identityIds.isEmpty, allowDiscovery {
             discoveredIds = try await discover()
             identityIds = localIdentityIds()
             // The SDK persister normally makes the rows visible before the
@@ -695,9 +699,11 @@ enum StartupIdentityRecoveryPolicy {
         /// process.
         case skipSettled
         /// The SDK reports the question unanswered AND not worth asking
-        /// again (`.discoveryFailed`: a local wallet/persistence fault):
-        /// nothing runs, nothing settles, the next runtime start asks again.
-        case skipNotRetryable
+        /// again (`.discoveryFailed`: a local wallet/persistence fault): no
+        /// scan, but the pipeline still refreshes and adopts whatever
+        /// identity rows exist locally, under the memo. The next runtime
+        /// start asks the SDK again.
+        case runPipelineWithoutDiscovery
     }
 
     /// `nil` status = no readiness pass ran in this start (a Platform-sync
@@ -710,10 +716,12 @@ enum StartupIdentityRecoveryPolicy {
     /// reachable, also what the SDK decodes an unrecognised FFI status into
     /// — and `.identityScanIncomplete`) or otherwise `identityIsSettled`
     /// runs the pipeline unless the wallet was already settled in this
-    /// process; a status that is neither (`.discoveryFailed`) is skipped
-    /// without settling. Every runtime start asks the SDK again regardless.
-    /// `readinessDiscoveredThisStart` is `discoveryAttempts > 0`: the SDK
-    /// ran a scan rather than reusing an identity already on file.
+    /// process; a status that is neither (`.discoveryFailed`) runs the
+    /// pipeline without its scan. Every runtime start asks the SDK again.
+    /// `readinessDiscoveredThisStart` means the wallet had NO local
+    /// identity before the readiness pass and has one after it — measured
+    /// by the caller from the store, not from `discoveryAttempts`, which
+    /// the SDK also increments when it rescans an identity already on file.
     static func decision(
         readinessStatus: WalletStartupStatus?,
         readinessIdentityId: Data?,
@@ -727,31 +735,42 @@ enum StartupIdentityRecoveryPolicy {
         if readinessStatus.discoveryWorthRetrying || readinessStatus.identityIsSettled {
             return .runPipeline
         }
-        return .skipNotRetryable
+        return .runPipelineWithoutDiscovery
     }
 
-    /// Whether a short-budget probe found an identity but ran out of budget
-    /// before the contact-request pass and the contact-account drain
-    /// completed — the two steps the readiness pass exists to guarantee
-    /// before the first SPV filter set is built. Never when the drain was
-    /// skipped for `seedBindingUnverified` (the SDK fails that closed on
-    /// every budget), and never when the probe's own scan was cut off
-    /// (`identityScanIncomplete`): the SDK then rescans on the next start
-    /// instead of reusing the identity, so a re-run would pay a fresh full
-    /// discovery on the switch path — the cost this budget exists to avoid.
-    /// Those two cases leave the contact steps to the DIP-15 rescan.
+    /// Whether a short-budget probe found an identity and the BUDGET — not
+    /// a Platform error — cut the sequence short before the contact-request
+    /// pass and the contact-account drain completed, the two steps the
+    /// readiness pass exists to guarantee before the first SPV filter set is
+    /// built. `budgetExhausted` is the caller's reading of `elapsed` against
+    /// the budget it passed: the SDK clears `dashPaySyncRan` for a degraded
+    /// or failed contact pass too, and a re-run cannot fix those. Never when
+    /// the drain was skipped for `seedBindingUnverified` (the SDK fails that
+    /// closed on every budget), and never when the probe's own scan was cut
+    /// off (`identityScanIncomplete`): the SDK then rescans on the next
+    /// start instead of reusing the identity, so a re-run would pay a fresh
+    /// full discovery on the switch path. Those cases leave the contact
+    /// steps to the DIP-15 rescan.
     static func probeNeedsFullRerun(
         identityFound: Bool,
+        budgetExhausted: Bool,
         dashPaySyncRan: Bool,
         contactAccountsPending: UInt32,
         seedBindingUnverified: Bool,
         identityScanIncomplete: Bool
     ) -> Bool {
         identityFound
+            && budgetExhausted
             && !seedBindingUnverified
             && !identityScanIncomplete
             && (!dashPaySyncRan || contactAccountsPending > 0)
     }
+
+    /// Attempts the backstop makes on an identity the store keeps failing
+    /// to confirm before it settles the context for the process anyway.
+    /// Bounds a SwiftData mirror that never lands the row: without a cap
+    /// every re-arm in the process would pay the unbudgeted scan.
+    static let maxUnpersistedAttempts = 2
 
     /// `nil` = the SDK default budget. `hasLocalIdentity == nil` means the
     /// lookup was inconclusive (fetch failed, no wallet row): the probe is
@@ -786,6 +805,9 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     /// its context on entry, before any early return, so one verdict is
     /// consulted at most once.
     private var startupVerdicts: [String: (status: WalletStartupStatus, identityId: Data?, discovered: Bool)] = [:]
+    /// Pipeline runs per context that acted on an identity the store did
+    /// not confirm (see `maxUnpersistedAttempts`).
+    private var unpersistedAttempts: [String: Int] = [:]
 
     private init() {}
 
@@ -818,6 +840,7 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         let suffix = ":" + walletId.hexEncodedString()
         completedContexts = completedContexts.filter { !$0.hasSuffix(suffix) }
         startupVerdicts = startupVerdicts.filter { !$0.key.hasSuffix(suffix) }
+        unpersistedAttempts = unpersistedAttempts.filter { !$0.key.hasSuffix(suffix) }
     }
 
     /// Startup budget for the SDK's pre-SPV sequence, or `nil` for the SDK
@@ -850,10 +873,14 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         // identity the store never confirmed: there the verdict stays
         // consumed so the retry rediscovers.
         let verdict = startupVerdicts.removeValue(forKey: contextKey)
+        // Restores only into an empty slot: a verdict recorded (or a clear
+        // performed by `fullReset`) while this call was suspended is newer
+        // than the one this call took, and wins.
         func restoreVerdict() {
-            if let verdict { startupVerdicts[contextKey] = verdict }
+            if let verdict, startupVerdicts[contextKey] == nil { startupVerdicts[contextKey] = verdict }
         }
 
+        let allowDiscovery: Bool
         switch StartupIdentityRecoveryPolicy.decision(
             readinessStatus: verdict?.status,
             readinessIdentityId: verdict?.identityId,
@@ -863,17 +890,22 @@ final class DWSameSeedIdentityRecoveryCoordinator {
             Self.logger.info(
                 "🪪 IDENT-RECOVERY :: skipped — startup readiness proved this seed owns no identity")
             return
-        case .skipNotRetryable:
-            restoreVerdict()
-            Self.logger.error(
-                "🪪 IDENT-RECOVERY :: skipped — startup readiness hit a local fault a rescan cannot clear; the next runtime start asks again")
-            return
         case .refreshNamesAndAdopt:
             // First sight of this identity on this install: run the pipeline
             // past the settled memo (its discovery finds the rows readiness
             // persisted; the name refresh rebuilds the contested bookmarks).
-            break
+            allowDiscovery = true
         case .runPipeline:
+            allowDiscovery = true
+            guard !completedContexts.contains(contextKey) else {
+                restoreVerdict()
+                return
+            }
+        case .runPipelineWithoutDiscovery:
+            // A local fault blocked the SDK's scan and a rescan cannot clear
+            // it: adopt and refresh whatever identity rows exist locally,
+            // never scan.
+            allowDiscovery = false
             guard !completedContexts.contains(contextKey) else {
                 restoreVerdict()
                 return
@@ -886,6 +918,7 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         do {
             let outcome = try await SameSeedIdentityRecoveryPipeline.run(
                 knownIdentityIds: verdict?.identityId.map { [$0] } ?? [],
+                allowDiscovery: allowDiscovery,
                 localIdentityIds: {
                     Self.localIdentityIds(walletId: walletId, modelContainer: modelContainer)
                 },
@@ -937,12 +970,24 @@ final class DWSameSeedIdentityRecoveryCoordinator {
             }
             if outcome.identityCount == 0 || outcome.identitiesPersisted {
                 completedContexts.insert(contextKey)
+                unpersistedAttempts[contextKey] = nil
             } else {
                 // Acted on ids the store has not confirmed: leave the context
                 // open (and the verdict consumed) so the next attempt runs
-                // the discovery that repopulates the store.
-                Self.logger.warning(
-                    "🪪 IDENT-RECOVERY :: identity acted on but not yet persisted locally; leaving the context open")
+                // the discovery that repopulates the store — a bounded
+                // number of times, then settle for the process anyway so a
+                // mirror that never lands the row cannot buy an unbudgeted
+                // scan on every re-arm.
+                let attempts = (unpersistedAttempts[contextKey] ?? 0) + 1
+                unpersistedAttempts[contextKey] = attempts
+                if attempts >= StartupIdentityRecoveryPolicy.maxUnpersistedAttempts {
+                    completedContexts.insert(contextKey)
+                    Self.logger.error(
+                        "🪪 IDENT-RECOVERY :: identity still not persisted after \(attempts, privacy: .public) attempt(s); settling for this process")
+                } else {
+                    Self.logger.warning(
+                        "🪪 IDENT-RECOVERY :: identity acted on but not yet persisted locally; leaving the context open")
+                }
             }
             Self.logger.info(
                 """

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -601,10 +601,11 @@ enum SameSeedIdentityRecoveryPipeline {
         let discoveredCount: Int
         let identityCount: Int
         let adopted: Bool
-        /// Whether the identity rows were found in the local store AFTER the
-        /// name refresh. `false` means the ids came from a discovery result
-        /// or from the readiness verdict and the persister has not landed
-        /// them (yet) — the caller must not treat the identity as settled.
+        /// Whether EVERY identity this run acted on was found in the local
+        /// store after the name refresh. `false` means at least one id came
+        /// from a discovery result or from the readiness verdict and the
+        /// persister has not landed it (yet) — the caller must not treat the
+        /// identity as settled, whatever other rows the wallet already has.
         let identitiesPersisted: Bool
     }
 
@@ -645,8 +646,10 @@ enum SameSeedIdentityRecoveryPipeline {
         try await refreshNames(identityIds)
         // Re-read rather than trust the ids we acted on: `knownIdentityIds`
         // came from a different call, and even a discovery result can
-        // outrun its own persistence.
-        let identitiesPersisted = !localIdentityIds().isEmpty
+        // outrun its own persistence. Intersected with the acted-on ids so
+        // a row the wallet already had cannot vouch for a new one.
+        let persistedIds = Set(localIdentityIds())
+        let identitiesPersisted = identityIds.allSatisfy { persistedIds.contains($0) }
         return Outcome(
             discoveredCount: discoveredIds.count,
             identityCount: identityIds.count,
@@ -675,74 +678,79 @@ enum StartupIdentityRecoveryPolicy {
     /// What the backstop does with the readiness verdict of this start.
     enum Decision: Equatable {
         /// Run the full pipeline (discover if needed → refresh names → adopt),
-        /// subject to the per-process settled memo.
+        /// subject to the per-process settled memo. Also the answer for an
+        /// identity readiness re-confirmed on file: the pipeline's DPNS name
+        /// refresh is the only code path that rebuilds contested-label
+        /// bookmarks and keeps the name cache `reconcileRecoveredIdentity`
+        /// reads, so adoption is never taken without it — once per process
+        /// per wallet, as before this policy existed.
         case runPipeline
-        /// Readiness knows the identity but this install has not yet
-        /// rebuilt the contested-label bookmarks for it (first sight after a
-        /// discovery, or a name refresh that failed on an earlier start).
-        /// The pipeline runs regardless of the settled memo — its discovery
-        /// finds the rows already there, and its name refresh rebuilds the
-        /// bookmarks a new install has no other source for.
+        /// Readiness discovered and persisted the identity in THIS start: a
+        /// second install's first sight of it. The pipeline runs regardless
+        /// of the settled memo (the memo may hold a `.noIdentity` from
+        /// earlier in the process) — its discovery finds the rows already
+        /// there, and its name refresh rebuilds the bookmarks.
         case refreshNamesAndAdopt
-        /// Readiness re-confirmed an identity that was already local AND the
-        /// bookmarks were rebuilt on this install: only the app-side
-        /// adoption can be missing, so the pipeline's DPNS round trips are
-        /// skipped on the switch's critical path.
-        case adoptOnly
-        /// Platform confirmed the seed owns no identity; nothing to do.
+        /// Platform confirmed the seed owns no identity; settled for the
+        /// process.
         case skipSettled
+        /// The SDK reports the question unanswered AND not worth asking
+        /// again (`.discoveryFailed`: a local wallet/persistence fault):
+        /// nothing runs, nothing settles, the next runtime start asks again.
+        case skipNotRetryable
     }
 
     /// `nil` status = no readiness pass ran in this start (a Platform-sync
     /// re-arm, the storage explorer's direct BLAST start, a thrown or elided
-    /// pass): the pipeline runs as before. Only `.noIdentity` settles the
-    /// question; every other identity-less status — `.partialNoIdentity`
-    /// (Platform or the Keychain scan key not reachable, also what the SDK
-    /// decodes an unrecognised FFI status into), `.discoveryFailed` (a local
-    /// fault the pipeline's own discovery entry point may not share) and the
-    /// rest — is the SDK's "ask again", answered by the pipeline unless the
-    /// wallet was already settled in this process (the per-process memo);
-    /// every runtime start asks the SDK again regardless.
+    /// pass): the pipeline runs as before. A known identity runs the
+    /// pipeline too (past the memo when it was discovered in this start).
+    /// Without an identity the SDK's own verdict properties decide:
+    /// `.noIdentity` settles; a status that is `discoveryWorthRetrying`
+    /// (`.partialNoIdentity` — Platform or the Keychain scan key not
+    /// reachable, also what the SDK decodes an unrecognised FFI status into
+    /// — and `.identityScanIncomplete`) or otherwise `identityIsSettled`
+    /// runs the pipeline unless the wallet was already settled in this
+    /// process; a status that is neither (`.discoveryFailed`) is skipped
+    /// without settling. Every runtime start asks the SDK again regardless.
     /// `readinessDiscoveredThisStart` is `discoveryAttempts > 0`: the SDK
     /// ran a scan rather than reusing an identity already on file.
-    /// `contestedBookmarksRebuilt` is this install's record of a completed
-    /// name refresh for the wallet.
     static func decision(
         readinessStatus: WalletStartupStatus?,
         readinessIdentityId: Data?,
-        readinessDiscoveredThisStart: Bool,
-        contestedBookmarksRebuilt: Bool
+        readinessDiscoveredThisStart: Bool
     ) -> Decision {
         guard let readinessStatus else { return .runPipeline }
         if readinessIdentityId != nil {
-            return !readinessDiscoveredThisStart && contestedBookmarksRebuilt
-                ? .adoptOnly
-                : .refreshNamesAndAdopt
+            return readinessDiscoveredThisStart ? .refreshNamesAndAdopt : .runPipeline
         }
-        switch readinessStatus {
-        case .noIdentity:
-            return .skipSettled
-        case .partialNoIdentity, .discoveryFailed, .ready, .partialAccountsPending,
-             .seedBindingUnverified, .identityScanIncomplete:
-            return .runPipeline
-        @unknown default:
+        if readinessStatus == .noIdentity { return .skipSettled }
+        if readinessStatus.discoveryWorthRetrying || readinessStatus.identityIsSettled {
             return .runPipeline
         }
+        return .skipNotRetryable
     }
 
     /// Whether a short-budget probe found an identity but ran out of budget
     /// before the contact-request pass and the contact-account drain
     /// completed — the two steps the readiness pass exists to guarantee
     /// before the first SPV filter set is built. Never when the drain was
-    /// skipped for `seedBindingUnverified`: the SDK fails that closed on
-    /// every budget, so a re-run would be pure latency.
+    /// skipped for `seedBindingUnverified` (the SDK fails that closed on
+    /// every budget), and never when the probe's own scan was cut off
+    /// (`identityScanIncomplete`): the SDK then rescans on the next start
+    /// instead of reusing the identity, so a re-run would pay a fresh full
+    /// discovery on the switch path — the cost this budget exists to avoid.
+    /// Those two cases leave the contact steps to the DIP-15 rescan.
     static func probeNeedsFullRerun(
         identityFound: Bool,
         dashPaySyncRan: Bool,
         contactAccountsPending: UInt32,
-        seedBindingUnverified: Bool
+        seedBindingUnverified: Bool,
+        identityScanIncomplete: Bool
     ) -> Bool {
-        identityFound && !seedBindingUnverified && (!dashPaySyncRan || contactAccountsPending > 0)
+        identityFound
+            && !seedBindingUnverified
+            && !identityScanIncomplete
+            && (!dashPaySyncRan || contactAccountsPending > 0)
     }
 
     /// `nil` = the SDK default budget. `hasLocalIdentity == nil` means the
@@ -810,24 +818,6 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         let suffix = ":" + walletId.hexEncodedString()
         completedContexts = completedContexts.filter { !$0.hasSuffix(suffix) }
         startupVerdicts = startupVerdicts.filter { !$0.key.hasSuffix(suffix) }
-        UserDefaults.standard.removeObject(forKey: Self.bookmarksRebuiltKey(walletId: walletId))
-    }
-
-    /// Per-install record that the pipeline's name refresh — the only code
-    /// path that rebuilds `DWContestedNameStatusService` submission
-    /// bookmarks from Platform — completed for `walletId`. UserDefaults on
-    /// purpose: a reinstall starts without bookmarks and must rebuild them
-    /// once, and a refresh that failed on one start stays due on the next.
-    private static func bookmarksRebuiltKey(walletId: Data) -> String {
-        "DWContestedBookmarksRebuilt." + walletId.hexEncodedString()
-    }
-
-    private static func contestedBookmarksRebuilt(walletId: Data) -> Bool {
-        UserDefaults.standard.bool(forKey: bookmarksRebuiltKey(walletId: walletId))
-    }
-
-    private static func recordContestedBookmarksRebuilt(walletId: Data) {
-        UserDefaults.standard.set(true, forKey: bookmarksRebuiltKey(walletId: walletId))
     }
 
     /// Startup budget for the SDK's pre-SPV sequence, or `nil` for the SDK
@@ -853,11 +843,12 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         guard !activeContexts.contains(contextKey) else { return }
 
         // Consumed here. A branch that settles the context keeps it
-        // consumed; a branch that ends without settling — adoption not
-        // possible yet, a thrown pipeline — puts it back, so the retry
-        // decides on the same verdict instead of degrading to a verdict-less
-        // pipeline run. Only an identity that turned out NOT to be persisted
-        // leaves without either: there the retry must rediscover.
+        // consumed; every branch that returns without settling — the memo
+        // early return, a thrown pipeline — puts it back, so a later call in
+        // the same start decides on the same verdict instead of a
+        // verdict-less one. The one exception is a pipeline run whose
+        // identity the store never confirmed: there the verdict stays
+        // consumed so the retry rediscovers.
         let verdict = startupVerdicts.removeValue(forKey: contextKey)
         func restoreVerdict() {
             if let verdict { startupVerdicts[contextKey] = verdict }
@@ -866,54 +857,33 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         switch StartupIdentityRecoveryPolicy.decision(
             readinessStatus: verdict?.status,
             readinessIdentityId: verdict?.identityId,
-            readinessDiscoveredThisStart: verdict?.discovered ?? false,
-            contestedBookmarksRebuilt: Self.contestedBookmarksRebuilt(walletId: walletId)) {
-        case .adoptOnly:
-            // Readiness re-confirmed an identity already on file and this
-            // install has its bookmarks; the pipeline's discovery and name
-            // refresh would only repeat SDK work. Adopt app-side and settle
-            // — a known identity adopts even for a context settled earlier
-            // in this process. The marker goes regardless (the seed owns an
-            // identity; the default budget is the safe direction), but the
-            // context settles only on a successful adoption —
-            // `reconcileRecoveredIdentity` returns false while the host or
-            // the snapshot is still hydrating, and that must stay retryable.
-            GeneratedWalletIdentityMarker.clear(walletId: walletId)
-            let adopted = DWCurrentUserIdentityInfo.shared.reconcileRecoveredIdentity()
-            guard adopted else {
-                restoreVerdict()
-                Self.logger.warning(
-                    "🪪 IDENT-RECOVERY :: identity re-confirmed by startup readiness but not adopted yet; leaving the context open")
-                return
-            }
-            completedContexts.insert(contextKey)
-            Self.logger.info("🪪 IDENT-RECOVERY :: adopted the identity startup readiness re-confirmed")
-            return
+            readinessDiscoveredThisStart: verdict?.discovered ?? false) {
         case .skipSettled:
             completedContexts.insert(contextKey)
             Self.logger.info(
                 "🪪 IDENT-RECOVERY :: skipped — startup readiness proved this seed owns no identity")
             return
+        case .skipNotRetryable:
+            restoreVerdict()
+            Self.logger.error(
+                "🪪 IDENT-RECOVERY :: skipped — startup readiness hit a local fault a rescan cannot clear; the next runtime start asks again")
+            return
         case .refreshNamesAndAdopt:
-            // Identity known but this install still owes it a name refresh:
-            // run the pipeline past the settled memo (its discovery finds the
-            // rows readiness persisted; the name refresh rebuilds the
-            // contested bookmarks).
+            // First sight of this identity on this install: run the pipeline
+            // past the settled memo (its discovery finds the rows readiness
+            // persisted; the name refresh rebuilds the contested bookmarks).
             break
         case .runPipeline:
-            guard !completedContexts.contains(contextKey) else { return }
+            guard !completedContexts.contains(contextKey) else {
+                restoreVerdict()
+                return
+            }
         }
 
         activeContexts.insert(contextKey)
         defer { activeContexts.remove(contextKey) }
 
         do {
-            // The contested-name half of `refreshNames` is best-effort per
-            // identity (a throw there must not fail the restore), so its
-            // success has to be carried out separately: the bookmark record
-            // below may only be written when every identity's contested
-            // refresh actually completed.
-            var contestedRefreshCompleted = true
             let outcome = try await SameSeedIdentityRecoveryPipeline.run(
                 knownIdentityIds: verdict?.identityId.map { [$0] } ?? [],
                 localIdentityIds: {
@@ -947,7 +917,6 @@ final class DWSameSeedIdentityRecoveryCoordinator {
                                     label: recoveredPending)
                             }
                         } catch {
-                            contestedRefreshCompleted = false
                             Self.logger.warning(
                                 """
                                 🪪 IDENT-RECOVERY :: contested-name refresh failed: \
@@ -965,12 +934,6 @@ final class DWSameSeedIdentityRecoveryCoordinator {
                 // run the full pre-SPV bring-up, not the generated-wallet
                 // probe.
                 GeneratedWalletIdentityMarker.clear(walletId: walletId)
-                // The bookmarks exist on this install only if the contested
-                // refresh completed for every identity; otherwise the next
-                // start with a known identity owes the name refresh again.
-                if contestedRefreshCompleted {
-                    Self.recordContestedBookmarksRebuilt(walletId: walletId)
-                }
             }
             if outcome.identityCount == 0 || outcome.identitiesPersisted {
                 completedContexts.insert(contextKey)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -603,7 +603,12 @@ enum SameSeedIdentityRecoveryPipeline {
         let adopted: Bool
     }
 
+    /// `knownIdentityIds`: identities the readiness pass already discovered
+    /// and persisted in this start. They stand in for an empty local read —
+    /// the persister normally lands the rows before the readiness call
+    /// returns, but a lagging store must not trigger a second discovery scan.
     static func run(
+        knownIdentityIds: [Data] = [],
         localIdentityIds: () -> [Data],
         discover: () async throws -> [Data],
         refreshNames: ([Data]) async throws -> Void,
@@ -611,6 +616,10 @@ enum SameSeedIdentityRecoveryPipeline {
     ) async throws -> Outcome {
         var identityIds = localIdentityIds()
         var discoveredIds: [Data] = []
+
+        if identityIds.isEmpty, !knownIdentityIds.isEmpty {
+            identityIds = knownIdentityIds
+        }
 
         if identityIds.isEmpty {
             discoveredIds = try await discover()
@@ -713,9 +722,12 @@ enum StartupIdentityRecoveryPolicy {
         identityFound && (!dashPaySyncRan || contactAccountsPending > 0)
     }
 
-    /// `nil` = the SDK default budget.
-    static func startupBudget(isGeneratedOnDevice: Bool, hasLocalIdentity: Bool) -> TimeInterval? {
-        guard isGeneratedOnDevice, !hasLocalIdentity else { return nil }
+    /// `nil` = the SDK default budget. `hasLocalIdentity == nil` means the
+    /// lookup was inconclusive (fetch failed, no wallet row): the probe is
+    /// only ever applied to a wallet KNOWN to have no local identity, so the
+    /// unknown case keeps the default budget.
+    static func startupBudget(isGeneratedOnDevice: Bool, hasLocalIdentity: Bool?) -> TimeInterval? {
+        guard isGeneratedOnDevice, hasLocalIdentity == false else { return nil }
         return generatedWalletStartupBudget
     }
 }
@@ -811,11 +823,20 @@ final class DWSameSeedIdentityRecoveryCoordinator {
             // pipeline's discovery and name refresh would only repeat SDK
             // work. Adopt app-side and settle — a known identity adopts even
             // for a context settled earlier in this process.
+            // The marker goes regardless (the seed owns an identity; the
+            // default budget is the safe direction), but the context settles
+            // only on a successful adoption — `reconcileRecoveredIdentity`
+            // returns false while the host or the snapshot is still
+            // hydrating, and that must stay retryable.
             GeneratedWalletIdentityMarker.clear(walletId: walletId)
             let adopted = DWCurrentUserIdentityInfo.shared.reconcileRecoveredIdentity()
+            guard adopted else {
+                Self.logger.warning(
+                    "🪪 IDENT-RECOVERY :: identity re-confirmed by startup readiness but not adopted yet; leaving the context open")
+                return
+            }
             completedContexts.insert(contextKey)
-            Self.logger.info(
-                "🪪 IDENT-RECOVERY :: adopted the identity startup readiness re-confirmed adopted=\(adopted, privacy: .public)")
+            Self.logger.info("🪪 IDENT-RECOVERY :: adopted the identity startup readiness re-confirmed")
             return
         case .skipSettled:
             completedContexts.insert(contextKey)
@@ -836,6 +857,7 @@ final class DWSameSeedIdentityRecoveryCoordinator {
 
         do {
             let outcome = try await SameSeedIdentityRecoveryPipeline.run(
+                knownIdentityIds: verdict?.identityId.map { [$0] } ?? [],
                 localIdentityIds: {
                     Self.localIdentityIds(walletId: walletId, modelContainer: modelContainer)
                 },
@@ -915,13 +937,15 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     /// `.identities` hydrates the inverse on demand; `isEmpty` faults the
     /// relationship but skips the sort and the `[Data]` copy
     /// `localIdentityIds` builds for callers that need the ids.
-    static func hasLocalIdentity(walletId: Data, modelContainer: ModelContainer) -> Bool {
+    /// `nil` when the answer is unknown — the fetch threw or there is no
+    /// wallet row to ask — so the caller can fail towards the default budget.
+    static func hasLocalIdentity(walletId: Data, modelContainer: ModelContainer) -> Bool? {
         var descriptor = FetchDescriptor<PersistentWallet>(
             predicate: #Predicate { $0.walletId == walletId }
         )
         descriptor.fetchLimit = 1
         guard let persistedWallet = try? modelContainer.mainContext.fetch(descriptor).first else {
-            return false
+            return nil
         }
         return !persistedWallet.identities.isEmpty
     }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -601,6 +601,11 @@ enum SameSeedIdentityRecoveryPipeline {
         let discoveredCount: Int
         let identityCount: Int
         let adopted: Bool
+        /// Whether the identity rows were found in the local store AFTER the
+        /// name refresh. `false` means the ids came from a discovery result
+        /// or from the readiness verdict and the persister has not landed
+        /// them (yet) — the caller must not treat the identity as settled.
+        let identitiesPersisted: Bool
     }
 
     /// `knownIdentityIds`: identities the readiness pass already discovered
@@ -633,14 +638,20 @@ enum SameSeedIdentityRecoveryPipeline {
         }
 
         guard !identityIds.isEmpty else {
-            return Outcome(discoveredCount: discoveredIds.count, identityCount: 0, adopted: false)
+            return Outcome(
+                discoveredCount: discoveredIds.count, identityCount: 0, adopted: false, identitiesPersisted: false)
         }
 
         try await refreshNames(identityIds)
+        // Re-read rather than trust the ids we acted on: `knownIdentityIds`
+        // came from a different call, and even a discovery result can
+        // outrun its own persistence.
+        let identitiesPersisted = !localIdentityIds().isEmpty
         return Outcome(
             discoveredCount: discoveredIds.count,
             identityCount: identityIds.count,
-            adopted: adopt())
+            adopted: adopt(),
+            identitiesPersisted: identitiesPersisted)
     }
 }
 
@@ -666,15 +677,17 @@ enum StartupIdentityRecoveryPolicy {
         /// Run the full pipeline (discover if needed → refresh names → adopt),
         /// subject to the per-process settled memo.
         case runPipeline
-        /// Readiness discovered and persisted the identity in THIS start: a
-        /// second install's first sight of it. The pipeline runs regardless
-        /// of the settled memo — its discovery finds the rows already there,
-        /// and its name refresh rebuilds the contested-label bookmarks a new
-        /// install has no other source for.
+        /// Readiness knows the identity but this install has not yet
+        /// rebuilt the contested-label bookmarks for it (first sight after a
+        /// discovery, or a name refresh that failed on an earlier start).
+        /// The pipeline runs regardless of the settled memo — its discovery
+        /// finds the rows already there, and its name refresh rebuilds the
+        /// bookmarks a new install has no other source for.
         case refreshNamesAndAdopt
-        /// Readiness re-confirmed an identity that was already local: only
-        /// the app-side adoption can be missing, so the pipeline's DPNS
-        /// round trips are skipped on the switch's critical path.
+        /// Readiness re-confirmed an identity that was already local AND the
+        /// bookmarks were rebuilt on this install: only the app-side
+        /// adoption can be missing, so the pipeline's DPNS round trips are
+        /// skipped on the switch's critical path.
         case adoptOnly
         /// Platform confirmed the seed owns no identity; nothing to do.
         case skipSettled
@@ -687,17 +700,24 @@ enum StartupIdentityRecoveryPolicy {
     /// (Platform or the Keychain scan key not reachable, also what the SDK
     /// decodes an unrecognised FFI status into), `.discoveryFailed` (a local
     /// fault the pipeline's own discovery entry point may not share) and the
-    /// rest — is the SDK's "ask again", answered by the pipeline.
+    /// rest — is the SDK's "ask again", answered by the pipeline unless the
+    /// wallet was already settled in this process (the per-process memo);
+    /// every runtime start asks the SDK again regardless.
     /// `readinessDiscoveredThisStart` is `discoveryAttempts > 0`: the SDK
     /// ran a scan rather than reusing an identity already on file.
+    /// `contestedBookmarksRebuilt` is this install's record of a completed
+    /// name refresh for the wallet.
     static func decision(
         readinessStatus: WalletStartupStatus?,
         readinessIdentityId: Data?,
-        readinessDiscoveredThisStart: Bool
+        readinessDiscoveredThisStart: Bool,
+        contestedBookmarksRebuilt: Bool
     ) -> Decision {
         guard let readinessStatus else { return .runPipeline }
         if readinessIdentityId != nil {
-            return readinessDiscoveredThisStart ? .refreshNamesAndAdopt : .adoptOnly
+            return !readinessDiscoveredThisStart && contestedBookmarksRebuilt
+                ? .adoptOnly
+                : .refreshNamesAndAdopt
         }
         switch readinessStatus {
         case .noIdentity:
@@ -713,13 +733,16 @@ enum StartupIdentityRecoveryPolicy {
     /// Whether a short-budget probe found an identity but ran out of budget
     /// before the contact-request pass and the contact-account drain
     /// completed — the two steps the readiness pass exists to guarantee
-    /// before the first SPV filter set is built.
+    /// before the first SPV filter set is built. Never when the drain was
+    /// skipped for `seedBindingUnverified`: the SDK fails that closed on
+    /// every budget, so a re-run would be pure latency.
     static func probeNeedsFullRerun(
         identityFound: Bool,
         dashPaySyncRan: Bool,
-        contactAccountsPending: UInt32
+        contactAccountsPending: UInt32,
+        seedBindingUnverified: Bool
     ) -> Bool {
-        identityFound && (!dashPaySyncRan || contactAccountsPending > 0)
+        identityFound && !seedBindingUnverified && (!dashPaySyncRan || contactAccountsPending > 0)
     }
 
     /// `nil` = the SDK default budget. `hasLocalIdentity == nil` means the
@@ -787,6 +810,24 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         let suffix = ":" + walletId.hexEncodedString()
         completedContexts = completedContexts.filter { !$0.hasSuffix(suffix) }
         startupVerdicts = startupVerdicts.filter { !$0.key.hasSuffix(suffix) }
+        UserDefaults.standard.removeObject(forKey: Self.bookmarksRebuiltKey(walletId: walletId))
+    }
+
+    /// Per-install record that the pipeline's name refresh — the only code
+    /// path that rebuilds `DWContestedNameStatusService` submission
+    /// bookmarks from Platform — completed for `walletId`. UserDefaults on
+    /// purpose: a reinstall starts without bookmarks and must rebuild them
+    /// once, and a refresh that failed on one start stays due on the next.
+    private static func bookmarksRebuiltKey(walletId: Data) -> String {
+        "DWContestedBookmarksRebuilt." + walletId.hexEncodedString()
+    }
+
+    private static func contestedBookmarksRebuilt(walletId: Data) -> Bool {
+        UserDefaults.standard.bool(forKey: bookmarksRebuiltKey(walletId: walletId))
+    }
+
+    private static func recordContestedBookmarksRebuilt(walletId: Data) {
+        UserDefaults.standard.set(true, forKey: bookmarksRebuiltKey(walletId: walletId))
     }
 
     /// Startup budget for the SDK's pre-SPV sequence, or `nil` for the SDK
@@ -806,31 +847,41 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     ) async {
         let walletId = wallet.walletId
         let contextKey = Self.contextKey(walletId: walletId, network: network)
-        // Consumed first: a verdict belongs to exactly one decision, and
-        // every branch below that acts on it records the outcome in
-        // `completedContexts`, so the decision holds for the rest of the
-        // process rather than for one call.
-        let verdict = startupVerdicts.removeValue(forKey: contextKey)
 
+        // An in-flight run for this context keeps its verdict untouched: the
+        // call that started it settles or returns it.
         guard !activeContexts.contains(contextKey) else { return }
+
+        // Consumed here. A branch that settles the context keeps it
+        // consumed; a branch that ends without settling — adoption not
+        // possible yet, a thrown pipeline — puts it back, so the retry
+        // decides on the same verdict instead of degrading to a verdict-less
+        // pipeline run. Only an identity that turned out NOT to be persisted
+        // leaves without either: there the retry must rediscover.
+        let verdict = startupVerdicts.removeValue(forKey: contextKey)
+        func restoreVerdict() {
+            if let verdict { startupVerdicts[contextKey] = verdict }
+        }
 
         switch StartupIdentityRecoveryPolicy.decision(
             readinessStatus: verdict?.status,
             readinessIdentityId: verdict?.identityId,
-            readinessDiscoveredThisStart: verdict?.discovered ?? false) {
+            readinessDiscoveredThisStart: verdict?.discovered ?? false,
+            contestedBookmarksRebuilt: Self.contestedBookmarksRebuilt(walletId: walletId)) {
         case .adoptOnly:
-            // Readiness re-confirmed an identity already on file; the
-            // pipeline's discovery and name refresh would only repeat SDK
-            // work. Adopt app-side and settle — a known identity adopts even
-            // for a context settled earlier in this process.
-            // The marker goes regardless (the seed owns an identity; the
-            // default budget is the safe direction), but the context settles
-            // only on a successful adoption — `reconcileRecoveredIdentity`
-            // returns false while the host or the snapshot is still
-            // hydrating, and that must stay retryable.
+            // Readiness re-confirmed an identity already on file and this
+            // install has its bookmarks; the pipeline's discovery and name
+            // refresh would only repeat SDK work. Adopt app-side and settle
+            // — a known identity adopts even for a context settled earlier
+            // in this process. The marker goes regardless (the seed owns an
+            // identity; the default budget is the safe direction), but the
+            // context settles only on a successful adoption —
+            // `reconcileRecoveredIdentity` returns false while the host or
+            // the snapshot is still hydrating, and that must stay retryable.
             GeneratedWalletIdentityMarker.clear(walletId: walletId)
             let adopted = DWCurrentUserIdentityInfo.shared.reconcileRecoveredIdentity()
             guard adopted else {
+                restoreVerdict()
                 Self.logger.warning(
                     "🪪 IDENT-RECOVERY :: identity re-confirmed by startup readiness but not adopted yet; leaving the context open")
                 return
@@ -844,9 +895,10 @@ final class DWSameSeedIdentityRecoveryCoordinator {
                 "🪪 IDENT-RECOVERY :: skipped — startup readiness proved this seed owns no identity")
             return
         case .refreshNamesAndAdopt:
-            // First sight of this identity on this install: run the pipeline
-            // past the settled memo (its discovery finds the rows readiness
-            // just persisted; the name refresh rebuilds contested bookmarks).
+            // Identity known but this install still owes it a name refresh:
+            // run the pipeline past the settled memo (its discovery finds the
+            // rows readiness persisted; the name refresh rebuilds the
+            // contested bookmarks).
             break
         case .runPipeline:
             guard !completedContexts.contains(contextKey) else { return }
@@ -903,18 +955,31 @@ final class DWSameSeedIdentityRecoveryCoordinator {
 
             if outcome.identityCount > 0 {
                 // The seed owns an identity after all; the next start must
-                // run the full pre-SPV bring-up, not the generated-wallet probe.
+                // run the full pre-SPV bring-up, not the generated-wallet
+                // probe. And the name refresh completed for it, so the
+                // contested bookmarks exist on this install.
                 GeneratedWalletIdentityMarker.clear(walletId: walletId)
+                Self.recordContestedBookmarksRebuilt(walletId: walletId)
             }
-            completedContexts.insert(contextKey)
+            if outcome.identityCount == 0 || outcome.identitiesPersisted {
+                completedContexts.insert(contextKey)
+            } else {
+                // Acted on ids the store has not confirmed: leave the context
+                // open (and the verdict consumed) so the next attempt runs
+                // the discovery that repopulates the store.
+                Self.logger.warning(
+                    "🪪 IDENT-RECOVERY :: identity acted on but not yet persisted locally; leaving the context open")
+            }
             Self.logger.info(
                 """
                 🪪 IDENT-RECOVERY :: complete \
                 discovered=\(outcome.discoveredCount, privacy: .public) \
                 identities=\(outcome.identityCount, privacy: .public) \
+                persisted=\(outcome.identitiesPersisted, privacy: .public) \
                 adopted=\(outcome.adopted, privacy: .public)
                 """)
         } catch {
+            restoreVerdict()
             Self.logger.warning(
                 """
                 🪪 IDENT-RECOVERY :: failed; will retry after next runtime start: \

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -968,7 +968,17 @@ final class DWSameSeedIdentityRecoveryCoordinator {
                 // probe.
                 GeneratedWalletIdentityMarker.clear(walletId: walletId)
             }
-            if outcome.identityCount == 0 || outcome.identitiesPersisted {
+            if outcome.identityCount == 0, !allowDiscovery {
+                // Nothing was established: this run was forbidden from
+                // scanning (a local fault the SDK says a rescan cannot
+                // clear) and found no local rows to adopt. Settling here
+                // would retire the backstop for the process on a transient
+                // fault, so leave the context open and hand the verdict back
+                // for a later start whose readiness has improved.
+                restoreVerdict()
+                Self.logger.warning(
+                    "🪪 IDENT-RECOVERY :: no local identity to adopt and scanning was not allowed; leaving the context open")
+            } else if outcome.identityCount == 0 || outcome.identitiesPersisted {
                 completedContexts.insert(contextKey)
                 unpersistedAttempts[contextKey] = nil
             } else {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -642,42 +642,75 @@ enum SameSeedIdentityRecoveryPipeline {
 enum StartupIdentityRecoveryPolicy {
     /// Budget handed to the SDK's startup sequence for a wallet whose
     /// mnemonic was generated on this device and that has no local identity.
-    /// It caps the WHOLE sequence, so it is only ever used as a first probe:
-    /// a proof of absence settles on the first discovery pass (seconds), an
-    /// unreachable Platform costs this much instead of the SDK default, and
-    /// a found identity makes `DashPayContactAddressReadiness` re-run the
-    /// sequence with the default budget so the contact sync and the
-    /// contact-account drain are not cut short.
+    /// It caps the WHOLE sequence, so it is only ever a first probe: a proof
+    /// of absence settles on the first discovery pass, an unreachable
+    /// Platform costs this much instead of the SDK default, and a probe cut
+    /// short after finding an identity is re-run with the default budget
+    /// (`probeNeedsFullRerun`). A probe that is cut off before it finds
+    /// anything reports `.partialNoIdentity`, which `decision` sends to the
+    /// backstop — so a generated wallet whose seed owns an identity
+    /// registered elsewhere is still discovered in the same runtime start.
     static let generatedWalletStartupBudget: TimeInterval = 5
 
+    /// What the backstop does with the readiness verdict of this start.
+    enum Decision: Equatable {
+        /// Run the full pipeline (discover if needed → refresh names → adopt),
+        /// subject to the per-process settled memo.
+        case runPipeline
+        /// Readiness discovered and persisted the identity in THIS start: a
+        /// second install's first sight of it. The pipeline runs regardless
+        /// of the settled memo — its discovery finds the rows already there,
+        /// and its name refresh rebuilds the contested-label bookmarks a new
+        /// install has no other source for.
+        case refreshNamesAndAdopt
+        /// Readiness re-confirmed an identity that was already local: only
+        /// the app-side adoption can be missing, so the pipeline's DPNS
+        /// round trips are skipped on the switch's critical path.
+        case adoptOnly
+        /// Platform confirmed the seed owns no identity; nothing to do.
+        case skipSettled
+    }
+
     /// `nil` status = no readiness pass ran in this start (a Platform-sync
-    /// re-arm, the storage explorer's direct BLAST start): the backstop runs
-    /// as before. A known identity keeps it running too — the pipeline then
-    /// skips discovery and only refreshes names + adopts. `.noIdentity` and
-    /// `.discoveryFailed` settle the question for this start (retrying the
-    /// unbudgeted scan is what cost a wallet switch 31 s). A pass that
-    /// never reached Platform (`.partialNoIdentity`, which is also what the
-    /// SDK decodes an unrecognised FFI status into) keeps the backstop as
-    /// the in-session retry — except for a wallet generated on this device,
-    /// where the next runtime start retries instead. Every other status
-    /// leaves the question to the backstop.
-    static func shouldRunBackstop(
+    /// re-arm, the storage explorer's direct BLAST start, a thrown or elided
+    /// pass): the pipeline runs as before. Only `.noIdentity` settles the
+    /// question; every other identity-less status — `.partialNoIdentity`
+    /// (Platform or the Keychain scan key not reachable, also what the SDK
+    /// decodes an unrecognised FFI status into), `.discoveryFailed` (a local
+    /// fault the pipeline's own discovery entry point may not share) and the
+    /// rest — is the SDK's "ask again", answered by the pipeline.
+    /// `readinessDiscoveredThisStart` is `discoveryAttempts > 0`: the SDK
+    /// ran a scan rather than reusing an identity already on file.
+    static func decision(
         readinessStatus: WalletStartupStatus?,
         readinessIdentityId: Data?,
-        isGeneratedOnDevice: Bool
-    ) -> Bool {
-        guard let readinessStatus else { return true }
-        if readinessIdentityId != nil { return true }
-        switch readinessStatus {
-        case .noIdentity, .discoveryFailed:
-            return false
-        case .partialNoIdentity, .identityScanIncomplete:
-            return !isGeneratedOnDevice
-        case .ready, .partialAccountsPending, .seedBindingUnverified:
-            return true
-        @unknown default:
-            return true
+        readinessDiscoveredThisStart: Bool
+    ) -> Decision {
+        guard let readinessStatus else { return .runPipeline }
+        if readinessIdentityId != nil {
+            return readinessDiscoveredThisStart ? .refreshNamesAndAdopt : .adoptOnly
         }
+        switch readinessStatus {
+        case .noIdentity:
+            return .skipSettled
+        case .partialNoIdentity, .discoveryFailed, .ready, .partialAccountsPending,
+             .seedBindingUnverified, .identityScanIncomplete:
+            return .runPipeline
+        @unknown default:
+            return .runPipeline
+        }
+    }
+
+    /// Whether a short-budget probe found an identity but ran out of budget
+    /// before the contact-request pass and the contact-account drain
+    /// completed — the two steps the readiness pass exists to guarantee
+    /// before the first SPV filter set is built.
+    static func probeNeedsFullRerun(
+        identityFound: Bool,
+        dashPaySyncRan: Bool,
+        contactAccountsPending: UInt32
+    ) -> Bool {
+        identityFound && (!dashPaySyncRan || contactAccountsPending > 0)
     }
 
     /// `nil` = the SDK default budget.
@@ -688,9 +721,13 @@ enum StartupIdentityRecoveryPolicy {
 }
 
 /// Best-effort startup recovery for an identity created by the same seed on a
-/// different device/install. One successful attempt is enough per
-/// network-scoped wallet and process; failures remain retryable on the next
-/// runtime start.
+/// different device/install. A network-scoped wallet is settled once per
+/// process — by a completed pipeline run, by a readiness pass that proved
+/// the seed owns no identity, or by adopting the identity a readiness pass
+/// found — until `forgetWallet` (wallet deletion) drops it, so a phrase
+/// removed and re-imported in the same session gets its attempt back.
+/// Failures remain retryable on the next runtime start. A readiness verdict
+/// with a known identity always adopts, settled or not.
 @MainActor
 final class DWSameSeedIdentityRecoveryCoordinator {
     static let shared = DWSameSeedIdentityRecoveryCoordinator()
@@ -705,7 +742,7 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     /// the current runtime start. `recoverIfNeeded` removes the verdict for
     /// its context on entry, before any early return, so one verdict is
     /// consulted at most once.
-    private var startupVerdicts: [String: (status: WalletStartupStatus, identityId: Data?)] = [:]
+    private var startupVerdicts: [String: (status: WalletStartupStatus, identityId: Data?, discovered: Bool)] = [:]
 
     private init() {}
 
@@ -714,30 +751,40 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     func recordStartupDiscovery(
         status: WalletStartupStatus,
         identityId: Data?,
+        discoveredThisStart: Bool,
         walletId: Data,
         network: Network
     ) {
-        startupVerdicts[Self.contextKey(walletId: walletId, network: network)] = (status, identityId)
+        startupVerdicts[Self.contextKey(walletId: walletId, network: network)] =
+            (status, identityId, discoveredThisStart)
     }
 
     /// Runtime teardown (`SwiftDashSDKWalletRuntime.fullReset`) calls this
-    /// so nothing recorded here outlives the start that produced it: the
-    /// readiness verdicts, and the completed contexts — walletIds are
-    /// deterministic per mnemonic+network, so a wallet removed and
-    /// re-imported in the same session must get its recovery attempt back.
-    func resetForRuntimeTeardown() {
+    /// so a readiness verdict never outlives the start that produced it.
+    /// The settled contexts deliberately survive: they are the per-process
+    /// memo that keeps the unbudgeted scan from running on every switch.
+    func clearStartupVerdicts() {
         startupVerdicts.removeAll()
-        completedContexts.removeAll()
+    }
+
+    /// Drop everything remembered about `walletId` on every network. Called
+    /// on wallet deletion: walletIds are deterministic per mnemonic+network,
+    /// so a phrase removed and re-imported must not inherit a settled
+    /// context.
+    func forgetWallet(walletId: Data) {
+        let suffix = ":" + walletId.hexEncodedString()
+        completedContexts = completedContexts.filter { !$0.hasSuffix(suffix) }
+        startupVerdicts = startupVerdicts.filter { !$0.key.hasSuffix(suffix) }
     }
 
     /// Startup budget for the SDK's pre-SPV sequence, or `nil` for the SDK
     /// default — see `StartupIdentityRecoveryPolicy.startupBudget`. The
-    /// SwiftData fetch only runs for a marked wallet.
+    /// SwiftData existence check only runs for a marked wallet.
     func startupBudget(walletId: Data, modelContainer: ModelContainer) -> TimeInterval? {
         guard GeneratedWalletIdentityMarker.isMarked(walletId: walletId) else { return nil }
         return StartupIdentityRecoveryPolicy.startupBudget(
             isGeneratedOnDevice: true,
-            hasLocalIdentity: !Self.localIdentityIds(walletId: walletId, modelContainer: modelContainer).isEmpty)
+            hasLocalIdentity: Self.hasLocalIdentity(walletId: walletId, modelContainer: modelContainer))
     }
 
     func recoverIfNeeded(
@@ -747,27 +794,41 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     ) async {
         let walletId = wallet.walletId
         let contextKey = Self.contextKey(walletId: walletId, network: network)
-        // Consumed first: a verdict belongs to exactly one backstop decision,
-        // whichever branch below takes it.
+        // Consumed first: a verdict belongs to exactly one decision, and
+        // every branch below that acts on it records the outcome in
+        // `completedContexts`, so the decision holds for the rest of the
+        // process rather than for one call.
         let verdict = startupVerdicts.removeValue(forKey: contextKey)
 
-        guard !completedContexts.contains(contextKey),
-              !activeContexts.contains(contextKey)
-        else {
-            return
-        }
+        guard !activeContexts.contains(contextKey) else { return }
 
-        if let verdict,
-           !StartupIdentityRecoveryPolicy.shouldRunBackstop(
-               readinessStatus: verdict.status,
-               readinessIdentityId: verdict.identityId,
-               isGeneratedOnDevice: GeneratedWalletIdentityMarker.isMarked(walletId: walletId)) {
+        switch StartupIdentityRecoveryPolicy.decision(
+            readinessStatus: verdict?.status,
+            readinessIdentityId: verdict?.identityId,
+            readinessDiscoveredThisStart: verdict?.discovered ?? false) {
+        case .adoptOnly:
+            // Readiness re-confirmed an identity already on file; the
+            // pipeline's discovery and name refresh would only repeat SDK
+            // work. Adopt app-side and settle — a known identity adopts even
+            // for a context settled earlier in this process.
+            GeneratedWalletIdentityMarker.clear(walletId: walletId)
+            let adopted = DWCurrentUserIdentityInfo.shared.reconcileRecoveredIdentity()
+            completedContexts.insert(contextKey)
             Self.logger.info(
-                """
-                🪪 IDENT-RECOVERY :: skipped — startup readiness already ran discovery \
-                (status=\(verdict.status.rawValue, privacy: .public))
-                """)
+                "🪪 IDENT-RECOVERY :: adopted the identity startup readiness re-confirmed adopted=\(adopted, privacy: .public)")
             return
+        case .skipSettled:
+            completedContexts.insert(contextKey)
+            Self.logger.info(
+                "🪪 IDENT-RECOVERY :: skipped — startup readiness proved this seed owns no identity")
+            return
+        case .refreshNamesAndAdopt:
+            // First sight of this identity on this install: run the pipeline
+            // past the settled memo (its discovery finds the rows readiness
+            // just persisted; the name refresh rebuilds contested bookmarks).
+            break
+        case .runPipeline:
+            guard !completedContexts.contains(contextKey) else { return }
         }
 
         activeContexts.insert(contextKey)
@@ -818,6 +879,11 @@ final class DWSameSeedIdentityRecoveryCoordinator {
                     DWCurrentUserIdentityInfo.shared.reconcileRecoveredIdentity()
                 })
 
+            if outcome.identityCount > 0 {
+                // The seed owns an identity after all; the next start must
+                // run the full pre-SPV bring-up, not the generated-wallet probe.
+                GeneratedWalletIdentityMarker.clear(walletId: walletId)
+            }
             completedContexts.insert(contextKey)
             Self.logger.info(
                 """
@@ -836,12 +902,21 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     }
 
     private static func contextKey(walletId: Data, network: Network) -> String {
-        "\(network.rawValue):" + walletId.map { String(format: "%02x", $0) }.joined()
+        "\(network.rawValue):" + walletId.hexEncodedString()
     }
 
-    /// Internal (was private): shared with the startup-budget decision above
-    /// — reuse, not a copy, per the repo's no-copy-then-adapt guardrail.
-    static func localIdentityIds(
+    /// Existence check for the startup-budget decision: a `fetchCount` over
+    /// the identity rows of `walletId`, so the wallet-switch path never
+    /// faults in and sorts the identity set it would only test for emptiness.
+    static func hasLocalIdentity(walletId: Data, modelContainer: ModelContainer) -> Bool {
+        var descriptor = FetchDescriptor<PersistentIdentity>(
+            predicate: #Predicate { $0.wallet?.walletId == walletId }
+        )
+        descriptor.fetchLimit = 1
+        return ((try? modelContainer.mainContext.fetchCount(descriptor)) ?? 0) > 0
+    }
+
+    private static func localIdentityIds(
         walletId: Data,
         modelContainer: ModelContainer
     ) -> [Data] {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -856,13 +856,14 @@ final class DWSameSeedIdentityRecoveryCoordinator {
     }
 
     /// Startup budget for the SDK's pre-SPV sequence, or `nil` for the SDK
-    /// default — see `StartupIdentityRecoveryPolicy.startupBudget`. The
-    /// SwiftData existence check only runs for a marked wallet.
-    func startupBudget(walletId: Data, modelContainer: ModelContainer) -> TimeInterval? {
-        guard GeneratedWalletIdentityMarker.isMarked(walletId: walletId) else { return nil }
-        return StartupIdentityRecoveryPolicy.startupBudget(
-            isGeneratedOnDevice: true,
-            hasLocalIdentity: Self.hasLocalIdentity(walletId: walletId, modelContainer: modelContainer))
+    /// default — see `StartupIdentityRecoveryPolicy.startupBudget`. Takes
+    /// the store reading rather than repeating it: the caller needs the
+    /// same value to tell a first sight from a re-confirmation, and this
+    /// runs on the pre-SPV main-thread path.
+    func startupBudget(walletId: Data, hasLocalIdentity: Bool?) -> TimeInterval? {
+        StartupIdentityRecoveryPolicy.startupBudget(
+            isGeneratedOnDevice: GeneratedWalletIdentityMarker.isMarked(walletId: walletId),
+            hasLocalIdentity: hasLocalIdentity)
     }
 
     func recoverIfNeeded(
@@ -885,9 +886,12 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         // identity the store never confirmed: there the verdict stays
         // consumed so the retry rediscovers.
         let verdict = startupVerdicts.removeValue(forKey: contextKey)
-        // Restores only into an empty slot: a verdict recorded (or a clear
-        // performed by `fullReset`) while this call was suspended is newer
-        // than the one this call took, and wins.
+        // Restores only into an empty slot, so a verdict RECORDED while this
+        // call was suspended wins over the one this call took. It does not
+        // distinguish "cleared by `fullReset`" from "never recorded" — both
+        // leave the slot nil. That case is handled by ordering instead:
+        // every non-elided refresh runs `fullReset` before the readiness
+        // pass that records the next verdict.
         func restoreVerdict() {
             if let verdict, startupVerdicts[contextKey] == nil { startupVerdicts[contextKey] = verdict }
         }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -908,6 +908,12 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         defer { activeContexts.remove(contextKey) }
 
         do {
+            // The contested-name half of `refreshNames` is best-effort per
+            // identity (a throw there must not fail the restore), so its
+            // success has to be carried out separately: the bookmark record
+            // below may only be written when every identity's contested
+            // refresh actually completed.
+            var contestedRefreshCompleted = true
             let outcome = try await SameSeedIdentityRecoveryPipeline.run(
                 knownIdentityIds: verdict?.identityId.map { [$0] } ?? [],
                 localIdentityIds: {
@@ -941,6 +947,7 @@ final class DWSameSeedIdentityRecoveryCoordinator {
                                     label: recoveredPending)
                             }
                         } catch {
+                            contestedRefreshCompleted = false
                             Self.logger.warning(
                                 """
                                 🪪 IDENT-RECOVERY :: contested-name refresh failed: \
@@ -956,10 +963,14 @@ final class DWSameSeedIdentityRecoveryCoordinator {
             if outcome.identityCount > 0 {
                 // The seed owns an identity after all; the next start must
                 // run the full pre-SPV bring-up, not the generated-wallet
-                // probe. And the name refresh completed for it, so the
-                // contested bookmarks exist on this install.
+                // probe.
                 GeneratedWalletIdentityMarker.clear(walletId: walletId)
-                Self.recordContestedBookmarksRebuilt(walletId: walletId)
+                // The bookmarks exist on this install only if the contested
+                // refresh completed for every identity; otherwise the next
+                // start with a known identity owes the name refresh again.
+                if contestedRefreshCompleted {
+                    Self.recordContestedBookmarksRebuilt(walletId: walletId)
+                }
             }
             if outcome.identityCount == 0 || outcome.identitiesPersisted {
                 completedContexts.insert(contextKey)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -905,15 +905,25 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         "\(network.rawValue):" + walletId.hexEncodedString()
     }
 
-    /// Existence check for the startup-budget decision: a `fetchCount` over
-    /// the identity rows of `walletId`, so the wallet-switch path never
-    /// faults in and sorts the identity set it would only test for emptiness.
+    /// Existence check for the startup-budget decision. Queried from the
+    /// wallet side, like `computeSnapshot`: a `#Predicate` over
+    /// `identity.wallet?.walletId` compiles to a relationship traversal that
+    /// silently misses rows on cold launch until the inverse edge is
+    /// hydrated, and this runs BEFORE `startWalletSubsystems` — a miss would
+    /// hand a wallet that does own a local identity the short probe budget.
+    /// `walletId` is a direct attribute on `PersistentWallet`, and reading
+    /// `.identities` hydrates the inverse on demand; `isEmpty` faults the
+    /// relationship but skips the sort and the `[Data]` copy
+    /// `localIdentityIds` builds for callers that need the ids.
     static func hasLocalIdentity(walletId: Data, modelContainer: ModelContainer) -> Bool {
-        var descriptor = FetchDescriptor<PersistentIdentity>(
-            predicate: #Predicate { $0.wallet?.walletId == walletId }
+        var descriptor = FetchDescriptor<PersistentWallet>(
+            predicate: #Predicate { $0.walletId == walletId }
         )
         descriptor.fetchLimit = 1
-        return ((try? modelContainer.mainContext.fetchCount(descriptor)) ?? 0) > 0
+        guard let persistedWallet = try? modelContainer.mainContext.fetch(descriptor).first else {
+            return false
+        }
+        return !persistedWallet.identities.isEmpty
     }
 
     private static func localIdentityIds(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -698,11 +698,13 @@ enum StartupIdentityRecoveryPolicy {
         /// Platform confirmed the seed owns no identity; settled for the
         /// process.
         case skipSettled
-        /// The SDK reports the question unanswered AND not worth asking
-        /// again (`.discoveryFailed`: a local wallet/persistence fault): no
-        /// scan, but the pipeline still refreshes and adopts whatever
-        /// identity rows exist locally, under the memo. The next runtime
-        /// start asks the SDK again.
+        /// Platform answered the network side and a scan would add nothing
+        /// — either it proved absence while the local store may still hold
+        /// rows, or the SDK reports a local fault a rescan cannot clear
+        /// (`.discoveryFailed`). No scan, but the pipeline still refreshes
+        /// and adopts whatever identity rows exist locally, under the memo.
+        /// A run that finds none settles nothing; the next runtime start
+        /// asks the SDK again.
         case runPipelineWithoutDiscovery
     }
 
@@ -722,16 +724,26 @@ enum StartupIdentityRecoveryPolicy {
     /// identity before the readiness pass and has one after it — measured
     /// by the caller from the store, not from `discoveryAttempts`, which
     /// the SDK also increments when it rescans an identity already on file.
+    /// `hasLocalIdentity` is the same store reading the startup budget uses,
+    /// `nil` when the lookup was inconclusive. A proof of absence only
+    /// settles a wallet the store agrees has no identity: the two can
+    /// disagree (a SwiftData mirror outliving a Rust-side store reset, a
+    /// watch-only wallet Rust answers for without a signer), and rows on
+    /// disk still deserve adoption — without a scan, since Platform already
+    /// answered the network side.
     static func decision(
         readinessStatus: WalletStartupStatus?,
         readinessIdentityId: Data?,
-        readinessDiscoveredThisStart: Bool
+        readinessDiscoveredThisStart: Bool,
+        hasLocalIdentity: Bool?
     ) -> Decision {
         guard let readinessStatus else { return .runPipeline }
         if readinessIdentityId != nil {
             return readinessDiscoveredThisStart ? .refreshNamesAndAdopt : .runPipeline
         }
-        if readinessStatus == .noIdentity { return .skipSettled }
+        if readinessStatus == .noIdentity {
+            return hasLocalIdentity == false ? .skipSettled : .runPipelineWithoutDiscovery
+        }
         if readinessStatus.discoveryWorthRetrying || readinessStatus.identityIsSettled {
             return .runPipeline
         }
@@ -884,7 +896,8 @@ final class DWSameSeedIdentityRecoveryCoordinator {
         switch StartupIdentityRecoveryPolicy.decision(
             readinessStatus: verdict?.status,
             readinessIdentityId: verdict?.identityId,
-            readinessDiscoveredThisStart: verdict?.discovered ?? false) {
+            readinessDiscoveredThisStart: verdict?.discovered ?? false,
+            hasLocalIdentity: Self.hasLocalIdentity(walletId: walletId, modelContainer: modelContainer)) {
         case .skipSettled:
             completedContexts.insert(contextKey)
             Self.logger.info(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -1375,14 +1375,16 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                 DWGlobalOptions.sharedInstance().dashpayUsername = username
                 DWGlobalOptions.sharedInstance().dashpayRegistrationCompleted = true
             }
-            // The wallet now owns an identity: drop the generated-on-device
-            // marker so the next runtime start runs the full pre-SPV
-            // bring-up (hygiene — the budget gate also checks local rows).
-            // Keyed by the wallet this attempt started for, not the host's
-            // current wallet, which a switch may have rebound meanwhile.
-            if let walletId = registrationWalletId {
-                GeneratedWalletIdentityMarker.clear(walletId: walletId)
-            }
+        }
+
+        // The registering wallet now owns an identity: drop its
+        // generated-on-device marker so the next runtime start runs the
+        // full pre-SPV bring-up (hygiene — the budget gate also checks local
+        // rows). Independent of the username mirror above, and keyed by the
+        // wallet this attempt started for, not the host's current wallet,
+        // which a switch may have rebound meanwhile.
+        if case .completed = newPhase, let walletId = registrationWalletId {
+            GeneratedWalletIdentityMarker.clear(walletId: walletId)
         }
 
         // Stop asset-lock polling on terminal phases — no further

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -310,6 +310,11 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
     /// `.completed` mirror can write DWGlobalOptions.dashpayUsername.
     private(set) var currentUsername: String?
 
+    /// Wallet the in-flight attempt registers for. Stashed at submit time
+    /// because `.completed` arrives after awaited Platform work, during
+    /// which a wallet switch can rebind `SwiftDashSDKHost.shared.wallet`.
+    private var registrationWalletId: Data?
+
     /// Funding source for the in-flight attempt (the value the
     /// coordinator's caller passed into `startCreateUsername(_:fundingSource:)`).
     /// Read by `DWIdentityRegistrationBridge.refreshFromCoordinator`
@@ -536,6 +541,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         resetState()
 
         currentUsername = username
+        registrationWalletId = wallet.walletId
         // A persisted identity-registration lock always wins over the
         // newly-selected funding source. The original Core payment has
         // already happened; presenting PP / shielded progress here would
@@ -963,6 +969,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         }
         resetState()
         currentUsername = name
+        registrationWalletId = wallet.walletId
         currentFundingSource = .core
 
         let newController = DWIdentityRegistrationController()
@@ -1371,7 +1378,9 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
             // The wallet now owns an identity: drop the generated-on-device
             // marker so the next runtime start runs the full pre-SPV
             // bring-up (hygiene — the budget gate also checks local rows).
-            if let walletId = SwiftDashSDKHost.shared.wallet?.walletId {
+            // Keyed by the wallet this attempt started for, not the host's
+            // current wallet, which a switch may have rebound meanwhile.
+            if let walletId = registrationWalletId {
                 GeneratedWalletIdentityMarker.clear(walletId: walletId)
             }
         }
@@ -1439,6 +1448,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         failedAtPhase = nil
         lastErrorMessage = nil
         currentUsername = nil
+        registrationWalletId = nil
         currentFundingSource = .core
         registeredTemporaryUsername = nil
         temporaryUsernameError = nil

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -1368,6 +1368,12 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                 DWGlobalOptions.sharedInstance().dashpayUsername = username
                 DWGlobalOptions.sharedInstance().dashpayRegistrationCompleted = true
             }
+            // The wallet now owns an identity: drop the generated-on-device
+            // marker so the next runtime start runs the full pre-SPV
+            // bring-up (hygiene — the budget gate also checks local rows).
+            if let walletId = SwiftDashSDKHost.shared.wallet?.walletId {
+                GeneratedWalletIdentityMarker.clear(walletId: walletId)
+            }
         }
 
         // Stop asset-lock polling on terminal phases — no further

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -925,7 +925,10 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         // the first filter set is built. This call stays as the backstop for
         // the orders that do not go through the SPV coordinator — a Platform
         // sync re-arm, or an SPV start that failed — and is a no-op once the
-        // identity has been adopted.
+        // identity has been adopted. When the readiness pass did run in this
+        // start it hands its verdict to the coordinator
+        // (`recordStartupDiscovery`), and `recoverIfNeeded` skips the repeat
+        // discovery for a seed that pass found no identity for.
         if let container = SwiftDashSDKHost.shared.modelContainer {
             await DWSameSeedIdentityRecoveryCoordinator.shared.recoverIfNeeded(
                 wallet: resolvedWallet,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -1365,6 +1365,11 @@ final class SwiftDashSDKHost {
 /// short startup budget (`StartupIdentityRecoveryPolicy`). Lives here, not
 /// in the DASHPAY-only identity file, because both writers compile into
 /// every target.
+///
+/// Deliberately NOT restored by `recoverPersistedWallet` (reinstall with a
+/// surviving Keychain mnemonic): UserDefaults die with the app, and a
+/// recovered wallet's origin is unknown — an imported seed must keep the
+/// default budget, so the safe direction is the slower one.
 enum GeneratedWalletIdentityMarker {
     private static func key(walletId: Data) -> String {
         "DWGeneratedWalletNoIdentity." + walletId.map { String(format: "%02x", $0) }.joined()

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -519,6 +519,7 @@ final class SwiftDashSDKHost {
                 mnemonic: mnemonic,
                 manager: handles.manager,
                 network: handles.network,
+                isImported: isImported,
                 // Imported mnemonics may hold history from long before
                 // this device: scan from the network's import floor
                 // (genesis on testnet, block 200,000 on mainnet — see
@@ -551,6 +552,7 @@ final class SwiftDashSDKHost {
                             mnemonic: mnemonic,
                             manager: targetManager,
                             network: targetNetwork,
+                            isImported: isImported,
                             birthHeight: isImported
                                 ? Self.importedWalletBirthHeight(for: targetNetwork)
                                 : nil,
@@ -690,6 +692,7 @@ final class SwiftDashSDKHost {
                     mnemonic: mnemonic,
                     manager: targetManager,
                     network: targetNetwork,
+                    isImported: isImported,
                     // Same semantics as `createOrImportWallet`: imports scan
                     // from each network's import floor, freshly generated
                     // wallets from that network's tip.
@@ -740,10 +743,15 @@ final class SwiftDashSDKHost {
     /// runtime; `createOrImportWallet` is NOT queue-serialized (the
     /// migrator is awaited by refresh itself — enqueueing would deadlock),
     /// so it must keep the MainActor-atomic critical section.
+    /// `isImported` drives `GeneratedWalletIdentityMarker`: a generated
+    /// mnemonic marks its walletId, an imported one clears it (walletIds are
+    /// deterministic per mnemonic+network, so a removed-then-re-imported
+    /// phrase must not inherit a stale marker).
     private func createAndPersist(
         mnemonic: String,
         manager: PlatformWalletManager,
         network: Network,
+        isImported: Bool,
         birthHeight: UInt32?,
         offMainCreate: Bool
     ) async throws -> ManagedPlatformWallet {
@@ -769,7 +777,7 @@ final class SwiftDashSDKHost {
         }
 
         do {
-            return try await MnemonicFirstWalletCreation.run(
+            let created = try await MnemonicFirstWalletCreation.run(
                 mnemonic: mnemonic,
                 persistMnemonic: {
                     try storage.storeMnemonic(mnemonic, for: walletId)
@@ -811,6 +819,12 @@ final class SwiftDashSDKHost {
                     }
                     return try syncCreate()
                 })
+            if isImported {
+                GeneratedWalletIdentityMarker.clear(walletId: walletId)
+            } else {
+                GeneratedWalletIdentityMarker.mark(walletId: walletId)
+            }
+            return created
         } catch MnemonicFirstWalletCreationError.mnemonicRoundTripMismatch {
             Self.logger.error("🪺 HOST :: mnemonic persistence round-trip mismatch")
             throw HostError.mnemonicRoundTripMismatch
@@ -1338,5 +1352,33 @@ final class SwiftDashSDKHost {
         return dir
             .appendingPathComponent("commitment-tree.sqlite", isDirectory: false)
             .path
+    }
+}
+
+/// Per-wallet "this mnemonic was generated on this device" marker, keyed by
+/// the network-scoped walletId (lowercase `%02x` hex, matching
+/// `WalletEnvironment.activeWalletIdHex`). Written by
+/// `SwiftDashSDKHost.createAndPersist` for a generated mnemonic and cleared
+/// there for an imported one, on wallet deletion
+/// (`SwiftDashSDKWalletWiper.deleteWalletFromSDK`) and when username
+/// registration completes. The DashPay identity bring-up reads it to pick a
+/// short startup budget (`StartupIdentityRecoveryPolicy`). Lives here, not
+/// in the DASHPAY-only identity file, because both writers compile into
+/// every target.
+enum GeneratedWalletIdentityMarker {
+    private static func key(walletId: Data) -> String {
+        "DWGeneratedWalletNoIdentity." + walletId.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func mark(walletId: Data) {
+        UserDefaults.standard.set(true, forKey: key(walletId: walletId))
+    }
+
+    static func isMarked(walletId: Data) -> Bool {
+        UserDefaults.standard.bool(forKey: key(walletId: walletId))
+    }
+
+    static func clear(walletId: Data) {
+        UserDefaults.standard.removeObject(forKey: key(walletId: walletId))
     }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -1356,15 +1356,17 @@ final class SwiftDashSDKHost {
 }
 
 /// Per-wallet "this mnemonic was generated on this device" marker, keyed by
-/// the network-scoped walletId (lowercase `%02x` hex, matching
-/// `WalletEnvironment.activeWalletIdHex`). Written by
+/// the network-scoped walletId (`Data.hexEncodedString()`, the same helper
+/// the runtime's wallet logging uses). Written by
 /// `SwiftDashSDKHost.createAndPersist` for a generated mnemonic and cleared
 /// there for an imported one, on wallet deletion
-/// (`SwiftDashSDKWalletWiper.deleteWalletFromSDK`) and when username
-/// registration completes. The DashPay identity bring-up reads it to pick a
-/// short startup budget (`StartupIdentityRecoveryPolicy`). Lives here, not
-/// in the DASHPAY-only identity file, because both writers compile into
-/// every target.
+/// (`SwiftDashSDKWalletWiper.deleteWalletFromSDK`), when username
+/// registration completes, and by the DashPay bring-up as soon as any path
+/// finds an identity for the seed. The identity bring-up reads it to pick a
+/// short startup probe budget (`StartupIdentityRecoveryPolicy`). Lives here,
+/// not in the DASHPAY-only identity file, because both writers compile into
+/// every target. `defaults` is injectable so the mark/clear matrix is
+/// testable against a throwaway suite.
 ///
 /// Deliberately NOT restored by `recoverPersistedWallet` (reinstall with a
 /// surviving Keychain mnemonic): UserDefaults die with the app, and a
@@ -1372,18 +1374,18 @@ final class SwiftDashSDKHost {
 /// default budget, so the safe direction is the slower one.
 enum GeneratedWalletIdentityMarker {
     private static func key(walletId: Data) -> String {
-        "DWGeneratedWalletNoIdentity." + walletId.map { String(format: "%02x", $0) }.joined()
+        "DWGeneratedWalletNoIdentity." + walletId.hexEncodedString()
     }
 
-    static func mark(walletId: Data) {
-        UserDefaults.standard.set(true, forKey: key(walletId: walletId))
+    static func mark(walletId: Data, defaults: UserDefaults = .standard) {
+        defaults.set(true, forKey: key(walletId: walletId))
     }
 
-    static func isMarked(walletId: Data) -> Bool {
-        UserDefaults.standard.bool(forKey: key(walletId: walletId))
+    static func isMarked(walletId: Data, defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: key(walletId: walletId))
     }
 
-    static func clear(walletId: Data) {
-        UserDefaults.standard.removeObject(forKey: key(walletId: walletId))
+    static func clear(walletId: Data, defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: key(walletId: walletId))
     }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -494,6 +494,10 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         // so switch telemetry survives into diagnostic exports.
         await SwiftDashSDKHost.shared.stopAsync()
         currentNetwork = nil
+#if DASHPAY
+        // A readiness verdict belongs to the start that produced it.
+        DWSameSeedIdentityRecoveryCoordinator.shared.clearStartupVerdicts()
+#endif
         if forWipe {
             DWCurrentUserIdentityInfo.shared.resetForWalletRemoval()
             publishActiveWalletDidChange(reason: "wallet-removed")

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -495,8 +495,9 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         await SwiftDashSDKHost.shared.stopAsync()
         currentNetwork = nil
 #if DASHPAY
-        // A readiness verdict belongs to the start that produced it.
-        DWSameSeedIdentityRecoveryCoordinator.shared.clearStartupVerdicts()
+        // Readiness verdicts and completed recovery contexts belong to the
+        // start that produced them.
+        DWSameSeedIdentityRecoveryCoordinator.shared.resetForRuntimeTeardown()
 #endif
         if forWipe {
             DWCurrentUserIdentityInfo.shared.resetForWalletRemoval()

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -495,9 +495,9 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         await SwiftDashSDKHost.shared.stopAsync()
         currentNetwork = nil
 #if DASHPAY
-        // Readiness verdicts and completed recovery contexts belong to the
-        // start that produced them.
-        DWSameSeedIdentityRecoveryCoordinator.shared.resetForRuntimeTeardown()
+        // A readiness verdict belongs to the start that produced it. The
+        // coordinator's settled contexts stay: they are per process.
+        DWSameSeedIdentityRecoveryCoordinator.shared.clearStartupVerdicts()
 #endif
         if forWipe {
             DWCurrentUserIdentityInfo.shared.resetForWalletRemoval()

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -639,6 +639,7 @@ final class SwiftDashSDKWalletWiper: NSObject {
             CrowdNodeDefaults.shared.clearPerWalletKeys(forWalletIdHex: walletIdHex)
             CoinJoinWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             ShieldedWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
+            GeneratedWalletIdentityMarker.clear(walletId: walletId)
         }
     }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -641,13 +641,18 @@ final class SwiftDashSDKWalletWiper: NSObject {
             CoinJoinWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             ShieldedWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             AssetLockProbeStore.shared.clearForWallet(walletIdHex: walletIdHex)
-            GeneratedWalletIdentityMarker.clear(walletId: walletId)
-#if DASHPAY
-            // walletIds are deterministic per mnemonic+network: the same
-            // phrase re-imported later must not inherit this wallet's settled
-            // identity-recovery context.
-            DWSameSeedIdentityRecoveryCoordinator.shared.forgetWallet(walletId: walletId)
-#endif
         }
+
+        // Per-wallet identity bookkeeping, not app-state cleanup: it runs on
+        // every deletion regardless of the injected `clearAppState` seam.
+        // walletIds are deterministic per mnemonic+network, so the same
+        // phrase re-imported later must inherit neither the generated-wallet
+        // marker (a short probe budget on an imported seed) nor this
+        // wallet's settled identity-recovery context (a backstop that never
+        // runs).
+        GeneratedWalletIdentityMarker.clear(walletId: walletId)
+#if DASHPAY
+        DWSameSeedIdentityRecoveryCoordinator.shared.forgetWallet(walletId: walletId)
+#endif
     }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -640,6 +640,12 @@ final class SwiftDashSDKWalletWiper: NSObject {
             CoinJoinWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             ShieldedWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             GeneratedWalletIdentityMarker.clear(walletId: walletId)
+#if DASHPAY
+            // walletIds are deterministic per mnemonic+network: the same
+            // phrase re-imported later must not inherit this wallet's settled
+            // identity-recovery context.
+            DWSameSeedIdentityRecoveryCoordinator.shared.forgetWallet(walletId: walletId)
+#endif
         }
     }
 }

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -209,6 +209,22 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         }
     }
 
+    func testBackstopRunsWhenSeedBindingIsUnverifiedWithoutAnIdentity() {
+        // The identity question is unresolved, not answered: the pass never
+        // got to derive anything for this wallet.
+        XCTAssertTrue(StartupIdentityRecoveryPolicy.shouldRunBackstop(
+            readinessStatus: .seedBindingUnverified, readinessIdentityId: nil))
+    }
+
+    func testBackstopRunsForNonDiscoveryStatusesWithoutAnIdentity() {
+        for status: WalletStartupStatus in [.ready, .partialAccountsPending, .identityScanIncomplete] {
+            XCTAssertTrue(
+                StartupIdentityRecoveryPolicy.shouldRunBackstop(
+                    readinessStatus: status, readinessIdentityId: nil),
+                "\(status)")
+        }
+    }
+
     func testOnlyProvenAbsenceCompletesTheRecoveryContext() {
         XCTAssertTrue(StartupIdentityRecoveryPolicy.marksContextCompleted(readinessStatus: .noIdentity))
         for status: WalletStartupStatus in [.ready, .partialNoIdentity, .discoveryFailed, .identityScanIncomplete] {

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -183,6 +183,50 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
             .init(discoveredCount: 0, identityCount: 1, adopted: true))
     }
 
+    // MARK: - StartupIdentityRecoveryPolicy
+
+    func testBackstopRunsWhenNoReadinessPassRan() {
+        XCTAssertTrue(StartupIdentityRecoveryPolicy.shouldRunBackstop(
+            readinessStatus: nil, readinessIdentityId: nil))
+    }
+
+    func testBackstopRunsWhenReadinessKnowsAnIdentity() {
+        let identityId = Data(repeating: 0x18, count: 32)
+        for status: WalletStartupStatus in [.ready, .partialAccountsPending, .identityScanIncomplete] {
+            XCTAssertTrue(
+                StartupIdentityRecoveryPolicy.shouldRunBackstop(
+                    readinessStatus: status, readinessIdentityId: identityId),
+                "\(status)")
+        }
+    }
+
+    func testBackstopSkipsWhenReadinessFoundNoIdentity() {
+        for status: WalletStartupStatus in [.noIdentity, .partialNoIdentity, .discoveryFailed] {
+            XCTAssertFalse(
+                StartupIdentityRecoveryPolicy.shouldRunBackstop(
+                    readinessStatus: status, readinessIdentityId: nil),
+                "\(status)")
+        }
+    }
+
+    func testOnlyProvenAbsenceCompletesTheRecoveryContext() {
+        XCTAssertTrue(StartupIdentityRecoveryPolicy.marksContextCompleted(readinessStatus: .noIdentity))
+        for status: WalletStartupStatus in [.ready, .partialNoIdentity, .discoveryFailed, .identityScanIncomplete] {
+            XCTAssertFalse(
+                StartupIdentityRecoveryPolicy.marksContextCompleted(readinessStatus: status),
+                "\(status)")
+        }
+    }
+
+    func testShortStartupBudgetOnlyForGeneratedWalletWithoutLocalIdentity() {
+        XCTAssertEqual(
+            StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: true, hasLocalIdentity: false),
+            StartupIdentityRecoveryPolicy.generatedWalletStartupBudget)
+        XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: true, hasLocalIdentity: true))
+        XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: false, hasLocalIdentity: false))
+        XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: false, hasLocalIdentity: true))
+    }
+
     func testWatchdogRefreshesOnlyAfterFullScanBecomesStale() {
         XCTAssertFalse(ShieldedSyncFreshnessPolicy.shouldRefreshForWatchdog(
             now: now,

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -185,52 +185,64 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
 
     // MARK: - StartupIdentityRecoveryPolicy
 
+    private static let discoveryVerdicts: [WalletStartupStatus] = [.noIdentity, .partialNoIdentity, .discoveryFailed]
+    private static let nonDiscoveryStatuses: [WalletStartupStatus] = [
+        .ready, .partialAccountsPending, .seedBindingUnverified, .identityScanIncomplete,
+    ]
+
     func testBackstopRunsWhenNoReadinessPassRan() {
-        XCTAssertTrue(StartupIdentityRecoveryPolicy.shouldRunBackstop(
-            readinessStatus: nil, readinessIdentityId: nil))
+        for isGenerated in [false, true] {
+            XCTAssertTrue(StartupIdentityRecoveryPolicy.shouldRunBackstop(
+                readinessStatus: nil, readinessIdentityId: nil, isGeneratedOnDevice: isGenerated))
+        }
     }
 
-    func testBackstopRunsWhenReadinessKnowsAnIdentity() {
+    func testKnownIdentityAlwaysRunsTheBackstop() {
+        // The guard behind adoption: whatever the status says, an identity
+        // the readiness pass knows about must reach refreshNames + adopt.
         let identityId = Data(repeating: 0x18, count: 32)
-        for status: WalletStartupStatus in [.ready, .partialAccountsPending, .identityScanIncomplete] {
+        for status in Self.discoveryVerdicts + Self.nonDiscoveryStatuses {
+            for isGenerated in [false, true] {
+                XCTAssertTrue(
+                    StartupIdentityRecoveryPolicy.shouldRunBackstop(
+                        readinessStatus: status, readinessIdentityId: identityId, isGeneratedOnDevice: isGenerated),
+                    "\(status) generated=\(isGenerated)")
+            }
+        }
+    }
+
+    func testSettledAbsenceSkipsTheBackstop() {
+        for status: WalletStartupStatus in [.noIdentity, .discoveryFailed] {
+            for isGenerated in [false, true] {
+                XCTAssertFalse(
+                    StartupIdentityRecoveryPolicy.shouldRunBackstop(
+                        readinessStatus: status, readinessIdentityId: nil, isGeneratedOnDevice: isGenerated),
+                    "\(status) generated=\(isGenerated)")
+            }
+        }
+    }
+
+    func testUnreachablePlatformKeepsTheBackstopUnlessTheWalletWasGeneratedHere() {
+        for status: WalletStartupStatus in [.partialNoIdentity, .identityScanIncomplete] {
             XCTAssertTrue(
                 StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                    readinessStatus: status, readinessIdentityId: identityId),
+                    readinessStatus: status, readinessIdentityId: nil, isGeneratedOnDevice: false),
                 "\(status)")
-        }
-    }
-
-    func testBackstopSkipsWhenReadinessFoundNoIdentity() {
-        for status: WalletStartupStatus in [.noIdentity, .partialNoIdentity, .discoveryFailed] {
             XCTAssertFalse(
                 StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                    readinessStatus: status, readinessIdentityId: nil),
+                    readinessStatus: status, readinessIdentityId: nil, isGeneratedOnDevice: true),
                 "\(status)")
         }
     }
 
-    func testBackstopRunsWhenSeedBindingIsUnverifiedWithoutAnIdentity() {
-        // The identity question is unresolved, not answered: the pass never
-        // got to derive anything for this wallet.
-        XCTAssertTrue(StartupIdentityRecoveryPolicy.shouldRunBackstop(
-            readinessStatus: .seedBindingUnverified, readinessIdentityId: nil))
-    }
-
-    func testBackstopRunsForNonDiscoveryStatusesWithoutAnIdentity() {
-        for status: WalletStartupStatus in [.ready, .partialAccountsPending, .identityScanIncomplete] {
-            XCTAssertTrue(
-                StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                    readinessStatus: status, readinessIdentityId: nil),
-                "\(status)")
-        }
-    }
-
-    func testOnlyProvenAbsenceCompletesTheRecoveryContext() {
-        XCTAssertTrue(StartupIdentityRecoveryPolicy.marksContextCompleted(readinessStatus: .noIdentity))
-        for status: WalletStartupStatus in [.ready, .partialNoIdentity, .discoveryFailed, .identityScanIncomplete] {
-            XCTAssertFalse(
-                StartupIdentityRecoveryPolicy.marksContextCompleted(readinessStatus: status),
-                "\(status)")
+    func testUnresolvedStatusesWithoutAnIdentityRunTheBackstop() {
+        for status: WalletStartupStatus in [.ready, .partialAccountsPending, .seedBindingUnverified] {
+            for isGenerated in [false, true] {
+                XCTAssertTrue(
+                    StartupIdentityRecoveryPolicy.shouldRunBackstop(
+                        readinessStatus: status, readinessIdentityId: nil, isGeneratedOnDevice: isGenerated),
+                    "\(status) generated=\(isGenerated)")
+            }
         }
     }
 

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -254,13 +254,41 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
             identityFound: false, dashPaySyncRan: false, contactAccountsPending: 0))
     }
 
-    func testShortStartupBudgetOnlyForGeneratedWalletWithoutLocalIdentity() {
+    func testShortStartupBudgetOnlyForGeneratedWalletKnownToHaveNoLocalIdentity() {
         XCTAssertEqual(
             StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: true, hasLocalIdentity: false),
             StartupIdentityRecoveryPolicy.generatedWalletStartupBudget)
         XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: true, hasLocalIdentity: true))
+        // Inconclusive lookup (fetch failed, no wallet row) keeps the default.
+        XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: true, hasLocalIdentity: nil))
         XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: false, hasLocalIdentity: false))
         XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: false, hasLocalIdentity: true))
+        XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: false, hasLocalIdentity: nil))
+    }
+
+    func testSameSeedIdentityRecoveryUsesReadinessIdentityWhenTheStoreLags() async throws {
+        // Readiness discovered the identity but the persister has not landed
+        // the row yet: the pipeline must refresh + adopt on the known id and
+        // never run a second discovery scan.
+        let identityId = Data(repeating: 0x19, count: 32)
+        var discoveryCalls = 0
+        var refreshedIdentityIds: [Data] = []
+
+        let outcome = try await SameSeedIdentityRecoveryPipeline.run(
+            knownIdentityIds: [identityId],
+            localIdentityIds: { [] },
+            discover: {
+                discoveryCalls += 1
+                return []
+            },
+            refreshNames: { refreshedIdentityIds = $0 },
+            adopt: { true })
+
+        XCTAssertEqual(discoveryCalls, 0)
+        XCTAssertEqual(refreshedIdentityIds, [identityId])
+        XCTAssertEqual(
+            outcome,
+            .init(discoveredCount: 0, identityCount: 1, adopted: true))
     }
 
     // MARK: - GeneratedWalletIdentityMarker

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -231,16 +231,28 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         }
     }
 
-    func testLocalDiscoveryFaultSkipsWithoutSettling() {
+    func testLocalDiscoveryFaultRunsThePipelineWithoutAScan() {
         // The SDK says a rescan cannot answer it (`discoveryWorthRetrying ==
-        // false`, `identityIsSettled == false`): no unbudgeted scan, and the
-        // next runtime start asks again.
+        // false`, `identityIsSettled == false`): no unbudgeted scan, but the
+        // rows that do exist locally are still refreshed and adopted.
         for discovered in Self.flags {
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
                     readinessStatus: .discoveryFailed, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
-                .skipNotRetryable)
+                .runPipelineWithoutDiscovery)
         }
+    }
+
+    func testSameSeedIdentityRecoveryNeverScansWhenDiscoveryIsNotAllowed() async throws {
+        let outcome = try await SameSeedIdentityRecoveryPipeline.run(
+            allowDiscovery: false,
+            localIdentityIds: { [] },
+            discover: { XCTFail("must not scan"); return [] },
+            refreshNames: { _ in XCTFail("nothing to refresh") },
+            adopt: { XCTFail("nothing to adopt"); return false })
+        XCTAssertEqual(
+            outcome,
+            .init(discoveredCount: 0, identityCount: 0, adopted: false, identitiesPersisted: false))
     }
 
     func testEveryOtherIdentitylessStatusRunsThePipeline() {
@@ -259,30 +271,30 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         }
     }
 
-    func testProbeRerunOnlyWhenTheContactStepsAloneWereCutShort() {
-        XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 0,
-            seedBindingUnverified: false, identityScanIncomplete: false))
-        XCTAssertTrue(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 0,
-            seedBindingUnverified: false, identityScanIncomplete: false))
-        XCTAssertTrue(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 2,
-            seedBindingUnverified: false, identityScanIncomplete: false))
+    func testProbeRerunOnlyWhenTheBudgetCutTheContactStepsShort() {
+        func rerun(
+            budgetExhausted: Bool = true, dashPaySyncRan: Bool = false, pending: UInt32 = 0,
+            seedUnverified: Bool = false, scanIncomplete: Bool = false, found: Bool = true
+        ) -> Bool {
+            StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
+                identityFound: found, budgetExhausted: budgetExhausted, dashPaySyncRan: dashPaySyncRan,
+                contactAccountsPending: pending, seedBindingUnverified: seedUnverified,
+                identityScanIncomplete: scanIncomplete)
+        }
+        XCTAssertTrue(rerun())
+        XCTAssertTrue(rerun(dashPaySyncRan: true, pending: 2))
+        XCTAssertFalse(rerun(dashPaySyncRan: true, pending: 0))
+        // The contact pass was degraded or failed by Platform, not cut by the
+        // budget: a re-run under the default budget hits the same error.
+        XCTAssertFalse(rerun(budgetExhausted: false))
         // Nothing to re-run for: the probe found no identity.
-        XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: false, dashPaySyncRan: false, contactAccountsPending: 0,
-            seedBindingUnverified: false, identityScanIncomplete: false))
+        XCTAssertFalse(rerun(found: false))
         // The drain was skipped for an unverified seed binding: the SDK fails
         // that closed on every budget, so a re-run would be pure latency.
-        XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 3,
-            seedBindingUnverified: true, identityScanIncomplete: false))
+        XCTAssertFalse(rerun(pending: 3, seedUnverified: true))
         // The probe's own scan was cut off: a re-run would rescan from scratch
         // under the default budget instead of reusing the identity.
-        XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 0,
-            seedBindingUnverified: false, identityScanIncomplete: true))
+        XCTAssertFalse(rerun(scanIncomplete: true))
     }
 
     func testShortStartupBudgetOnlyForGeneratedWalletKnownToHaveNoLocalIdentity() {

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -194,88 +194,95 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
 
     func testPipelineRunsWhenNoReadinessPassRan() {
         for discovered in Self.flags {
-            for bookmarks in Self.flags {
-                XCTAssertEqual(
-                    StartupIdentityRecoveryPolicy.decision(
-                        readinessStatus: nil, readinessIdentityId: nil,
-                        readinessDiscoveredThisStart: discovered, contestedBookmarksRebuilt: bookmarks),
-                    .runPipeline)
-            }
+            XCTAssertEqual(
+                StartupIdentityRecoveryPolicy.decision(
+                    readinessStatus: nil, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                .runPipeline)
         }
     }
 
-    func testKnownIdentityIsNeverRediscoveredNorSkipped() {
+    func testKnownIdentityAlwaysReachesThePipeline() {
         // The guard behind adoption: whatever the status says, an identity the
-        // readiness pass knows about reaches adoption. Adopt-only needs BOTH
-        // an identity already on file and this install's bookmarks rebuilt;
-        // anything else owes the name refresh.
+        // readiness pass knows about goes through the pipeline (name refresh
+        // then adopt) — past the memo when it was discovered in this start,
+        // under the memo when it was already on file. Never a skip, never an
+        // adoption without the name refresh.
         let identityId = Data(repeating: 0x18, count: 32)
         for status in Self.allStatuses {
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: status, readinessIdentityId: identityId,
-                    readinessDiscoveredThisStart: false, contestedBookmarksRebuilt: true),
-                .adoptOnly,
+                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: false),
+                .runPipeline,
                 "\(status)")
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: status, readinessIdentityId: identityId,
-                    readinessDiscoveredThisStart: false, contestedBookmarksRebuilt: false),
+                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: true),
                 .refreshNamesAndAdopt,
-                "\(status) bookmarks missing")
-            for bookmarks in Self.flags {
-                XCTAssertEqual(
-                    StartupIdentityRecoveryPolicy.decision(
-                        readinessStatus: status, readinessIdentityId: identityId,
-                        readinessDiscoveredThisStart: true, contestedBookmarksRebuilt: bookmarks),
-                    .refreshNamesAndAdopt,
-                    "\(status) discovered bookmarks=\(bookmarks)")
-            }
+                "\(status) discovered")
         }
     }
 
     func testOnlyProvenAbsenceSettlesTheBackstop() {
         for discovered in Self.flags {
-            for bookmarks in Self.flags {
-                XCTAssertEqual(
-                    StartupIdentityRecoveryPolicy.decision(
-                        readinessStatus: .noIdentity, readinessIdentityId: nil,
-                        readinessDiscoveredThisStart: discovered, contestedBookmarksRebuilt: bookmarks),
-                    .skipSettled)
-            }
+            XCTAssertEqual(
+                StartupIdentityRecoveryPolicy.decision(
+                    readinessStatus: .noIdentity, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                .skipSettled)
+        }
+    }
+
+    func testLocalDiscoveryFaultSkipsWithoutSettling() {
+        // The SDK says a rescan cannot answer it (`discoveryWorthRetrying ==
+        // false`, `identityIsSettled == false`): no unbudgeted scan, and the
+        // next runtime start asks again.
+        for discovered in Self.flags {
+            XCTAssertEqual(
+                StartupIdentityRecoveryPolicy.decision(
+                    readinessStatus: .discoveryFailed, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                .skipNotRetryable)
         }
     }
 
     func testEveryOtherIdentitylessStatusRunsThePipeline() {
         // `.partialNoIdentity` (Platform or scan key unreachable, and the
-        // decoder's fallback for unknown FFI statuses) and `.discoveryFailed`
-        // (a local fault) are the SDK's "ask again", not verdicts.
-        for status in Self.allStatuses where status != .noIdentity {
+        // decoder's fallback for unknown FFI statuses) is the SDK's "ask
+        // again"; the settled statuses without an identity are unexpected
+        // pairs and fail towards the pipeline.
+        for status in Self.allStatuses where status != .noIdentity && status != .discoveryFailed {
             for discovered in Self.flags {
                 XCTAssertEqual(
                     StartupIdentityRecoveryPolicy.decision(
-                        readinessStatus: status, readinessIdentityId: nil,
-                        readinessDiscoveredThisStart: discovered, contestedBookmarksRebuilt: false),
+                        readinessStatus: status, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
                     .runPipeline,
                     "\(status) discovered=\(discovered)")
             }
         }
     }
 
-    func testProbeRerunOnlyWhenTheSequenceWasCutShort() {
+    func testProbeRerunOnlyWhenTheContactStepsAloneWereCutShort() {
         XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 0, seedBindingUnverified: false))
+            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 0,
+            seedBindingUnverified: false, identityScanIncomplete: false))
         XCTAssertTrue(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 0, seedBindingUnverified: false))
+            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 0,
+            seedBindingUnverified: false, identityScanIncomplete: false))
         XCTAssertTrue(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 2, seedBindingUnverified: false))
+            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 2,
+            seedBindingUnverified: false, identityScanIncomplete: false))
         // Nothing to re-run for: the probe found no identity.
         XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: false, dashPaySyncRan: false, contactAccountsPending: 0, seedBindingUnverified: false))
+            identityFound: false, dashPaySyncRan: false, contactAccountsPending: 0,
+            seedBindingUnverified: false, identityScanIncomplete: false))
         // The drain was skipped for an unverified seed binding: the SDK fails
         // that closed on every budget, so a re-run would be pure latency.
         XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 3, seedBindingUnverified: true))
+            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 3,
+            seedBindingUnverified: true, identityScanIncomplete: false))
+        // The probe's own scan was cut off: a re-run would rescan from scratch
+        // under the default budget instead of reusing the identity.
+        XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
+            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 0,
+            seedBindingUnverified: false, identityScanIncomplete: true))
     }
 
     func testShortStartupBudgetOnlyForGeneratedWalletKnownToHaveNoLocalIdentity() {
@@ -311,6 +318,27 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertEqual(discoveryCalls, 0)
         XCTAssertEqual(refreshedIdentityIds, [identityId])
         // The store never confirmed the row: the caller must not settle on it.
+        XCTAssertEqual(
+            outcome,
+            .init(discoveredCount: 0, identityCount: 1, adopted: true, identitiesPersisted: false))
+    }
+
+    func testSameSeedIdentityRecoveryPersistenceIsPerActedOnIdentityNotPerWallet() async throws {
+        // The wallet already has identity A on file; the readiness verdict
+        // carries a new identity B whose row never landed. A must not vouch
+        // for B.
+        let identityA = Data(repeating: 0x1b, count: 32)
+        let identityB = Data(repeating: 0x1c, count: 32)
+        var localIds: [Data] = []
+        let outcome = try await SameSeedIdentityRecoveryPipeline.run(
+            knownIdentityIds: [identityB],
+            localIdentityIds: {
+                defer { localIds = [identityA] }   // A shows up on the re-read only
+                return localIds
+            },
+            discover: { XCTFail("known identity must not be rediscovered"); return [] },
+            refreshNames: { XCTAssertEqual($0, [identityB]) },
+            adopt: { true })
         XCTAssertEqual(
             outcome,
             .init(discoveredCount: 0, identityCount: 1, adopted: true, identitiesPersisted: false))

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -159,7 +159,7 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertEqual(events, ["discover", "refresh", "adopt"])
         XCTAssertEqual(
             outcome,
-            .init(discoveredCount: 1, identityCount: 1, adopted: true))
+            .init(discoveredCount: 1, identityCount: 1, adopted: true, identitiesPersisted: true))
     }
 
     func testSameSeedIdentityRecoveryUsesPersistedIdentityWithoutRescanning() async throws {
@@ -180,7 +180,7 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertEqual(refreshedIdentityIds, [identityId])
         XCTAssertEqual(
             outcome,
-            .init(discoveredCount: 0, identityCount: 1, adopted: true))
+            .init(discoveredCount: 0, identityCount: 1, adopted: true, identitiesPersisted: true))
     }
 
     // MARK: - StartupIdentityRecoveryPolicy
@@ -190,40 +190,59 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         .discoveryFailed, .seedBindingUnverified, .identityScanIncomplete,
     ]
 
+    private static let flags = [false, true]
+
     func testPipelineRunsWhenNoReadinessPassRan() {
-        for discovered in [false, true] {
-            XCTAssertEqual(
-                StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: nil, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
-                .runPipeline)
+        for discovered in Self.flags {
+            for bookmarks in Self.flags {
+                XCTAssertEqual(
+                    StartupIdentityRecoveryPolicy.decision(
+                        readinessStatus: nil, readinessIdentityId: nil,
+                        readinessDiscoveredThisStart: discovered, contestedBookmarksRebuilt: bookmarks),
+                    .runPipeline)
+            }
         }
     }
 
     func testKnownIdentityIsNeverRediscoveredNorSkipped() {
         // The guard behind adoption: whatever the status says, an identity the
-        // readiness pass knows about reaches adoption. Re-confirmed on file →
-        // adopt only; discovered in this start → refresh names + adopt.
+        // readiness pass knows about reaches adoption. Adopt-only needs BOTH
+        // an identity already on file and this install's bookmarks rebuilt;
+        // anything else owes the name refresh.
         let identityId = Data(repeating: 0x18, count: 32)
         for status in Self.allStatuses {
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: false),
+                    readinessStatus: status, readinessIdentityId: identityId,
+                    readinessDiscoveredThisStart: false, contestedBookmarksRebuilt: true),
                 .adoptOnly,
                 "\(status)")
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: true),
+                    readinessStatus: status, readinessIdentityId: identityId,
+                    readinessDiscoveredThisStart: false, contestedBookmarksRebuilt: false),
                 .refreshNamesAndAdopt,
-                "\(status)")
+                "\(status) bookmarks missing")
+            for bookmarks in Self.flags {
+                XCTAssertEqual(
+                    StartupIdentityRecoveryPolicy.decision(
+                        readinessStatus: status, readinessIdentityId: identityId,
+                        readinessDiscoveredThisStart: true, contestedBookmarksRebuilt: bookmarks),
+                    .refreshNamesAndAdopt,
+                    "\(status) discovered bookmarks=\(bookmarks)")
+            }
         }
     }
 
     func testOnlyProvenAbsenceSettlesTheBackstop() {
-        for discovered in [false, true] {
-            XCTAssertEqual(
-                StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: .noIdentity, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
-                .skipSettled)
+        for discovered in Self.flags {
+            for bookmarks in Self.flags {
+                XCTAssertEqual(
+                    StartupIdentityRecoveryPolicy.decision(
+                        readinessStatus: .noIdentity, readinessIdentityId: nil,
+                        readinessDiscoveredThisStart: discovered, contestedBookmarksRebuilt: bookmarks),
+                    .skipSettled)
+            }
         }
     }
 
@@ -232,10 +251,11 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         // decoder's fallback for unknown FFI statuses) and `.discoveryFailed`
         // (a local fault) are the SDK's "ask again", not verdicts.
         for status in Self.allStatuses where status != .noIdentity {
-            for discovered in [false, true] {
+            for discovered in Self.flags {
                 XCTAssertEqual(
                     StartupIdentityRecoveryPolicy.decision(
-                        readinessStatus: status, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                        readinessStatus: status, readinessIdentityId: nil,
+                        readinessDiscoveredThisStart: discovered, contestedBookmarksRebuilt: false),
                     .runPipeline,
                     "\(status) discovered=\(discovered)")
             }
@@ -244,14 +264,18 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
 
     func testProbeRerunOnlyWhenTheSequenceWasCutShort() {
         XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 0))
+            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 0, seedBindingUnverified: false))
         XCTAssertTrue(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 0))
+            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 0, seedBindingUnverified: false))
         XCTAssertTrue(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 2))
+            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 2, seedBindingUnverified: false))
         // Nothing to re-run for: the probe found no identity.
         XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
-            identityFound: false, dashPaySyncRan: false, contactAccountsPending: 0))
+            identityFound: false, dashPaySyncRan: false, contactAccountsPending: 0, seedBindingUnverified: false))
+        // The drain was skipped for an unverified seed binding: the SDK fails
+        // that closed on every budget, so a re-run would be pure latency.
+        XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
+            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 3, seedBindingUnverified: true))
     }
 
     func testShortStartupBudgetOnlyForGeneratedWalletKnownToHaveNoLocalIdentity() {
@@ -286,9 +310,24 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
 
         XCTAssertEqual(discoveryCalls, 0)
         XCTAssertEqual(refreshedIdentityIds, [identityId])
+        // The store never confirmed the row: the caller must not settle on it.
         XCTAssertEqual(
             outcome,
-            .init(discoveredCount: 0, identityCount: 1, adopted: true))
+            .init(discoveredCount: 0, identityCount: 1, adopted: true, identitiesPersisted: false))
+    }
+
+    func testSameSeedIdentityRecoveryReportsPersistenceFromTheStoreNotTheIds() async throws {
+        // Discovery returned an id the persister never landed: acted on as a
+        // hydration fallback, but reported as not persisted.
+        let identityId = Data(repeating: 0x1a, count: 32)
+        let outcome = try await SameSeedIdentityRecoveryPipeline.run(
+            localIdentityIds: { [] },
+            discover: { [identityId] },
+            refreshNames: { _ in },
+            adopt: { true })
+        XCTAssertEqual(
+            outcome,
+            .init(discoveredCount: 1, identityCount: 1, adopted: true, identitiesPersisted: false))
     }
 
     // MARK: - GeneratedWalletIdentityMarker

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -196,7 +196,7 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         for discovered in Self.flags {
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: nil, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                    readinessStatus: nil, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered, hasLocalIdentity: false),
                 .runPipeline)
         }
     }
@@ -211,14 +211,30 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         for status in Self.allStatuses {
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: false),
+                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: false, hasLocalIdentity: true),
                 .runPipeline,
                 "\(status)")
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: true),
+                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: true, hasLocalIdentity: false),
                 .refreshNamesAndAdopt,
                 "\(status) discovered")
+        }
+    }
+
+    func testProvenAbsenceOnlySettlesWhenTheStoreAgrees() {
+        // Rust proved the seed owns no identity, but the SwiftData mirror
+        // still holds rows (or the lookup was inconclusive): adopt them
+        // without a scan rather than retiring the backstop for the process.
+        for discovered in Self.flags {
+            for local: Bool? in [true, nil] {
+                XCTAssertEqual(
+                    StartupIdentityRecoveryPolicy.decision(
+                        readinessStatus: .noIdentity, readinessIdentityId: nil,
+                        readinessDiscoveredThisStart: discovered, hasLocalIdentity: local),
+                    .runPipelineWithoutDiscovery,
+                    "local=\(String(describing: local))")
+            }
         }
     }
 
@@ -226,7 +242,8 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         for discovered in Self.flags {
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: .noIdentity, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                    readinessStatus: .noIdentity, readinessIdentityId: nil,
+                    readinessDiscoveredThisStart: discovered, hasLocalIdentity: false),
                 .skipSettled)
         }
     }
@@ -238,7 +255,8 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         for discovered in Self.flags {
             XCTAssertEqual(
                 StartupIdentityRecoveryPolicy.decision(
-                    readinessStatus: .discoveryFailed, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                    readinessStatus: .discoveryFailed, readinessIdentityId: nil,
+                    readinessDiscoveredThisStart: discovered, hasLocalIdentity: false),
                 .runPipelineWithoutDiscovery)
         }
     }
@@ -264,7 +282,8 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
             for discovered in Self.flags {
                 XCTAssertEqual(
                     StartupIdentityRecoveryPolicy.decision(
-                        readinessStatus: status, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                        readinessStatus: status, readinessIdentityId: nil,
+                        readinessDiscoveredThisStart: discovered, hasLocalIdentity: false),
                     .runPipeline,
                     "\(status) discovered=\(discovered)")
             }

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -185,65 +185,73 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
 
     // MARK: - StartupIdentityRecoveryPolicy
 
-    private static let discoveryVerdicts: [WalletStartupStatus] = [.noIdentity, .partialNoIdentity, .discoveryFailed]
-    private static let nonDiscoveryStatuses: [WalletStartupStatus] = [
-        .ready, .partialAccountsPending, .seedBindingUnverified, .identityScanIncomplete,
+    private static let allStatuses: [WalletStartupStatus] = [
+        .ready, .noIdentity, .partialNoIdentity, .partialAccountsPending,
+        .discoveryFailed, .seedBindingUnverified, .identityScanIncomplete,
     ]
 
-    func testBackstopRunsWhenNoReadinessPassRan() {
-        for isGenerated in [false, true] {
-            XCTAssertTrue(StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                readinessStatus: nil, readinessIdentityId: nil, isGeneratedOnDevice: isGenerated))
+    func testPipelineRunsWhenNoReadinessPassRan() {
+        for discovered in [false, true] {
+            XCTAssertEqual(
+                StartupIdentityRecoveryPolicy.decision(
+                    readinessStatus: nil, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                .runPipeline)
         }
     }
 
-    func testKnownIdentityAlwaysRunsTheBackstop() {
-        // The guard behind adoption: whatever the status says, an identity
-        // the readiness pass knows about must reach refreshNames + adopt.
+    func testKnownIdentityIsNeverRediscoveredNorSkipped() {
+        // The guard behind adoption: whatever the status says, an identity the
+        // readiness pass knows about reaches adoption. Re-confirmed on file →
+        // adopt only; discovered in this start → refresh names + adopt.
         let identityId = Data(repeating: 0x18, count: 32)
-        for status in Self.discoveryVerdicts + Self.nonDiscoveryStatuses {
-            for isGenerated in [false, true] {
-                XCTAssertTrue(
-                    StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                        readinessStatus: status, readinessIdentityId: identityId, isGeneratedOnDevice: isGenerated),
-                    "\(status) generated=\(isGenerated)")
-            }
-        }
-    }
-
-    func testSettledAbsenceSkipsTheBackstop() {
-        for status: WalletStartupStatus in [.noIdentity, .discoveryFailed] {
-            for isGenerated in [false, true] {
-                XCTAssertFalse(
-                    StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                        readinessStatus: status, readinessIdentityId: nil, isGeneratedOnDevice: isGenerated),
-                    "\(status) generated=\(isGenerated)")
-            }
-        }
-    }
-
-    func testUnreachablePlatformKeepsTheBackstopUnlessTheWalletWasGeneratedHere() {
-        for status: WalletStartupStatus in [.partialNoIdentity, .identityScanIncomplete] {
-            XCTAssertTrue(
-                StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                    readinessStatus: status, readinessIdentityId: nil, isGeneratedOnDevice: false),
+        for status in Self.allStatuses {
+            XCTAssertEqual(
+                StartupIdentityRecoveryPolicy.decision(
+                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: false),
+                .adoptOnly,
                 "\(status)")
-            XCTAssertFalse(
-                StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                    readinessStatus: status, readinessIdentityId: nil, isGeneratedOnDevice: true),
+            XCTAssertEqual(
+                StartupIdentityRecoveryPolicy.decision(
+                    readinessStatus: status, readinessIdentityId: identityId, readinessDiscoveredThisStart: true),
+                .refreshNamesAndAdopt,
                 "\(status)")
         }
     }
 
-    func testUnresolvedStatusesWithoutAnIdentityRunTheBackstop() {
-        for status: WalletStartupStatus in [.ready, .partialAccountsPending, .seedBindingUnverified] {
-            for isGenerated in [false, true] {
-                XCTAssertTrue(
-                    StartupIdentityRecoveryPolicy.shouldRunBackstop(
-                        readinessStatus: status, readinessIdentityId: nil, isGeneratedOnDevice: isGenerated),
-                    "\(status) generated=\(isGenerated)")
+    func testOnlyProvenAbsenceSettlesTheBackstop() {
+        for discovered in [false, true] {
+            XCTAssertEqual(
+                StartupIdentityRecoveryPolicy.decision(
+                    readinessStatus: .noIdentity, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                .skipSettled)
+        }
+    }
+
+    func testEveryOtherIdentitylessStatusRunsThePipeline() {
+        // `.partialNoIdentity` (Platform or scan key unreachable, and the
+        // decoder's fallback for unknown FFI statuses) and `.discoveryFailed`
+        // (a local fault) are the SDK's "ask again", not verdicts.
+        for status in Self.allStatuses where status != .noIdentity {
+            for discovered in [false, true] {
+                XCTAssertEqual(
+                    StartupIdentityRecoveryPolicy.decision(
+                        readinessStatus: status, readinessIdentityId: nil, readinessDiscoveredThisStart: discovered),
+                    .runPipeline,
+                    "\(status) discovered=\(discovered)")
             }
         }
+    }
+
+    func testProbeRerunOnlyWhenTheSequenceWasCutShort() {
+        XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
+            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 0))
+        XCTAssertTrue(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
+            identityFound: true, dashPaySyncRan: false, contactAccountsPending: 0))
+        XCTAssertTrue(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
+            identityFound: true, dashPaySyncRan: true, contactAccountsPending: 2))
+        // Nothing to re-run for: the probe found no identity.
+        XCTAssertFalse(StartupIdentityRecoveryPolicy.probeNeedsFullRerun(
+            identityFound: false, dashPaySyncRan: false, contactAccountsPending: 0))
     }
 
     func testShortStartupBudgetOnlyForGeneratedWalletWithoutLocalIdentity() {
@@ -253,6 +261,30 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: true, hasLocalIdentity: true))
         XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: false, hasLocalIdentity: false))
         XCTAssertNil(StartupIdentityRecoveryPolicy.startupBudget(isGeneratedOnDevice: false, hasLocalIdentity: true))
+    }
+
+    // MARK: - GeneratedWalletIdentityMarker
+
+    func testGeneratedWalletMarkerMarksClearsAndIsolatesWallets() throws {
+        let suiteName = "SwiftDashSDKCoreLifecycleTests." + UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let generated = Data(repeating: 0x21, count: 32)
+        let imported = Data(repeating: 0x22, count: 32)
+
+        XCTAssertFalse(GeneratedWalletIdentityMarker.isMarked(walletId: generated, defaults: defaults))
+
+        GeneratedWalletIdentityMarker.mark(walletId: generated, defaults: defaults)
+        XCTAssertTrue(GeneratedWalletIdentityMarker.isMarked(walletId: generated, defaults: defaults))
+        XCTAssertFalse(GeneratedWalletIdentityMarker.isMarked(walletId: imported, defaults: defaults))
+
+        // Clearing is idempotent and per wallet.
+        GeneratedWalletIdentityMarker.clear(walletId: imported, defaults: defaults)
+        XCTAssertTrue(GeneratedWalletIdentityMarker.isMarked(walletId: generated, defaults: defaults))
+        GeneratedWalletIdentityMarker.clear(walletId: generated, defaults: defaults)
+        XCTAssertFalse(GeneratedWalletIdentityMarker.isMarked(walletId: generated, defaults: defaults))
+        GeneratedWalletIdentityMarker.clear(walletId: generated, defaults: defaults)
+        XCTAssertFalse(GeneratedWalletIdentityMarker.isMarked(walletId: generated, defaults: defaults))
     }
 
     func testWatchdogRefreshesOnlyAfterFullScanBecomesStale() {


### PR DESCRIPTION
## Problem

A runtime wallet switch (Wallets → switch, and the auto-switch after Add Wallet) spent ~54 s under the lifecycle overlay. Measured on the simulator (testnet, Platform DAPI unreachable):

| step | time |
|---|---|
| host stop + rebuild + `loadFromPersistor` | ~1 s |
| `DashPayContactAddressReadiness.awaitReady` → SDK `startWalletSubsystems` (Rust identity discovery, 20 s budget) → `.partialNoIdentity` | 20 s |
| `startSpv` + BLAST bind | ~2 s |
| BLAST `performStart` → `DWSameSeedIdentityRecoveryCoordinator.recoverIfNeeded` → a **second** `discoverIdentities(startIndex: 0)`, unbudgeted | 31 s |

The readiness pass already is the discovery (with the SDK's backoff schedule), but its `WalletStartupOutcome` was logged and discarded, so the BLAST-side backstop could not tell a repeat from a first run and re-scanned every time.

## Change (app-side only, no SDK changes)

**A. Readiness verdict handoff.** `awaitReady` hands its outcome (status, identityId, whether a scan ran) to `DWSameSeedIdentityRecoveryCoordinator` (`recordStartupDiscovery`; removed on entry to `recoverIfNeeded`, and every branch that acts on it settles the context so the decision holds for the process). Pure `StartupIdentityRecoveryPolicy.decision`:
- no readiness in this start (re-arm, storage-explorer BLAST start, thrown/elided pass) → pipeline runs as before, under the per-process settled memo;
- readiness knows an identity → the pipeline runs (DPNS name refresh, contested-bookmark rebuild, then adopt; discovery is skipped because the rows are there / the verdict id is passed in as `knownIdentityIds`): past the settled memo when readiness discovered it in this start, under the memo otherwise — i.e. once per process per wallet, the cadence the pipeline had before this PR. There is deliberately no adopt-only shortcut: the name refresh is the only rebuild of contested bookmarks and the only thing that keeps the name cache `reconcileRecoveredIdentity` reads populated;
- identity-less statuses follow the SDK's own `discoveryWorthRetrying` / `identityIsSettled`: `.noIdentity` → settled, backstop skipped; `.partialNoIdentity` (also the decoder's fallback for unknown FFI statuses) / `.identityScanIncomplete` → pipeline runs unless the wallet was already settled in this process; `.discoveryFailed` → the pipeline runs **without its scan** (a rescan cannot clear a local fault), so whatever identity rows exist locally are still refreshed and adopted; a run that could not scan and found nothing settles nothing, so the next runtime start reaches the backstop again.
A found identity settles the context only when the pipeline re-reads every id it acted on from the store (`Outcome.identitiesPersisted`); every branch that returns without settling (memo early return, `.discoveryFailed`, a thrown pipeline) puts the verdict back for a later call in the same start. `fullReset` clears only the verdicts; the settled memo is per process and dropped per wallet on deletion (`forgetWallet`, run on every deletion outside the injectable `clearAppState` seam), so a phrase removed and re-imported in one session gets its attempt back.

**B. Short probe budget for a wallet generated on this device.** `GeneratedWalletIdentityMarker` (UserDefaults, per network-scoped walletId, injectable store) is written by `SwiftDashSDKHost.createAndPersist` for a generated mnemonic and cleared for an imported one (deterministic ids), on wallet deletion, on completed username registration (keyed on the walletId stashed at submit) and by the bring-up as soon as any path finds an identity for the seed. A marked wallet with no local identity (a `fetchCount` existence check) passes `budget: 5` to `startWalletSubsystems`. The budget caps the whole sequence, so it is a probe: a probe that finds an identity with a complete scan but is cut short before the contact steps (`!dashPaySyncRan || contactAccountsPending > 0`; never for `seedBindingUnverified`, never when the probe's own scan was cut off — the SDK would then rediscover under the default budget) re-runs with the default budget, and a throwing re-run keeps the probe's verdict; a probe cut off before finding anything reports `.partialNoIdentity`, which runs the backstop in the same start. Probe lines are logged as `DP-READY (probe) ::`; one start logs one verdict line. Not restored after a reinstall (origin unknown → default budget).

Not changed on purpose: the default 20 s budget for imported seeds, no "Platform unreachable" caching. Follow-up (`TODO(platform-wallet)` in the readiness header): carry "generated on this device" on the wallet record so the probe lives in the shared Rust sequence and Android gets it too.

## Verification

- Clean `dashpay` arm64 simulator build; `scripts/a11y_audit.py --check` no new findings.
- `SwiftDashSDKCoreLifecycleTests`: decision table (every status × identity known / discovered / absent), probe re-run gate, budget selection, marker mark/clear matrix on a throwaway `UserDefaults` suite (compile-ready; the unit-test target is still broken). The coordinator itself is a private-init singleton and is not unit-testable without a seam refactor that is out of scope here.
- Smoke re-run on the **current head** (simulator, testnet, Platform reachable, two wallets — one owning a DashPay identity, one generated here with none):

| step | time |
|---|---|
| switch to the wallet with no identity (`DP-READY` probe 5 s budget → proof of absence in 3.6 s → backstop skipped) | 10.6 s |
| switch back to the identity wallet, recovery already settled this process | 10.2 s |
| first bring-up of the identity wallet in the process (here on launch): readiness 2.7 s + the recovery pipeline's DPNS refresh | +10.3 s once |

The original measurement of this path was 54 s (readiness 20 s + a duplicate unbudgeted 31 s scan). The earlier 6.2 s / 8.1 s figures in this description were taken on the round-1 head with a different wallet set and no longer describe the code; these replace them. The remaining ~10 s per switch is host teardown/rebuild (~2.5 s), the SDK readiness pass (~3 s), SPV start + BLAST bind (~4.5 s) — none of it the identity duplication this PR targets, and all of it what the "take the bring-up off the overlay critical path" follow-up below would address.

## Out of scope (follow-ups)

- ~11 s stop phase on a network switch (`stopShieldedSync` quiesce budget, SDK-side).
- Taking the whole Platform bring-up (readiness / BLAST / recovery) off the overlay's critical path — would bring every switch to ~3 s regardless of Platform, but changes `isRuntimeReady` and the overlay contract.
- ~2.6 s main-thread stall at SPV start/bind (known).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup identity recovery to avoid unnecessary repeat checks while retrying interrupted recovery.
  - Improved handling of known identities, including adoption and name refresh scenarios.
  - Corrected identity recovery state when wallets are deleted, recreated, or imported.
  - Fixed generated-wallet tracking to keep identity recovery isolated between wallets.
  - Improved username creation and purchase flows to associate results with the correct wallet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


