### PR TITLE
feat: explain balances in the internal transfer picker

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/Components/TransferEndpointPicker.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/Components/TransferEndpointPicker.swift
@@ -209,6 +209,7 @@ private struct TransferBalanceHelpButton: View {
     let title: String
     let network: ChainNetwork?
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var isPresented = false
 
     var body: some View {
@@ -225,20 +226,37 @@ private struct TransferBalanceHelpButton: View {
         .accessibilityLabel(String(format: NSLocalizedString(
             "About %@ balance", comment: "Balance help button; placeholder is the balance name"), title))
         .popover(isPresented: $isPresented) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(title)
-                    .font(.headline)
-                    .foregroundColor(.dash.primaryText)
-                Text(explanation)
-                    .font(.subheadline)
-                    .foregroundColor(.dash.primaryText)
-                    .fixedSize(horizontal: false, vertical: true)
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    ScrollView {
+                        helpContent
+                        Button(NSLocalizedString("Got it", comment: "Dismiss balance help")) {
+                            isPresented = false
+                        }
+                        .font(.body)
+                        .padding(20)
+                    }
+                } else {
+                    helpContent
+                        .frame(idealWidth: 280, maxWidth: 300)
+                }
             }
-            .padding(20)
-            .frame(idealWidth: 280, maxWidth: 300)
             .presentationBackground(Color.dash.primaryBackground)
-            .presentationCompactAdaptation(.popover)
+            .presentationCompactAdaptation(dynamicTypeSize.isAccessibilitySize ? .sheet : .popover)
         }
