### PR TITLE
fix(ui): limit clipboard reads to the visible Send address screen

### DIFF
--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -255,6 +255,7 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         // same receive session (or start a fresh "Receive another" session).
         viewModel.setReceiptWatchingObscured(false)
         isSurfaceOnScreen = true
+        embeddedSendViewModel.refreshClipboardSuggestion()
         isPushingReceiveStep = false
         receiveStepObservers.removeAll()
         viewModel.setReceiveSurfaceVisible(true)

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -168,6 +168,10 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         super.viewDidLoad()
         view.backgroundColor = .dw_background()
 
+        embeddedSendViewModel.isClipboardReadAllowed = { [weak self] in
+            self?.viewModel.activeTab == .send
+        }
+
         addChild(hostingController)
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
         hostingController.view.backgroundColor = .clear

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -63,6 +63,11 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
     /// suspends watching the moment that screen is pushed, so nothing is
     /// detected while the user is on the very screen they are handing over.
     private var isPushingReceiveStep = false
+    /// Whether this landing is the screen the user is on. Gates the Send
+    /// tab's pasteboard reads: unlike the receive session, a pushed step is
+    /// not "still here" for the clipboard, so this one tracks plain
+    /// appearance and ignores `isPushingReceiveStep`.
+    private var isSurfaceOnScreen = false
     /// The specify-amount sheet while it is up, so a receipt can dismiss it.
     private weak var requestAmountController: RequestAmountHostingController?
     /// Kept apart from `cancellables`: these live exactly as long as that sheet
@@ -168,8 +173,13 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         super.viewDidLoad()
         view.backgroundColor = .dw_background()
 
+        // Reads need both halves: this landing on screen (a pushed send step
+        // or a dismissal revokes it, and the model is reused by those steps)
+        // and the Send tab selected. The tab check alone is not enough — the
+        // outgoing form stays alive through its slide-out transition.
         embeddedSendViewModel.isClipboardReadAllowed = { [weak self] in
-            self?.viewModel.activeTab == .send
+            guard let self else { return false }
+            return self.isSurfaceOnScreen && self.viewModel.activeTab == .send
         }
 
         addChild(hostingController)
@@ -244,6 +254,7 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         // here as well so returning from transaction details can resume the
         // same receive session (or start a fresh "Receive another" session).
         viewModel.setReceiptWatchingObscured(false)
+        isSurfaceOnScreen = true
         isPushingReceiveStep = false
         receiveStepObservers.removeAll()
         viewModel.setReceiveSurfaceVisible(true)
@@ -255,6 +266,9 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        // Set before the receive-step exemption below: for the clipboard,
+        // every way of leaving this screen counts, pushed step included.
+        isSurfaceOnScreen = false
         // Stepping deeper into the receive flow is not leaving it. Everything
         // else — a tab change, a dismissal, a pop — still puts the session to
         // sleep.

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -31,6 +31,10 @@ struct SendScreen: View {
 
     @FocusState private var addressFieldFocused: Bool
     @State private var isEditingAddress = false
+    /// Identifies this instance's clipboard-monitoring registration. During a
+    /// tab change two `SendScreen`s are alive at once, so the outgoing one's
+    /// `onDisappear` must withdraw only its own.
+    @State private var clipboardMonitorToken = UUID()
 
     /// The address is "locked" (shown as a truncated card) once a valid
     /// destination is decoded and focus has left the field; tapping it reopens
@@ -80,13 +84,15 @@ struct SendScreen: View {
         .navigationBarHidden(true)
         .task {
             // A pasteboard read can block on the system permission dialog.
-            // Let the address form's entrance animation finish first. SwiftUI
-            // cancels this task if the user leaves before then.
+            // Let the address form's entrance animation finish first. This
+            // view can still be on its way out when the sleep ends — its
+            // removal transition outlasts the delay — which is why the read
+            // itself is gated on the host's `isClipboardReadAllowed`.
             try? await Task.sleep(for: .milliseconds(300))
             guard !Task.isCancelled else { return }
-            viewModel.setClipboardMonitoringEnabled(true)
+            viewModel.setClipboardMonitoring(true, token: clipboardMonitorToken)
         }
-        .onDisappear { viewModel.setClipboardMonitoringEnabled(false) }
+        .onDisappear { viewModel.setClipboardMonitoring(false, token: clipboardMonitorToken) }
     }
 
     // MARK: - Header

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -78,6 +78,15 @@ struct SendScreen: View {
         }
         .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
+        .task {
+            // A pasteboard read can block on the system permission dialog.
+            // Let the address form's entrance animation finish first. SwiftUI
+            // cancels this task if the user leaves before then.
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            viewModel.setClipboardMonitoringEnabled(true)
+        }
+        .onDisappear { viewModel.setClipboardMonitoringEnabled(false) }
     }
 
     // MARK: - Header

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 @objc(DWSendScreenViewController)
 final class SendScreenViewController: DWBasePayViewController {
 
-    /// Set by the "Send to Address" shortcut entry: on load, a valid address
+    /// Set by the "Send to Address" shortcut entry: on appearance, a valid address
     /// on the clipboard is applied to the address field directly — the same
     /// action as tapping the clipboard suggestion chip.
     var prefillsFromClipboard = false
@@ -60,15 +60,21 @@ final class SendScreenViewController: DWBasePayViewController {
         ])
         hostingController.didMove(toParent: self)
 
