### PR TITLE
fix(wallet): hold "syncing" until scanned history is durably persisted

### DIFF
--- a/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
+++ b/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
@@ -16,6 +16,7 @@
 //
 
 import Combine
+import CoreData
 import Foundation
 import OSLog
 import SwiftDashSDK
@@ -111,6 +112,11 @@ public class SyncStateSnapshot: NSObject {
 protocol SyncingActivityMonitorObserver: AnyObject {
     func syncingActivityMonitorProgressDidChange(_ progress: Double)
     func syncingActivityMonitorStateDidChange(previousState: SyncingActivityMonitor.State, state: SyncingActivityMonitor.State)
+    /// Fires when `SyncingActivityMonitor.isPersistingScannedHistory`
+    /// flips. `state` stays `.syncing` across the flip, so observers that
+    /// only key off state changes never see it — this is for the few
+    /// surfaces that word the syncing phase.
+    @objc optional func syncingActivityMonitorPersistingDidChange(_ isPersisting: Bool)
 }
 
 // MARK: - SyncingActivityMonitor
@@ -179,6 +185,31 @@ class SyncingActivityMonitor: NSObject, NetworkReachabilityHandling {
     private var lastPeakDate: Date?
     private var cancellables = Set<AnyCancellable>()
 
+    /// True while dash-spv reports the scan complete but the persisted
+    /// watermark — what the transaction list is built out of and what a
+    /// relaunch resumes from — is still behind the scanned tip. `state`
+    /// is held at `.syncing` and `progress` tracks the watermark for the
+    /// duration; see `handleCoordinatorUpdate`.
+    ///
+    /// Measured on a mixing-heavy wallet on an iPhone 13 Pro: the persister
+    /// needed ~20 minutes to write the tail after dash-spv called the
+    /// scan done. A "synced" wallet whose history ends two years ago is
+    /// exactly the screen users kill the app on.
+    @objc public private(set) var isPersistingScannedHistory = false {
+        didSet {
+            guard oldValue != isPersistingScannedHistory else { return }
+            observerSnapshot().forEach {
+                $0.syncingActivityMonitorPersistingDidChange?(isPersistingScannedHistory)
+            }
+        }
+    }
+
+    /// Blocks the durable watermark may trail the scanned tip by while the
+    /// sync still counts as done. New blocks land in the store within a
+    /// second of being scanned, so a small tolerance covers that window
+    /// without letting a genuine backlog through.
+    private static let durableLagTolerance: UInt32 = 3
+
     /// The wallet the in-flight sync cycle started on. `.syncDone` arrives
     /// from a singleton SPV stream that carries no wallet identity, while the
     /// durable watermark is read from whichever wallet is active at log time —
@@ -200,6 +231,7 @@ class SyncingActivityMonitor: NSObject, NetworkReachabilityHandling {
 
         initializeReachibility()
         subscribeToCoordinator()
+        subscribeToPersistedWatermark()
     }
 
     @objc
@@ -315,11 +347,44 @@ extension SyncingActivityMonitor {
             mapped = .unknown
         }
 
-        applyProgressWithPeakSmoothing(sdkProgress)
-        isSyncing = (mapped == .syncing)
         let wasDone = state == .syncDone
         let wasSyncing = state == .syncing
-        state = mapped
+
+        // Durable-watermark gate. `.syncDone` from dash-spv means the scan
+        // reached the tip in memory; the transaction list is read from
+        // SwiftData, which the persister fills in rounds that can trail the
+        // scan by many minutes on a large wallet. Hold `.syncing` until the
+        // persisted watermark is within tolerance of the scanned tip, and
+        // let `progress` show the watermark climbing instead of a frozen
+        // 100%. Only evaluated on the way INTO done (or while held): once
+        // done is confirmed it stays done until dash-spv itself leaves it,
+        // so a new block briefly ahead of its own persist round can't flap
+        // the UI.
+        var effective = mapped
+        var effectiveProgress = sdkProgress
+        if mapped == .syncDone, !wasDone || isPersistingScannedHistory {
+            if let hold = durableLag(scannedTip: sdkSyncProgress.headers?.currentHeight) {
+                effective = .syncing
+                effectiveProgress = min(hold.progress, 0.999)
+                if !isPersistingScannedHistory {
+                    Self.logger.info(
+                        """
+                        ⛓️ SYNCSTATE :: scan done at tip \(hold.scannedTip, privacy: .public); holding \
+                        .syncing until the durable watermark (\(hold.durable, privacy: .public), behind by \
+                        \(hold.scannedTip - hold.durable, privacy: .public) block(s)) catches up
+                        """)
+                }
+                isPersistingScannedHistory = true
+            } else {
+                isPersistingScannedHistory = false
+            }
+        } else {
+            isPersistingScannedHistory = false
+        }
+
+        applyProgressWithPeakSmoothing(effectiveProgress)
+        isSyncing = (effective == .syncing)
+        state = effective
 
         // `syncDone` is derived purely from the SPV network phases — it knows
         // nothing about how much of what was scanned is durably persisted.
@@ -335,16 +400,63 @@ extension SyncingActivityMonitor {
         // `.noConnection` never reaches the `.syncDone` branch that clears it,
         // and a stale id would make the next cycle's completion look like it
         // belonged to a wallet that is no longer active.
-        if mapped == .syncing && !wasSyncing {
+        if effective == .syncing && !wasSyncing {
             syncCycleWalletId = SwiftDashSDKWalletSource.activeWalletId
         }
 
-        if mapped == .syncDone && !wasDone {
+        if effective == .syncDone && !wasDone {
             logDurableWatermarkAtCompletion(
                 scannedTip: sdkSyncProgress.headers?.currentHeight,
                 cycleWalletId: syncCycleWalletId)
             syncCycleWalletId = nil
         }
+    }
+
+    /// The persisted watermark's shortfall against the scanned tip, or `nil`
+    /// when there is nothing to hold on: no active wallet, no watermark yet
+    /// (a wallet whose first persist round hasn't landed — holding there
+    /// would pin a fresh wallet on "processing" with nothing to process),
+    /// no scanned tip, or a shortfall within `durableLagTolerance`.
+    private func durableLag(scannedTip: UInt32?) -> (scannedTip: UInt32, durable: UInt32, progress: Double)? {
+        guard let scannedTip, scannedTip > 0,
+              let snapshot = SwiftDashSDKWalletSource.persistedSyncedHeightSnapshot(),
+              let durable = snapshot.height,
+              durable + Self.durableLagTolerance < scannedTip else {
+            return nil
+        }
+        return (scannedTip, durable, Double(durable) / Double(scannedTip))
+    }
+
+    /// Re-run the gate whenever the persister commits a round. The round's
+    /// final save updates `PersistentWallet.syncedHeight`, so a save whose
+    /// updated set carries that entity is the exact signal; the coordinator
+    /// publishes nothing at that moment (dash-spv is idle at the tip), so
+    /// without this the hold would only lift on the next unrelated tick.
+    /// Payload inspection happens before the main-queue hop — the object
+    /// sets belong to the posting thread. Throttled: intermediate saves
+    /// every 500 rows also fire this notification.
+    private func subscribeToPersistedWatermark() {
+        NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)
+            .filter { Self.saveTouchesWalletWatermark($0) }
+            .map { _ in () }
+            .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] in
+                guard let self, self.isPersistingScannedHistory else { return }
+                let coord = SwiftDashSDKSPVCoordinator.shared
+                self.handleCoordinatorUpdate(
+                    sdkState: coord.state,
+                    sdkProgress: coord.progress,
+                    sdkSyncProgress: coord.syncProgress,
+                    peersBestHeight: coord.bestPeerHeight)
+            }
+            .store(in: &cancellables)
+    }
+
+    private static func saveTouchesWalletWatermark(_ notification: Notification) -> Bool {
+        guard let updated = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> else {
+            return false
+        }
+        return updated.contains { $0.entity.name == "PersistentWallet" }
     }
 
     /// One-shot read of the persisted sync height at the moment the UI first

--- a/DashWallet/Sources/UI/Home/Syncing Views/Model/SyncModel.swift
+++ b/DashWallet/Sources/UI/Home/Syncing Views/Model/SyncModel.swift
@@ -29,6 +29,10 @@ protocol SyncModel {
     var progressDidChange: ((Double) -> ())? { get set }
     var progress: Double { get }
 
+    /// See `SyncingActivityMonitor.isPersistingScannedHistory`.
+    var persistingDidChange: ((Bool) -> ())? { get set }
+    var isPersistingScannedHistory: Bool { get }
+
     func forceStartSyncingActivity()
 }
 
@@ -43,6 +47,9 @@ final class SyncModelImpl: SyncModel, ObservableObject {
     var progressDidChange: ((Double) -> ())?
     @Published private(set) var progress: Double
 
+    var persistingDidChange: ((Bool) -> ())?
+    @Published private(set) var isPersistingScannedHistory: Bool
+
     internal var reachabilityObserver: Any!
     private let syncMonitor: SyncingActivityMonitor
 
@@ -50,6 +57,7 @@ final class SyncModelImpl: SyncModel, ObservableObject {
         syncMonitor = SyncingActivityMonitor.shared
         state = syncMonitor.state
         progress = syncMonitor.progress
+        isPersistingScannedHistory = syncMonitor.isPersistingScannedHistory
         syncMonitor.add(observer: self)
 
         startNetworkMonitoring()
@@ -81,5 +89,10 @@ extension SyncModelImpl: SyncingActivityMonitorObserver {
     func syncingActivityMonitorStateDidChange(previousState: SyncingActivityMonitor.State, state: SyncingActivityMonitor.State) {
         self.state = state
         stateDidChage?(state)
+    }
+
+    func syncingActivityMonitorPersistingDidChange(_ isPersisting: Bool) {
+        isPersistingScannedHistory = isPersisting
+        persistingDidChange?(isPersisting)
     }
 }

--- a/DashWallet/Sources/UI/Home/Syncing Views/Sync View/SyncView.swift
+++ b/DashWallet/Sources/UI/Home/Syncing Views/Sync View/SyncView.swift
@@ -77,6 +77,12 @@ final class SyncView: UIView {
         model.stateDidChage = { [weak self] _ in
             self?.updateView()
         }
+
+        // The state stays `.syncing` across this flip, so `stateDidChage`
+        // never fires for it; the title still has to switch.
+        model.persistingDidChange = { [weak self] _ in
+            self?.updateView()
+        }
     }
 
     private func set(progress: Float, animated: Bool) {
@@ -142,7 +148,9 @@ extension SyncView {
             percentLabel.isHidden = false
             retryButton.isHidden = true
             progressView.isHidden = false
-            titleLabel.text = NSLocalizedString("Syncing", comment: "")
+            titleLabel.text = SyncingActivityMonitor.shared.isPersistingScannedHistory
+                ? NSLocalizedString("Processing transactions", comment: "Sync phase: scan finished, transactions still being written")
+                : NSLocalizedString("Syncing", comment: "")
             updateUIForViewStateSeeingBlocks()
 
         case .syncFailed:

--- a/DashWallet/Sources/UI/Home/Views/Cells/SyncingHeaderView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Cells/SyncingHeaderView.swift
@@ -45,7 +45,9 @@ struct SyncingHeaderView: View {
             if model.state == .syncing {
                 Button(action: onSyncTap) {
                     HStack(spacing: 4) {
-                        Text(NSLocalizedString("Syncing", comment: ""))
+                        Text(model.isPersistingScannedHistory
+                            ? NSLocalizedString("Processing transactions", comment: "Sync phase: scan finished, transactions still being written")
+                            : NSLocalizedString("Syncing", comment: ""))
                             .font(.subheadline)
                         
                         if model.progress > 0 {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -3368,6 +3368,9 @@
 /* Platform → Transparent withdrawal */
 "Processing time" = "Processing time";
 
+/* Sync phase: scan finished, transactions still being written */
+"Processing transactions" = "Processing transactions";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
On a large, mixing-heavy wallet the app reports "synced" as soon as dash-spv's scan reaches the tip, while the transaction list is still being written to the SwiftData store. The persisted watermark trails the scan by minutes (measured on an iPhone 13 Pro: 15–30 minutes after a relaunch or rescan). The user sees "Syncing 100%" / a synced balance with history ending in 2024, assumes transactions are missing, and kills the app — which is exactly the moment the in-flight persistence round is lost. This is the app-side part of the large-wallet "missing transactions" reports; the SDK-side parts (durable backward re-walk, linear persister) are tracked separately.

## What was done?
- `SyncingActivityMonitor` gates `.syncDone` on `PersistentWallet.syncedHeight` being within 3 blocks of the scanned tip. While behind, the state stays `.syncing`, `progress` reports watermark / tip instead of a frozen 100%, and a new `isPersistingScannedHistory` flag is exposed (plus an optional observer callback).
- The gate is re-evaluated on every persister save that updates `PersistentWallet` (throttled to 1 s), because dash-spv publishes nothing while idle at the tip. Once done is confirmed it stays done until dash-spv itself leaves `.synced`, so a new block briefly ahead of its own persist round cannot flap the UI. A wallet with no persisted watermark yet is not held.
- `SyncingHeaderView` and `SyncView` show "Processing transactions" instead of "Syncing" during that phase; `SyncModel` carries the flag. New English catalog key `"Processing transactions"`.

## How Has This Been Tested?
- iPhone 13 Pro, mainnet, ~6.7k-transaction CoinJoin wallet, rescan from birth height: dash-spv scan finished at 17:07:16, persisted watermark reached the tip at 17:12:25, UI switched to done at 17:12:26 (from the app log). The previous build on the same wallet switched to done ~15 minutes before the watermark reached the tip.
- Second rescan on the same device (36 min end-to-end): `syncDone` stayed false for the whole persistence tail and flipped when the watermark reached the tip.
- Simulator (iPhone 17 Pro Max), same wallet: rescan, process killed mid re-walk, relaunch — the hold re-armed and released once persistence caught up; no state flapping observed on new blocks after completion.
- Known limitation: the percentage only moves when a persister round commits (5–11 minutes on device in CoinJoin-dense ranges). Driving it from intermediate saves is a follow-up.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a distinct sync phase for processing scanned transactions after scanning completes.
  - Sync progress now remains active until scanned history is saved.
  - Added “Processing transactions” status messaging in sync screens and headers.

- **Bug Fixes**
  - Improved sync completion accuracy by waiting for persisted history to catch up before marking synchronization complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->