+    }
+
+    private var helpContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+                .foregroundColor(.dash.primaryText)
+            Text(explanation)
+                .font(.subheadline)
+                .foregroundColor(.dash.primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(20)
     }
 
     private var explanation: String {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/Components/TransferEndpointPicker.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/Components/TransferEndpointPicker.swift
@@ -209,7 +209,8 @@ private struct TransferBalanceHelpButton: View {
     let title: String
     let network: ChainNetwork?
 
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.dynamicTypeSize)
+    private var dynamicTypeSize
     @State private var isPresented = false
 
     var body: some View {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/Components/TransferEndpointPicker.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/Components/TransferEndpointPicker.swift
@@ -114,6 +114,7 @@ struct TransferEndpointPicker: View {
                 ForEach(networks, id: \.self) { network in
                     row(
                         display: display(network: network),
+                        network: network,
                         selected: network == selected,
                         action: { select(network) })
                 }
@@ -156,6 +157,7 @@ struct TransferEndpointPicker: View {
     private func sourceRow(_ source: TransferSource) -> some View {
         row(
             display: display(network: source.balanceNetwork),
+            network: source.balanceNetwork,
             selected: viewModel.transferSource == source,
             action: { viewModel.selectStandaloneSource(source) })
     }
@@ -163,40 +165,101 @@ struct TransferEndpointPicker: View {
     private func destinationRow(_ destination: TransferDestination) -> some View {
         row(
             display: display(network: destination.balanceNetwork),
+            network: destination.balanceNetwork,
             selected: viewModel.destination == destination,
             action: { viewModel.selectStandaloneDestination(destination) })
     }
 
-    /// The design system's `MenuItem`, with the blue tick as its trailing
-    /// accessory.
-    ///
-    /// Name and mark only. No From / To caption — the sheet's own title
-    /// already says which side is being chosen, and repeating it four times
-    /// reads as noise. No radio circle either: the tick is the selection. And
-    /// no balance, which the cards behind the sheet are already showing.
+    /// Selection and help are separate buttons so reading about a balance
+    /// never changes the route or dismisses the picker.
     private func row(
         display: TransferEndpointDisplay,
+        network: ChainNetwork?,
         selected: Bool,
         action: @escaping () -> Void
     ) -> some View {
-        Button {
-            action()
-            onPicked()
-        } label: {
-            DashUIKit.MenuItem(
-                leadingIcon: display.icon,
-                title: display.title,
-                accessory: .selection(isSelected: selected)
-            )
-            .contentShape(Rectangle())
+        HStack(spacing: 0) {
+            Button {
+                action()
+                onPicked()
+            } label: {
+                DashUIKit.MenuItem(
+                    leadingIcon: display.icon,
+                    title: display.title,
+                    accessory: .selection(isSelected: selected)
+                )
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            TransferBalanceHelpButton(title: display.title, network: network)
+                .padding(.trailing, 8)
         }
-        .buttonStyle(.plain)
     }
 
     /// `nil` is the identity row — the one endpoint that is not a balance.
     private func display(network: ChainNetwork?) -> TransferEndpointDisplay {
         guard let network else { return .identity(in: viewModel) }
         return .network(network, in: viewModel)
+    }
+}
+
+/// A compact explanation anchored to its own button, including on iPhone.
+private struct TransferBalanceHelpButton: View {
+    let title: String
+    let network: ChainNetwork?
+
+    @State private var isPresented = false
+
+    var body: some View {
+        Button {
+            isPresented = true
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.body)
+                .foregroundColor(.dash.blue)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(format: NSLocalizedString(
+            "About %@ balance", comment: "Balance help button; placeholder is the balance name"), title))
+        .popover(isPresented: $isPresented) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundColor(.dash.primaryText)
+                Text(explanation)
+                    .font(.subheadline)
+                    .foregroundColor(.dash.primaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(20)
+            .frame(idealWidth: 280, maxWidth: 300)
+            .presentationBackground(Color.dash.primaryBackground)
+            .presentationCompactAdaptation(.popover)
+        }
+    }
+
+    private var explanation: String {
+        switch network {
+        case .core:
+            return NSLocalizedString(
+                "Your everyday Dash balance. Use it to pay merchants or send to other Dash wallets and exchanges; amounts and addresses are public.",
+                comment: "Brief explanation of Transparent balance and why to fund it")
+        case .platform:
+            return NSLocalizedString(
+                "Dash for payments on Dash Platform. Keep funds here to send to Platform addresses or move into your Shielded or Identity balance.",
+                comment: "Brief explanation of Platform balance and why to fund it")
+        case .shielded:
+            return NSLocalizedString(
+                "Dash held privately, with your balance hidden from public view. Use it for private payments to other shielded addresses.",
+                comment: "Brief explanation of Shielded balance and why to fund it")
+        case nil:
+            return NSLocalizedString(
+                "Credits that power your Dash identity. Add funds here to register usernames and pay for actions in apps that use your identity.",
+                comment: "Brief explanation of Identity balance and why to fund it")
+        }
     }
 }
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -5858,3 +5858,12 @@
 
 /* Receive: the QR image doubles as a copy control */
 "Copy QR code" = "Copy QR code";
+
+/* Brief help in the internal transfer balance picker */
+"Transfer from" = "Transfer from";
+"Transfer to" = "Transfer to";
+"About %@ balance" = "About %@ balance";
+"Your everyday Dash balance. Use it to pay merchants or send to other Dash wallets and exchanges; amounts and addresses are public." = "Your everyday Dash balance. Use it to pay merchants or send to other Dash wallets and exchanges; amounts and addresses are public.";
+"Dash for payments on Dash Platform. Keep funds here to send to Platform addresses or move into your Shielded or Identity balance." = "Dash for payments on Dash Platform. Keep funds here to send to Platform addresses or move into your Shielded or Identity balance.";
+"Dash held privately, with your balance hidden from public view. Use it for private payments to other shielded addresses." = "Dash held privately, with your balance hidden from public view. Use it for private payments to other shielded addresses.";
+"Credits that power your Dash identity. Add funds here to register usernames and pay for actions in apps that use your identity." = "Credits that power your Dash identity. Add funds here to register usernames and pay for actions in apps that use your identity.";


### PR DESCRIPTION
## Issue being fixed or feature implemented

The internal transfer picker names four balances without explaining what they are or why to fund them. Users can now tap an info button next to each balance for a brief explanation before choosing.

## What was done?

- Added separate help buttons for Transparent, Platform, Shielded, and Identity in both endpoint pickers, including the pinned balance variants.
- Kept help independent of selection: opening or dismissing it preserves the route and picker.
- Used compact anchored popovers at standard text sizes and a scrollable help sheet at accessibility sizes, with localized copy and accessibility labels.

## How Has This Been Tested?

- Signed local `dashpay` Debug build, installation, launch, and process-liveness verification on iPhone 16 Pro / iOS 26.5.
- Simulator interactions: all four explanations, dismissal with selection preserved, selecting a destination afterward, source help, light/dark appearance, and the largest accessibility text size with Got it dismissal.
- Accessibility audit: no findings in the changed Swift file; repository blocking audit passes. All 54 audit self-tests pass.
- `plutil -lint`, `git diff --check`, and code-review-validator review pass.

Screenshots run app revision `d8f9bd3e9587e5c7fc9566972cf4cbd952b891b5` using an isolated empty Mainnet wallet with Advanced mode enabled. The later merge of `develop` at `656d912d00a08213e3d9382150fb0a97e5b702d0` preserves this picker unchanged, resolves only the overlapping localization additions, and passed another signed simulator build/install/launch check. No transfers were submitted. All published images were visually inspected and their downloaded bytes verified.

| Transfer to | Transfer from |
| --- | --- |
| <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/screenshots/picker-dark.png" width="280" alt="Transfer to"> | <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/screenshots/source-light.png" width="280" alt="Transfer from"> |

| Transparent help | Platform help |
| --- | --- |
| <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/screenshots/transparent-dark.png" width="280" alt="Transparent help"> | <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/screenshots/platform-dark.png" width="280" alt="Platform help"> |

| Shielded help | Identity help |
| --- | --- |
| <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/screenshots/shielded-dark.png" width="280" alt="Shielded help"> | <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/screenshots/identity-dark.png" width="280" alt="Identity help"> |

[Light-mode help](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/screenshots/identity-light.png) · [Largest text size](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/screenshots/large-text.png) · [Full-resolution evidence and provenance](https://github.com/PastaPastaPasta/dash-ui-artifacts/blob/82f1fe9485c4ddc7bcc4c835c968e177875412ca/dashwallet-ios/pr-1115/README.md)

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

This pull request was created by Codex.