-        if prefillsFromClipboard {
-            sendViewModel.useClipboardSuggestion()
-        }
         if let prefillAddress {
             sendViewModel.addressText = prefillAddress
             if prefillAmountDuffs > 0 {
                 sendViewModel.unit = .dash
                 sendViewModel.amountText = prefillAmountDuffs.formattedDashAmountWithoutCurrencySymbol
             }
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if prefillsFromClipboard {
+            prefillsFromClipboard = false
+            sendViewModel.setClipboardMonitoringEnabled(true)
+            sendViewModel.useClipboardSuggestion()
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
@@ -85,6 +85,8 @@ final class SendScreenViewController: DWBasePayViewController {
             // animation is deferred), so the intent is handed to the model
             // rather than acted on against a suggestion that cannot exist yet.
             sendViewModel.applyClipboardSuggestionWhenAvailable()
+        } else {
+            sendViewModel.refreshClipboardSuggestion()
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
@@ -26,6 +26,11 @@ final class SendScreenViewController: DWBasePayViewController {
     private var prefillAddress: String?
     private var prefillAmountDuffs: UInt64 = 0
 
+    /// Grants the model its pasteboard reads. The SwiftUI form below stays
+    /// alive while a later send step is pushed over it, so appearance — not
+    /// the form's lifetime — is what says the screen is on screen.
+    private var isOnScreen = false
+
     private let sendViewModel = SendViewModel()
     private lazy var hostingController: UIHostingController<SendScreen> = {
         let screen = SendScreen(
@@ -60,6 +65,8 @@ final class SendScreenViewController: DWBasePayViewController {
         ])
         hostingController.didMove(toParent: self)
 
+        sendViewModel.isClipboardReadAllowed = { [weak self] in self?.isOnScreen == true }
+
         if let prefillAddress {
             sendViewModel.addressText = prefillAddress
             if prefillAmountDuffs > 0 {
@@ -71,11 +78,19 @@ final class SendScreenViewController: DWBasePayViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        isOnScreen = true
         if prefillsFromClipboard {
             prefillsFromClipboard = false
-            sendViewModel.setClipboardMonitoringEnabled(true)
-            sendViewModel.useClipboardSuggestion()
+            // The form registers for reads shortly after this (its entrance
+            // animation is deferred), so the intent is handed to the model
+            // rather than acted on against a suggestion that cannot exist yet.
+            sendViewModel.applyClipboardSuggestionWhenAvailable()
         }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        isOnScreen = false
     }
 
     // MARK: - QR scan

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -94,10 +94,19 @@ final class SendViewModel: ObservableObject {
         }
     }
     @Published private(set) var clipboardSuggestion: ClipboardSuggestion? = nil
-    private var isClipboardMonitoringEnabled = false
-    /// Hosts with animated tabs must also check selection: the outgoing view
-    /// can remain alive briefly after another tab has been selected.
-    var isClipboardReadAllowed: () -> Bool = { true }
+    /// One token per address form that currently wants automatic reads. A set
+    /// rather than a flag because a host with animated tabs keeps the outgoing
+    /// form alive after the incoming one appeared: both are registered at
+    /// once, and the outgoing one's removal drops only its own registration.
+    private var clipboardMonitors: Set<UUID> = []
+    /// The "Send to Address" shortcut's intent, held until a read this screen
+    /// was actually allowed to make has run — a deferred or denied read must
+    /// not silently consume it.
+    private var appliesClipboardSuggestionWhenAvailable = false
+    /// Granted by the host for as long as its send surface is on screen.
+    /// Closed by default: a host that never opts in must not have the user's
+    /// pasteboard read behind its back.
+    var isClipboardReadAllowed: () -> Bool = { false }
 
     // Balances — same feeds as `InternalTransferViewModel` (BIP44 duffs,
     // DIP-17 credits, Orchard credits).
@@ -427,25 +436,60 @@ final class SendViewModel: ObservableObject {
         let kind: DestinationKind
     }
 
-    /// Only the visible address form enables automatic reads. This model also
-    /// exists behind Receive/Internal and is reused by later send steps.
-    func setClipboardMonitoringEnabled(_ enabled: Bool) {
-        guard isClipboardMonitoringEnabled != enabled else { return }
-        isClipboardMonitoringEnabled = enabled
+    /// Only a visible address form registers for automatic reads. This model
+    /// also exists behind Receive/Internal and is reused by later send steps.
+    ///
+    /// `token` identifies the registering form. Reads run while at least one
+    /// registration stands, so a form being removed can never switch off the
+    /// monitoring another form just switched on.
+    func setClipboardMonitoring(_ enabled: Bool, token: UUID) {
+        let wasMonitoring = !clipboardMonitors.isEmpty
         if enabled {
-            refreshClipboardSuggestion()
+            clipboardMonitors.insert(token)
         } else {
+            clipboardMonitors.remove(token)
+        }
+
+        if !clipboardMonitors.isEmpty {
+            refreshClipboardSuggestion()
+        } else if wasMonitoring {
             clipboardSuggestion = nil
+            appliesClipboardSuggestionWhenAvailable = false
         }
     }
 
+    /// The "Send to Address" shortcut: fill the address field from the
+    /// clipboard as soon as a permitted read runs. The host calls this on
+    /// appearance, before the form has registered, so the intent waits for
+    /// that first read instead of being spent on a read that cannot happen.
+    func applyClipboardSuggestionWhenAvailable() {
+        appliesClipboardSuggestionWhenAvailable = true
+        refreshClipboardSuggestion()
+    }
+
     private func refreshClipboardSuggestion() {
-        guard isClipboardMonitoringEnabled, isClipboardReadAllowed() else { return }
-        guard let raw = UIPasteboard.general.string else {
+        guard !clipboardMonitors.isEmpty, isClipboardReadAllowed() else {
+            // Not allowed to read is also not allowed to keep offering what an
+            // earlier read found: the pasteboard may have changed since, and
+            // the chip must not outlive the screen that produced it.
             clipboardSuggestion = nil
             return
         }
-        clipboardSuggestion = Self.detect(in: raw)
+
+        if let raw = UIPasteboard.general.string {
+            clipboardSuggestion = Self.detect(in: raw)
+        } else {
+            clipboardSuggestion = nil
+        }
+
+        guard appliesClipboardSuggestionWhenAvailable else { return }
+        // Spent by the first permitted read, whatever it found — a denied
+        // prompt or an empty clipboard has no retry to wait for.
+        appliesClipboardSuggestionWhenAvailable = false
+        // An explicit prefill (a scan-routed address, applied on load) wins
+        // over the clipboard, as it did when both ran in `viewDidLoad`.
+        guard trimmedAddress.isEmpty else { return }
+        useClipboardSuggestion()
     }
 
     func useClipboardSuggestion() {

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -467,7 +467,9 @@ final class SendViewModel: ObservableObject {
         refreshClipboardSuggestion()
     }
 
-    private func refreshClipboardSuggestion() {
+    /// Refreshes when a host becomes visible or the clipboard changes. Both
+    /// the form registration and the host's permission must allow the read.
+    func refreshClipboardSuggestion() {
         guard !clipboardMonitors.isEmpty, isClipboardReadAllowed() else {
             // Not allowed to read is also not allowed to keep offering what an
             // earlier read found: the pasteboard may have changed since, and

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -94,6 +94,10 @@ final class SendViewModel: ObservableObject {
         }
     }
     @Published private(set) var clipboardSuggestion: ClipboardSuggestion? = nil
+    private var isClipboardMonitoringEnabled = false
+    /// Hosts with animated tabs must also check selection: the outgoing view
+    /// can remain alive briefly after another tab has been selected.
+    var isClipboardReadAllowed: () -> Bool = { true }
 
     // Balances — same feeds as `InternalTransferViewModel` (BIP44 duffs,
     // DIP-17 credits, Orchard credits).
@@ -157,7 +161,6 @@ final class SendViewModel: ObservableObject {
         if let pinnedSource {
             source = pinnedSource
         }
-        refreshClipboardSuggestion()
         SyncingActivityMonitor.shared.add(observer: self)
 
         NotificationCenter.default.publisher(for: UIPasteboard.changedNotification)
@@ -424,7 +427,18 @@ final class SendViewModel: ObservableObject {
         let kind: DestinationKind
     }
 
-    func refreshClipboardSuggestion() {
+    /// Only the visible address form enables automatic reads. This model also
+    /// exists behind Receive/Internal and is reused by later send steps.
+    func setClipboardMonitoringEnabled(_ enabled: Bool) {
+        guard isClipboardMonitoringEnabled != enabled else { return }
+        isClipboardMonitoringEnabled = enabled
+        if enabled {
+            refreshClipboardSuggestion()
+        }
+    }
+
+    private func refreshClipboardSuggestion() {
+        guard isClipboardMonitoringEnabled, isClipboardReadAllowed() else { return }
         guard let raw = UIPasteboard.general.string else {
             clipboardSuggestion = nil
             return

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -434,6 +434,8 @@ final class SendViewModel: ObservableObject {
         isClipboardMonitoringEnabled = enabled
         if enabled {
             refreshClipboardSuggestion()
+        } else {
+            clipboardSuggestion = nil
         }
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Opening Receive or Internal could show iOS’s paste-permission dialog because the shared Send view model read the clipboard while its address form was hidden. Its notification observers could also read the clipboard after navigating to later send steps.

## What was done?

Automatic clipboard reads now run only while the Send address form is visible. Reads start after its entrance animation and stop when it disappears; a live tab-selection check also prevents outgoing animated views from reading after the user switches tabs. Cached suggestions are cleared when monitoring stops so the previous clipboard address cannot be selected during the next refresh delay. Monitoring registrations belong to individual forms, so an outgoing form cannot disable an incoming form. UIKit host visibility also gates reads while later send steps cover the form, and the suggestion refreshes when the host reappears. The standalone Send shortcut still prefills a copied address, with that work deferred until presentation.

## How Has This Been Tested?

- Built the `dashpay` scheme locally for an arm64 iOS 26.5 simulator; code-signing verification and launch/liveness checks passed.
- Reproduced the original Receive paste prompt, then verified Receive and Internal remain quiet with the fix, including clipboard changes and a Send-to-Internal switch within 60 ms.
- Verified Send displays the prompt over the address form, accepting it produces a usable address suggestion, source selection ignores clipboard changes, and returning to the address step refreshes the clipboard.
- Verified the old suggestion is absent 152 ms after returning to Send, before the delayed refresh, and remains absent when paste access is denied.
- Built and exercised the latest follow-up (`77b707ceb`): confirmed the missing refresh on return from source selection before the fix, and verified it refreshes afterward while Receive, Internal, and source selection stay quiet.
- Swift syntax, whitespace checks, targeted accessibility lint, and code review passed. No unit-suite result is claimed.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Clipboard address suggestions are monitored only while the Send screen is visible and active.
  * Suggestions are refreshed when entering the Send screen and applied when the screen appears.
  * Clipboard access is limited to the active Send tab, reducing unnecessary background reads.
  * Switching between payment tabs no longer interrupts clipboard monitoring for the currently visible Send screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
