### PR TITLE
feat(dashpay): pay contacts from any address balance

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -2029,6 +2029,9 @@
 		25B84141680B6A9F225C995C /* BulkVoteSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E5E523355F3EEC5CDEB00A /* BulkVoteSheet.swift */; };
 		7062FCF792F292D84A0B819B /* VoteHistoryDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFB72236D79932EAE7A38E2 /* VoteHistoryDAO.swift */; };
 		553696A24F315D361BC86231 /* VoteHistoryDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFB72236D79932EAE7A38E2 /* VoteHistoryDAO.swift */; };
+		C4A14BAD09A608E7499B32B8 /* DashPayWithdrawalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9653678681D52B55713B5A /* DashPayWithdrawalStore.swift */; };
+		4F3D13471128A38D468CCADE /* DashPayWithdrawalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F1E6AB037F85A309E8DBA4 /* DashPayWithdrawalStoreTests.swift */; };
+		D45A707A1000000000000001 /* DashPayWithdrawalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9653678681D52B55713B5A /* DashPayWithdrawalStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -3832,6 +3835,8 @@
 		C3E5E523355F3EEC5CDEB00A /* BulkVoteSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BulkVoteSheet.swift; sourceTree = "<group>"; };
 		A1B2C3D40001VOTINGNODESEL /* VotingNodeSelectionSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VotingNodeSelectionSheet.swift; sourceTree = "<group>"; };
 		0AFB72236D79932EAE7A38E2 /* VoteHistoryDAO.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoteHistoryDAO.swift; sourceTree = "<group>"; };
+		EC9653678681D52B55713B5A /* DashPayWithdrawalStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DashPayWithdrawalStore.swift; sourceTree = "<group>"; };
+		78F1E6AB037F85A309E8DBA4 /* DashPayWithdrawalStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DashPayWithdrawalStoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -6990,6 +6995,7 @@
 				4D0A7C21B5E39F04A11C2D57 /* DashPayUserLink.swift */,
 				02357928871603392E797C9A /* SwiftDashSDKContactsService.swift */,
 				5ADPR0012E4A0000000000F1 /* DashPayContactAddressReadiness.swift */,
+				EC9653678681D52B55713B5A /* DashPayWithdrawalStore.swift */,
 			);
 			path = Contacts;
 			sourceTree = "<group>";
@@ -7379,6 +7385,7 @@
 				DA57A1010000000000000001 /* PastedAmountNormalizationTests.swift */,
 				DA5A00000000000000000005 /* DashPayIdentityKeysTests.swift */,
 				D5E2D975669CB53883D56803 /* DWAvatarUploadClientTests.swift */,
+				78F1E6AB037F85A309E8DBA4 /* DashPayWithdrawalStoreTests.swift */,
 			);
 			path = DashWalletTests;
 			sourceTree = "<group>";
@@ -10523,6 +10530,7 @@
 				A15ED0B9E7AAF29C694E4E17 /* DWIdentityAuthorizer.swift in Sources */,
 				2A6B1257A51E609B8025BF3A /* ShieldedTransferCoordinator.swift in Sources */,
 				9B40E576972DB41F7EF4D21E /* ShieldedWithdrawalStore.swift in Sources */,
+				D45A707A1000000000000001 /* DashPayWithdrawalStore.swift in Sources */,
 				06132521E7B4D21B4A1597E7 /* PlatformSendExecutor.swift in Sources */,
 				D3DA37D1924A7F5B089FE110 /* StorageExplorerView.swift in Sources */,
 				3B1ECCE5521BAB084D74B5ED /* StorageModelListViews.swift in Sources */,
@@ -10613,6 +10621,7 @@
 				DA57A1010000000000000002 /* PastedAmountNormalizationTests.swift in Sources */,
 				DA5A00000000000000000004 /* DashPayIdentityKeysTests.swift in Sources */,
 				215F9BB0CAADF4D47D95C444 /* DWAvatarUploadClientTests.swift in Sources */,
+				4F3D13471128A38D468CCADE /* DashPayWithdrawalStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11636,6 +11645,7 @@
 				4720E26BFE56A4559C602ED5 /* ShieldedIdentityFundingReadiness.swift in Sources */,
 				D15607B6987D27ACDC844F9E /* DWAvatarUploadClient.swift in Sources */,
 				A365C2F95472285830E6CDEB /* HomeUsernameRow.swift in Sources */,
+				C4A14BAD09A608E7499B32B8 /* DashPayWithdrawalStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayWithdrawalStore.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayWithdrawalStore.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Local provenance for DashPay payments funded by a Platform withdrawal.
+/// These are submission records, never Core transaction IDs or proof that a
+/// recipient has received funds. The withdrawal SDK does not return a Core
+/// transaction ID. Keep this journal separate from its Core payment history.
+final class DashPayWithdrawalStore {
+    static let shared = DashPayWithdrawalStore(directory: FileManager.default
+        .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("DashPayWithdrawals", isDirectory: true))
+
+    static let didChangeNotification = Notification.Name("DWDashPayWithdrawalsDidChange")
+
+    struct Scope: Codable, Equatable {
+        let networkRaw: Int
+        let walletId: Data
+        let ownerIdentityId: Data
+    }
+
+    enum Source: String, Codable {
+        case platform
+        case shielded
+    }
+
+    enum Status: String, Codable {
+        /// Persisted before invoking the opaque withdrawal SDK call. A crash
+        /// can leave this state behind even if submission succeeded.
+        case submitting
+        /// SDK accepted the withdrawal; the Core payout is still asynchronous.
+        case submitted
+        /// Submission was attempted but its result could not be established.
+        case unconfirmed
+    }
+
+    struct Entry: Codable, Equatable, Identifiable {
+        let id: UUID
+        let scope: Scope
+        let contactIdentityId: Data
+        let address: String
+        let amountDuffs: UInt64
+        let amountIsEstimate: Bool
+        let source: Source
+        let createdAt: Date
+        var status: Status
+    }
+
+    enum StoreError: LocalizedError {
+        case invalidPayment
+        case missingEntry
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidPayment:
+                return NSLocalizedString("Unable to save this DashPay withdrawal.", comment: "")
+            case .missingEntry:
+                return NSLocalizedString("The DashPay withdrawal record is unavailable.", comment: "")
+            }
+        }
+    }
+
+    private let directory: URL
+    private let lock = NSLock()
+
+    init(directory: URL) {
+        self.directory = directory
+    }
+
+    /// Call after authorization and address reservation, immediately BEFORE
+    /// invoking the withdrawal. A failed save must prevent submission. Keep
+    /// the captured scope through awaits so a wallet switch cannot relabel it.
+    func begin(
+        scope: Scope,
+        contactIdentityId: Data,
+        address: String,
+        amountDuffs: UInt64,
+        amountIsEstimate: Bool = false,
+        source: Source
+    ) throws -> Entry {
+        guard scope.walletId.count == 32, scope.ownerIdentityId.count == 32,
+              contactIdentityId.count == 32, !address.isEmpty, amountDuffs > 0,
+              (0...2).contains(scope.networkRaw) else {
+            throw StoreError.invalidPayment
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        var entries = try load(scope: scope)
+        let entry = Entry(
+            id: UUID(), scope: scope, contactIdentityId: contactIdentityId,
+            address: address, amountDuffs: amountDuffs,
+            amountIsEstimate: amountIsEstimate, source: source,
+            createdAt: Date(), status: .submitting)
+        entries.append(entry)
+        try save(entries, scope: scope)
+        return entry
+    }
+
+    func update(_ entry: Entry, status: Status) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        var entries = try load(scope: entry.scope)
+        guard let index = entries.firstIndex(where: { $0.id == entry.id }) else {
+            throw StoreError.missingEntry
+        }
+        entries[index].status = status
+        try save(entries, scope: entry.scope)
+    }
+
+    /// Only remove when the caller knows submission never happened. Unknown
+    /// outcomes must remain visible across restarts; they are never retried by
+    /// this store or inferred successful from a payment to the same address.
+    func remove(_ entry: Entry) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        let entries = try load(scope: entry.scope).filter { $0.id != entry.id }
+        try save(entries, scope: entry.scope)
+    }
+
+    func entries(scope: Scope, contactIdentityId: Data) throws -> [Entry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return try load(scope: scope)
+            .filter { $0.scope == scope && $0.contactIdentityId == contactIdentityId }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    func clearForWallet(walletId: Data) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        guard FileManager.default.fileExists(atPath: directory.path) else { return }
+        let walletHex = Self.hex(walletId)
+        for file in try FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil)
+        where file.lastPathComponent.split(separator: "_").dropFirst().first.map(String.init) == walletHex {
+            try FileManager.default.removeItem(at: file)
+        }
+        notifyChange()
+    }
+
+    func resetForWipe() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.removeItem(at: directory)
+        }
+        notifyChange()
+    }
+
+    private func fileURL(scope: Scope) -> URL {
+        directory.appendingPathComponent(
+            "\(scope.networkRaw)_\(Self.hex(scope.walletId))_\(Self.hex(scope.ownerIdentityId)).json")
+    }
+
+    private func load(scope: Scope) throws -> [Entry] {
+        let url = fileURL(scope: scope)
+        guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+        // Do not overwrite corrupt/unreadable history with an empty journal.
+        return try JSONDecoder().decode([Entry].self, from: Data(contentsOf: url))
+    }
+
+    private func save(_ entries: [Entry], scope: Scope) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try JSONEncoder().encode(entries).write(to: fileURL(scope: scope), options: .atomic)
+        notifyChange()
+    }
+
+    private func notifyChange() {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
+        }
+    }
+
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
@@ -121,6 +121,8 @@ final class SwiftDashSDKContactsService: ObservableObject {
         // back-to-back) into one snapshot rebuild.
         saveObserverCancellable = NotificationCenter.default
             .publisher(for: .NSManagedObjectContextDidSave)
+            .merge(with: NotificationCenter.default.publisher(
+                for: DashPayWithdrawalStore.didChangeNotification))
             .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refresh()
@@ -530,24 +532,27 @@ final class SwiftDashSDKContactsService: ObservableObject {
     /// One row of the payments-between-us history for a contact,
     /// read from the SwiftData rows the DashPay sync reconciles.
     struct ContactPayment: Identifiable {
+        let id: String
         /// Display-order (RPC) txid hex — the Rust `dashpay_payments`
-        /// map key, produced by `dashcore::Txid::to_string()`.
-        let txid: String
+        /// map key, produced by `dashcore::Txid::to_string()`. Absent for a
+        /// withdrawal submission, which has no known Core transaction yet.
+        let txid: String?
         let amountDuffs: UInt64
+        let amountIsEstimate: Bool
         let direction: DashPayPaymentDirection
         let memo: String?
         let date: Date
         /// Current-rate fiat equivalent of `amountDuffs`, formatted for
         /// display (e.g. "$0.35"). Nil only when the amount is zero.
         let fiatString: String?
-        var id: String { txid }
+        let withdrawalStatus: String?
 
         /// Wire-order txid (the byte reverse of the display-order hex
         /// key) — the form `SwiftDashSDKWalletSource.fetch(txid:)` and
         /// `TxDetailModel(txidWire:)` expect, matching
         /// `PersistentTransaction.txid`. Nil when the hex won't parse.
         var txidWire: Data? {
-            guard let display = Data(hex: txid) else { return nil }
+            guard let txid, let display = Data(hex: txid) else { return nil }
             return Data(display.reversed())
         }
     }
@@ -580,7 +585,7 @@ final class SwiftDashSDKContactsService: ObservableObject {
             }
         }
 
-        return rows.map { row in
+        var payments = rows.map { row in
             let dash = Decimal(row.amountDuffs) / Decimal(100_000_000)
             // `PersistentDashpayPayment.txid` is display-order hex; the
             // transaction table is keyed by the wire-order bytes.
@@ -593,8 +598,10 @@ final class SwiftDashSDKContactsService: ObservableObject {
                 .map { Date(timeIntervalSince1970: TimeInterval($0)) }
                 ?? row.createdAt
             return ContactPayment(
+                id: row.txid,
                 txid: row.txid,
                 amountDuffs: row.amountDuffs,
+                amountIsEstimate: false,
                 direction: row.direction,
                 memo: row.memo,
                 date: date,
@@ -604,12 +611,39 @@ final class SwiftDashSDKContactsService: ObservableObject {
                 // rather than throwing when rates aren't up yet.
                 fiatString: row.amountDuffs > 0
                     ? CurrencyExchanger.shared.fiatAmountString(for: dash)
-                    : nil)
+                    : nil,
+                withdrawalStatus: nil)
+        }
+        if let walletId = WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind) {
+            let scope = DashPayWithdrawalStore.Scope(
+                networkRaw: WalletEnvironment.networkKind.rawValue,
+                walletId: walletId, ownerIdentityId: ownerId)
+            do {
+                let withdrawals = try DashPayWithdrawalStore.shared.entries(
+                    scope: scope, contactIdentityId: contactId)
+                payments += withdrawals.map { entry in
+                    ContactPayment(
+                        id: "withdrawal:\(entry.id.uuidString)",
+                        txid: nil,
+                        amountDuffs: entry.amountDuffs,
+                        amountIsEstimate: entry.amountIsEstimate,
+                        direction: .sent,
+                        memo: nil,
+                        date: entry.createdAt,
+                        fiatString: CurrencyExchanger.shared.fiatAmountString(
+                            for: Decimal(entry.amountDuffs) / Decimal(100_000_000)),
+                        withdrawalStatus: entry.status == .submitted
+                            ? NSLocalizedString("Withdrawal submitted", comment: "DashPay payment history")
+                            : NSLocalizedString("Withdrawal status unknown", comment: "DashPay payment history"))
+                }
+            } catch {
+                Self.logger.error("DashPay withdrawal history could not be read: \(String(describing: error), privacy: .public)")
+            }
         }
         // Sort on the payment date, not the row's insert order: reconstructed
         // rows are all written within the same second, so insert order says
         // nothing about which payment came first.
-        .sorted { $0.date > $1.date }
+        return payments.sorted { $0.date > $1.date }
     }
 
     /// Write the owner-private contact metadata (alias / note / hidden)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -287,6 +287,13 @@ final class SwiftDashSDKWalletWiper: NSObject {
             return false
         }
 
+        do {
+            try DashPayWithdrawalStore.shared.resetForWipe()
+        } catch {
+            logger.error("failed to clear DashPay withdrawal history: \(String(describing: error), privacy: .public)")
+            return false
+        }
+
         // The SDK wallet deletion is now known to have succeeded for every
         // network. Clear every global app-owned store only at this commit
         // point, so a failed wipe preserves a coherent wallet,
@@ -640,6 +647,7 @@ final class SwiftDashSDKWalletWiper: NSObject {
             CrowdNodeDefaults.shared.clearPerWalletKeys(forWalletIdHex: walletIdHex)
             CoinJoinWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             ShieldedWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
+            try DashPayWithdrawalStore.shared.clearForWallet(walletId: walletId)
             AssetLockProbeStore.shared.clearForWallet(walletIdHex: walletIdHex)
         }
     }

--- a/DashWallet/Sources/Models/Transactions/WalletSendService.swift
+++ b/DashWallet/Sources/Models/Transactions/WalletSendService.swift
@@ -501,6 +501,9 @@ final class WalletSendService: NSObject {
               recipient.identityId.count == 32,
               ownerId.count == 32,
               walletId == SwiftDashSDKHost.shared.wallet?.walletId,
+              walletId == WalletEnvironment.activeWalletId(for: recipient.network),
+              SwiftDashSDKHost.shared.runningNetwork != nil,
+              SwiftDashSDKHost.shared.runningNetwork == WalletEnvironment.network,
               ownerId == DWCurrentUserIdentityInfo.shared.identityId,
               recipient.network == WalletEnvironment.networkKind else {
             throw makeError(

--- a/DashWallet/Sources/Models/Transactions/WalletSendService.swift
+++ b/DashWallet/Sources/Models/Transactions/WalletSendService.swift
@@ -9,6 +9,17 @@ import Foundation
 import OSLog
 import SwiftDashSDK
 
+/// Immutable recipient and wallet context retained throughout a contact payment.
+/// A wallet/identity switch while a sheet or authentication prompt is open must
+/// invalidate the payment rather than spend from the newly selected wallet.
+struct ContactPaymentRecipient {
+    let identityId: Data
+    let displayName: String
+    let walletId: Data?
+    let ownerIdentityId: Data?
+    let network: WalletEnvironment.NetworkKind
+}
+
 /// Core-chain transaction constants the app needs without DashSync.
 enum CoreTxConstants {
     /// DashSync's TX_MIN_OUTPUT_AMOUNT: TX_FEE_PER_B(1) × 3 × (TX_OUTPUT_SIZE(34) +
@@ -437,16 +448,24 @@ final class WalletSendService: NSObject {
     func sendToContact(
         contactIdentityId: Data,
         amount: UInt64,
-        memo: String? = nil
+        memo: String? = nil,
+        recipient: ContactPaymentRecipient? = nil
     ) async throws -> (txid: Data, feeDuffs: UInt64) {
         Self.logger.info("💸 TXSEND :: pay-to-contact starting — \(amount, privacy: .public) duffs")
+        if let recipient {
+            try await MainActor.run { try Self.validateContactRecipient(recipient) }
+            guard recipient.identityId == contactIdentityId else {
+                throw Self.makeError(code: .dashPayPaymentUnavailable, description: "The payment recipient changed. Reopen the payment and try again.")
+            }
+        }
         try Self.ensureInitialRestoreSyncCompleted()
         // spendAmount engages the biometric spending limit (C7.4) —
         // without it the gate is non-monetary and Face ID alone would
         // authorize a contact payment of any size.
         try await sendAuthorizer.authorizeSend(spendAmount: amount)
 
-        let context: (wallet: ManagedPlatformWallet, ourId: Data)? = await MainActor.run {
+        let context: (wallet: ManagedPlatformWallet, ourId: Data)? = try await MainActor.run {
+            if let recipient { try Self.validateContactRecipient(recipient) }
             guard let wallet = SwiftDashSDKHost.shared.wallet,
                   let ourId = DWCurrentUserIdentityInfo.shared.identityId else {
                 return nil
@@ -474,6 +493,47 @@ final class WalletSendService: NSObject {
         return (txid: txid, feeDuffs: feeDuffs)
     }
 #endif
+
+    @MainActor
+    static func validateContactRecipient(_ recipient: ContactPaymentRecipient) throws {
+        guard let walletId = recipient.walletId,
+              let ownerId = recipient.ownerIdentityId,
+              recipient.identityId.count == 32,
+              ownerId.count == 32,
+              walletId == SwiftDashSDKHost.shared.wallet?.walletId,
+              ownerId == DWCurrentUserIdentityInfo.shared.identityId,
+              recipient.network == WalletEnvironment.networkKind else {
+            throw makeError(
+                code: .dashPayPaymentUnavailable,
+                description: NSLocalizedString("Your wallet or DashPay identity changed. Reopen the payment and try again.", comment: "DashPay send context changed"))
+        }
+    }
+
+    /// Called only after explicit confirmation. Authorize the monetary spend,
+    /// then reserve a fresh contact address through the SDK's authoritative pool.
+    @MainActor
+    func prepareContactWithdrawal(
+        recipient: ContactPaymentRecipient,
+        amountDuffs: UInt64
+    ) async throws -> String {
+        try Self.validateContactRecipient(recipient)
+        try Self.ensureOnline()
+        try await sendAuthorizer.authorizeSend(spendAmount: amountDuffs)
+        try Self.validateContactRecipient(recipient)
+        guard let wallet = SwiftDashSDKHost.shared.wallet,
+              let ownerId = recipient.ownerIdentityId else {
+            throw Self.makeError(code: .dashPayPaymentUnavailable, description: "Wallet or DashPay identity is not ready")
+        }
+        do {
+            let address = try await wallet.reserveDashPayPaymentAddress(
+                fromIdentityId: ownerId,
+                toContactIdentityId: recipient.identityId)
+            try Self.validateContactRecipient(recipient)
+            return address
+        } catch {
+            throw Self.contactPaymentError(from: error)
+        }
+    }
 
     @objc(prepareStandardSendForConfirmationWithAddress:amount:completion:)
     func prepareStandardSendForConfirmation(

--- a/DashWallet/Sources/Models/Transactions/WalletSendService.swift
+++ b/DashWallet/Sources/Models/Transactions/WalletSendService.swift
@@ -449,14 +449,12 @@ final class WalletSendService: NSObject {
         contactIdentityId: Data,
         amount: UInt64,
         memo: String? = nil,
-        recipient: ContactPaymentRecipient? = nil
+        recipient: ContactPaymentRecipient
     ) async throws -> (txid: Data, feeDuffs: UInt64) {
         Self.logger.info("💸 TXSEND :: pay-to-contact starting — \(amount, privacy: .public) duffs")
-        if let recipient {
-            try await MainActor.run { try Self.validateContactRecipient(recipient) }
-            guard recipient.identityId == contactIdentityId else {
-                throw Self.makeError(code: .dashPayPaymentUnavailable, description: "The payment recipient changed. Reopen the payment and try again.")
-            }
+        try await MainActor.run { try Self.validateContactRecipient(recipient) }
+        guard recipient.identityId == contactIdentityId else {
+            throw Self.makeError(code: .dashPayPaymentUnavailable, description: "The payment recipient changed. Reopen the payment and try again.")
         }
         try Self.ensureInitialRestoreSyncCompleted()
         // spendAmount engages the biometric spending limit (C7.4) —
@@ -465,7 +463,7 @@ final class WalletSendService: NSObject {
         try await sendAuthorizer.authorizeSend(spendAmount: amount)
 
         let context: (wallet: ManagedPlatformWallet, ourId: Data)? = try await MainActor.run {
-            if let recipient { try Self.validateContactRecipient(recipient) }
+            try Self.validateContactRecipient(recipient)
             guard let wallet = SwiftDashSDKHost.shared.wallet,
                   let ourId = DWCurrentUserIdentityInfo.shared.identityId else {
                 return nil

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -635,11 +635,16 @@ struct ContactProfileSheet: View {
                 ? "arrow.up.circle.fill" : "arrow.down.circle.fill")
                 .foregroundColor(payment.direction == .sent ? .dash.blue : .dashGreen)
             VStack(alignment: .leading, spacing: 2) {
-                Text("\(payment.direction == .sent ? "-" : "+")\(Self.dashString(duffs: payment.amountDuffs)) DASH")
+                Text("\(payment.amountIsEstimate ? "≈ " : "")\(payment.direction == .sent ? "-" : "+")\(Self.dashString(duffs: payment.amountDuffs)) DASH")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.dash.primaryText)
                 if let fiat = payment.fiatString {
                     Text(fiat)
+                        .font(.system(size: 12))
+                        .foregroundColor(.dash.secondaryText)
+                }
+                if let status = payment.withdrawalStatus {
+                    Text(status)
                         .font(.system(size: 12))
                         .foregroundColor(.dash.secondaryText)
                 }
@@ -706,6 +711,55 @@ struct ContactProfileSheet: View {
 
 // MARK: - PayContactSheet
 
+/// Contact payments share the address-send source picker and withdrawal flow.
+/// Transparent payments keep the SDK's atomic DIP-15 Core send.
+struct PayContactSheet: View {
+    let contact: ContactItem
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel: SendViewModel
+    @State private var showsAmount = false
+    @State private var showsCorePayment = false
+
+    init(contact: ContactItem) {
+        self.contact = contact
+        let recipient = ContactPaymentRecipient(
+            identityId: contact.contactIdentityId,
+            displayName: contact.displayTitle,
+            walletId: SwiftDashSDKHost.shared.wallet?.walletId,
+            ownerIdentityId: DWCurrentUserIdentityInfo.shared.identityId,
+            network: WalletEnvironment.networkKind)
+        _viewModel = StateObject(wrappedValue: SendViewModel(contactRecipient: recipient))
+    }
+
+    var body: some View {
+        NavigationStack {
+            SendSourceScreen(
+                viewModel: viewModel,
+                onBack: { dismiss() },
+                onContinue: {
+                    if viewModel.source == .core {
+                        showsCorePayment = true
+                    } else {
+                        showsAmount = true
+                    }
+                })
+                .navigationDestination(isPresented: $showsAmount) {
+                    ExternalSendAmountScreen(
+                        viewModel: viewModel,
+                        onBack: { showsAmount = false },
+                        onContinueCore: { _, _ in },
+                        onSendCompleted: { dismiss() })
+                }
+                .sheet(isPresented: $showsCorePayment) {
+                    if let recipient = viewModel.contactRecipient {
+                        CoreContactPaymentSheet(contact: contact, recipient: recipient)
+                    }
+                }
+        }
+        .presentationDetents([.large])
+    }
+}
+
 /// Minimal pay-to-contact amount sheet (Row #18 phase 6). The Pay
 /// button is the explicit user confirmation; tapping it runs the
 /// spend-auth gate and then the single-shot SDK payment (which
@@ -714,8 +768,9 @@ struct ContactProfileSheet: View {
 /// SDK on top of the entered amount — the cap below uses
 /// `maxSendable` (spendable minus a conservative fee reserve) so the
 /// fee can't push the send over the balance.
-struct PayContactSheet: View {
+struct CoreContactPaymentSheet: View {
     let contact: ContactItem
+    let recipient: ContactPaymentRecipient
 
     @Environment(\.dismiss) private var dismiss
     @StateObject private var walletState = SwiftDashSDKWalletState.shared
@@ -881,7 +936,8 @@ struct PayContactSheet: View {
             do {
                 let (txid, feeDuffs) = try await WalletSendService.shared.sendToContact(
                     contactIdentityId: contact.contactIdentityId,
-                    amount: duffs)
+                    amount: duffs,
+                    recipient: recipient)
                 sentTxid = txid
                 sentFeeDuffs = feeDuffs
                 sentAmountDuffs = duffs

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
@@ -811,7 +811,7 @@ private struct DashPayFAQSheet: View {
             Item(
                 question: NSLocalizedString("How private is DashPay?", comment: "DashPay FAQ"),
                 answer: NSLocalizedString(
-                    "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform.",
+                    "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. You can pay from your Transparent, Platform, or Shielded balance. Platform and Shielded payments withdraw directly to your contact’s DashPay address. The recipient still receives a transparent-chain payment, so the payout is public. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform.",
                     comment: "DashPay FAQ")),
             Item(
                 question: NSLocalizedString("When will contact requests become private?", comment: "DashPay FAQ"),
@@ -841,7 +841,7 @@ private struct DashPayFAQSheet: View {
             Item(
                 question: NSLocalizedString("What's coming next?", comment: "DashPay FAQ"),
                 answer: NSLocalizedString(
-                    "Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon.",
+                    "Private contact requests (so who you connect with stays private), payments that remain Shielded for the recipient, and paying users who aren't in your contacts yet are all coming soon.",
                     comment: "DashPay FAQ")),
         ]
     }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/Shielded/ShieldedSubmittedUnconfirmedView.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/Shielded/ShieldedSubmittedUnconfirmedView.swift
@@ -8,6 +8,8 @@ import DashUIKit
 
 /// sync.
 struct ShieldedSubmittedUnconfirmedView: View {
+    var title: String? = nil
+    var message: String? = nil
     var onDone: () -> Void
 
     var body: some View {
@@ -19,12 +21,12 @@ struct ShieldedSubmittedUnconfirmedView: View {
                 .foregroundColor(.dash.blue)
                 .padding(.top, 24)
 
-            Text(NSLocalizedString("Submitted — confirming", comment: "InternalTransfer"))
+            Text(title ?? NSLocalizedString("Submitted — confirming", comment: "InternalTransfer"))
                 .font(.title3)
                 .fontWeight(.semibold)
                 .foregroundColor(.dash.primaryText)
 
-            Text(NSLocalizedString(
+            Text(message ?? NSLocalizedString(
                 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.",
                 comment: "InternalTransfer"))
                 .font(.callout)

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/Shielded/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/Shielded/ShieldedTransferCoordinator.swift
@@ -207,6 +207,8 @@ final class ShieldedTransferCoordinator: ObservableObject {
         case failed(String)
     }
 
+    @Published private(set) var contactWithdrawalStatusUnknown = false
+
     enum Source {
         case core
         case platform
@@ -840,7 +842,8 @@ final class ShieldedTransferCoordinator: ObservableObject {
     func performWithdraw(
         amountCredits: UInt64,
         sweepAll: Bool = false,
-        toCoreAddress destinationOverride: String? = nil
+        toCoreAddress destinationOverride: String? = nil,
+        contactRecipient: ContactPaymentRecipient? = nil
     ) async {
         guard beginTransfer() else { return }
         Self.logger.info("🛡️ SHIELD-TX :: withdraw route amount=\(amountCredits) credits external=\(destinationOverride != nil)")
@@ -875,9 +878,12 @@ final class ShieldedTransferCoordinator: ObservableObject {
         // the phase — same ordering as `resolveEnvironment()`. The reader is
         // main-actor-safe and we're already on @MainActor, so call it
         // directly (no GCD hop).
-        let coreAddress: String
+        var coreAddress: String
         let paysOwnWallet: Bool
-        if let destinationOverride, !destinationOverride.isEmpty {
+        if contactRecipient != nil {
+            coreAddress = ""
+            paysOwnWallet = false
+        } else if let destinationOverride, !destinationOverride.isEmpty {
             coreAddress = destinationOverride
             paysOwnWallet = false
         } else {
@@ -891,7 +897,12 @@ final class ShieldedTransferCoordinator: ObservableObject {
         }
 
         do {
-            try await authorize()
+            if let contactRecipient {
+                coreAddress = try await WalletSendService.shared.prepareContactWithdrawal(
+                    recipient: contactRecipient, amountDuffs: submittedAmount / 1000)
+            } else {
+                try await authorize()
+            }
         } catch {
             handleFailure(error)
             return
@@ -900,16 +911,21 @@ final class ShieldedTransferCoordinator: ObservableObject {
         phase = .proving
 
         do {
-            try await env.manager.shieldedWithdraw(
-                walletId: env.walletId,
-                // Per-operation Orchard spend authority (seedless shielded
-                // bind, platform #4125/#4126); the SDK holds the resolver
-                // alive across the FFI call via withExtendedLifetime.
-                resolver: MnemonicResolver(),
-                account: 0,
-                toCoreAddress: coreAddress,
-                amount: submittedAmount)
+            try await submitWithdrawal(
+                recipient: contactRecipient, address: coreAddress,
+                amountDuffs: submittedAmount / 1000, source: .shielded
+            ) {
+                try await env.manager.shieldedWithdraw(
+                    walletId: env.walletId,
+                    // Per-operation Orchard spend authority; the SDK keeps
+                    // the resolver alive across the FFI call.
+                    resolver: MnemonicResolver(),
+                    account: 0,
+                    toCoreAddress: coreAddress,
+                    amount: submittedAmount)
+            }
         } catch {
+            if handleContactWithdrawalUncertainty(error) { return }
             // shieldedSpendUnconfirmed means the spend may already be on
             // chain (non-retryable), so its payout can still arrive — tag
             // the destination so the incoming tx classifies as a shielded
@@ -1173,7 +1189,8 @@ final class ShieldedTransferCoordinator: ObservableObject {
         amountCredits: UInt64,
         fullBalance: Bool,
         feeHeadroomCredits: UInt64?,
-        toCoreAddress destinationOverride: String? = nil
+        toCoreAddress destinationOverride: String? = nil,
+        contactRecipient: ContactPaymentRecipient? = nil
     ) async {
         guard beginTransfer() else { return }
         Self.logger.info("🛡️ SHIELD-TX :: platform→core withdraw route full=\(fullBalance) amount=\(amountCredits) external=\(destinationOverride != nil)")
@@ -1181,8 +1198,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
         // Destination Core (BIP44, Base58Check) address — for the internal
         // transfer, the wallet's own receive address (same resolution as the
         // shielded withdraw route).
-        let coreAddress: String
-        if let destinationOverride, !destinationOverride.isEmpty {
+        var coreAddress: String
+        if contactRecipient != nil {
+            coreAddress = ""
+        } else if let destinationOverride, !destinationOverride.isEmpty {
             coreAddress = destinationOverride
         } else {
             guard let ownAddress = SwiftDashSDKReceiveAddressReader.receiveAddress(),
@@ -1194,7 +1213,12 @@ final class ShieldedTransferCoordinator: ObservableObject {
         }
 
         do {
-            try await authorize()
+            if let contactRecipient {
+                coreAddress = try await WalletSendService.shared.prepareContactWithdrawal(
+                    recipient: contactRecipient, amountDuffs: amountCredits / 1000)
+            } else {
+                try await authorize()
+            }
         } catch {
             handleFailure(error)
             return
@@ -1203,15 +1227,21 @@ final class ShieldedTransferCoordinator: ObservableObject {
         phase = .broadcasting
 
         do {
-            if fullBalance {
-                try await PlatformAddressSyncCoordinator.shared.withdrawAllToCore(address: coreAddress)
-            } else {
-                try await PlatformAddressSyncCoordinator.shared.withdrawToCore(
-                    amountCredits: amountCredits,
-                    address: coreAddress,
-                    feeHeadroomCredits: feeHeadroomCredits)
+            try await submitWithdrawal(
+                recipient: contactRecipient, address: coreAddress,
+                amountDuffs: amountCredits / 1000, amountIsEstimate: fullBalance, source: .platform
+            ) {
+                if fullBalance {
+                    try await PlatformAddressSyncCoordinator.shared.withdrawAllToCore(address: coreAddress)
+                } else {
+                    try await PlatformAddressSyncCoordinator.shared.withdrawToCore(
+                        amountCredits: amountCredits,
+                        address: coreAddress,
+                        feeHeadroomCredits: feeHeadroomCredits)
+                }
             }
         } catch {
+            if handleContactWithdrawalUncertainty(error) { return }
             handleFailure(CoordinatorError.transferFailed(error))
             return
         }
@@ -1322,6 +1352,61 @@ final class ShieldedTransferCoordinator: ObservableObject {
         schedulePlatformResync()
     }
 
+    private enum ContactWithdrawalError: Error {
+        case submissionUncertain
+    }
+
+    /// Persist intent before entering the opaque withdrawal call. A thrown
+    /// result after that boundary is conservatively non-retryable: Platform
+    /// may have accepted it even when the response never reached this device.
+    private func submitWithdrawal(
+        recipient: ContactPaymentRecipient?,
+        address: String,
+        amountDuffs: UInt64,
+        amountIsEstimate: Bool = false,
+        source: DashPayWithdrawalStore.Source,
+        operation: () async throws -> Void
+    ) async throws {
+        guard let recipient else {
+            try await operation()
+            return
+        }
+        try WalletSendService.validateContactRecipient(recipient)
+        guard let walletId = recipient.walletId,
+              let ownerId = recipient.ownerIdentityId else {
+            throw WalletSendService.makeError(code: .dashPayPaymentUnavailable, description: "Wallet or DashPay identity is not ready")
+        }
+        let entry = try DashPayWithdrawalStore.shared.begin(
+            scope: .init(networkRaw: recipient.network.rawValue, walletId: walletId, ownerIdentityId: ownerId),
+            contactIdentityId: recipient.identityId,
+            address: address,
+            amountDuffs: amountDuffs,
+            amountIsEstimate: amountIsEstimate,
+            source: source)
+        do {
+            try await operation()
+        } catch {
+            // The pre-submit .submitting record is durable even if this second
+            // write fails; on restart it is displayed as status unknown.
+            try? DashPayWithdrawalStore.shared.update(entry, status: .unconfirmed)
+            throw ContactWithdrawalError.submissionUncertain
+        }
+        // Never turn an accepted withdrawal into a retryable error because its
+        // local status update failed. The original intent remains recoverable.
+        try? DashPayWithdrawalStore.shared.update(entry, status: .submitted)
+    }
+
+    private func handleContactWithdrawalUncertainty(_ error: Error) -> Bool {
+        guard case ContactWithdrawalError.submissionUncertain = error else { return false }
+        contactWithdrawalStatusUnknown = true
+        phase = .submittedUnconfirmed
+        schedulePlatformResync()
+        if let manager = SwiftDashSDKHost.shared.manager {
+            scheduleShieldedResync(manager: manager)
+        }
+        return true
+    }
+
     /// Reset to `.idle` so the user can retry from a `.failed` state.
     /// Keeps no in-flight observers — the FFI calls themselves are
     /// uncancellable, so this just resets UI state.
@@ -1330,6 +1415,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
         lastAssetLockOutPoint = nil
         lastFailure = nil
         lastResumeReport = nil
+        contactWithdrawalStatusUnknown = false
         phase = .idle
     }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/Shielded/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/Shielded/ShieldedTransferCoordinator.swift
@@ -1374,7 +1374,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
         try WalletSendService.validateContactRecipient(recipient)
         guard let walletId = recipient.walletId,
               let ownerId = recipient.ownerIdentityId else {
-            throw WalletSendService.makeError(code: .dashPayPaymentUnavailable, description: "Wallet or DashPay identity is not ready")
+            throw CoordinatorError.noWallet
         }
         let entry = try DashPayWithdrawalStore.shared.begin(
             scope: .init(networkRaw: recipient.network.rawValue, walletId: walletId, ownerIdentityId: ownerId),

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -434,6 +434,7 @@ struct ExternalSendAmountScreen: View {
                     withdrawalFeeCredits: viewModel.withdrawalPreflight?.estimatedFee,
                     isFullPlatformWithdrawal: viewModel.isFullPlatformWithdrawal,
                     isFullShieldedSweep: viewModel.isFullShieldedSweep,
+                    contactRecipient: viewModel.contactRecipient,
                     onCancel: { showConfirm = false },
                     onCompleted: {
                         showConfirm = false
@@ -624,6 +625,36 @@ private struct SendAddressSummary: View {
     var onEdit: () -> Void
 
     var body: some View {
+        if let recipient = viewModel.contactRecipient {
+            HStack(spacing: 12) {
+                Image(systemName: "person.crop.circle.fill")
+                    .font(.title)
+                    .foregroundColor(.dashBlue)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(NSLocalizedString("To", comment: ""))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(recipient.displayName)
+                        .font(.headline)
+                        .foregroundColor(.primaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+                Text("DashPay")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.dashBlue)
+            }
+            .padding(14)
+            .background(Color.secondaryBackground)
+            .cornerRadius(12)
+            .padding(.horizontal, 20)
+        } else {
+            addressButton
+        }
+    }
+
+    private var addressButton: some View {
         Button(action: onEdit) {
             VStack(alignment: .leading, spacing: 6) {
                 HStack {
@@ -735,6 +766,7 @@ struct SendConfirmSheet: View {
     var withdrawalFeeCredits: UInt64? = nil
     var isFullPlatformWithdrawal: Bool = false
     var isFullShieldedSweep: Bool = false
+    var contactRecipient: ContactPaymentRecipient? = nil
     var onCancel: () -> Void
     var onCompleted: () -> Void
 
@@ -754,7 +786,12 @@ struct SendConfirmSheet: View {
             case .success:
                 successBody
             case .submittedUnconfirmed:
-                ShieldedSubmittedUnconfirmedView(onDone: onCompleted)
+                ShieldedSubmittedUnconfirmedView(
+                    title: coordinator.contactWithdrawalStatusUnknown
+                        ? NSLocalizedString("Payment status unknown", comment: "DashPay withdrawal") : nil,
+                    message: coordinator.contactWithdrawalStatusUnknown
+                        ? NSLocalizedString("We couldn't confirm whether your withdrawal was accepted. Check your contact's payment history and balances before sending again.", comment: "DashPay withdrawal") : nil,
+                    onDone: onCompleted)
             default:
                 detailsBody
             }
@@ -858,9 +895,28 @@ struct SendConfirmSheet: View {
     private var successBody: some View {
         VStack(spacing: 16) {
             PaymentSuccessHeader(
-                title: NSLocalizedString("Sent", comment: "Send confirm sheet"),
+                title: contactRecipient == nil
+                    ? NSLocalizedString("Sent", comment: "Send confirm sheet")
+                    : NSLocalizedString("Withdrawal submitted", comment: "DashPay withdrawal"),
                 amountDuffs: dashDuffs,
                 fiatText: fiatText)
+
+            if let contactRecipient {
+                Text(String.localizedStringWithFormat(
+                    NSLocalizedString("%@ will receive the payment after the network processes the withdrawal.", comment: "DashPay withdrawal submitted"),
+                    contactRecipient.displayName))
+                    .font(.callout)
+                    .foregroundColor(.dash.secondaryText)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                if isFullPlatformWithdrawal {
+                    Text(NSLocalizedString("The amount shown is an estimate. The final payout depends on the network fee.", comment: "DashPay maximum withdrawal"))
+                        .font(.caption)
+                        .foregroundColor(.dash.secondaryText)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                }
+            }
 
             Spacer(minLength: 12)
 
@@ -887,8 +943,8 @@ struct SendConfirmSheet: View {
                     .font(.system(size: 14))
                     .foregroundColor(.dash.secondaryText)
                 Spacer()
-                Text(truncateMiddle(destinationAddress))
-                    .font(.system(.footnote, design: .monospaced))
+                Text(contactRecipient?.displayName ?? truncateMiddle(destinationAddress))
+                    .font(.system(.footnote, design: contactRecipient == nil ? .monospaced : .default))
                     .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
             }
@@ -1119,12 +1175,14 @@ struct SendConfirmSheet: View {
                     amountCredits: creditsAmount,
                     fullBalance: isFullPlatformWithdrawal,
                     feeHeadroomCredits: withdrawalFeeCredits,
-                    toCoreAddress: destinationAddress)
+                    toCoreAddress: destinationAddress,
+                    contactRecipient: contactRecipient)
             case .shieldedToCore:
                 await coordinator.performWithdraw(
                     amountCredits: creditsAmount,
                     sweepAll: isFullShieldedSweep,
-                    toCoreAddress: destinationAddress)
+                    toCoreAddress: destinationAddress,
+                    contactRecipient: contactRecipient)
             case .shieldedToPlatform:
                 await coordinator.performUnshield(
                     amountCredits: creditsAmount,

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -158,6 +158,7 @@ final class SendViewModel: ObservableObject {
     /// that balance can't pay surfaces as a mismatch (`pinnedSourceMismatch`)
     /// rather than silently re-picking the source.
     let pinnedSource: ChainNetwork?
+    let contactRecipient: ContactPaymentRecipient?
 
     deinit {
         // The monitor holds observers strongly — without this the VM (and
@@ -165,8 +166,9 @@ final class SendViewModel: ObservableObject {
         SyncingActivityMonitor.shared.remove(observer: self)
     }
 
-    init(pinnedSource: ChainNetwork? = nil) {
+    init(pinnedSource: ChainNetwork? = nil, contactRecipient: ContactPaymentRecipient? = nil) {
         self.pinnedSource = pinnedSource
+        self.contactRecipient = contactRecipient
         if let pinnedSource {
             source = pinnedSource
         }
@@ -214,6 +216,13 @@ final class SendViewModel: ObservableObject {
                 self?.refreshShieldedSpendCeiling()
             }
             .store(in: &cancellables)
+        if contactRecipient != nil {
+            // DashPay currently receives at a DIP-15 Core address. Resolve the
+            // actual address only after confirmation, so browsing consumes none.
+            destination = .core
+            setSourceWithoutClaimingUserIntent(validSources.first { balanceDuffs(of: $0) > 0 } ?? .core)
+            routeDidChange()
+        }
     }
 
     /// Fee kind for the pool-spending routes; `nil` for every other route.
@@ -261,6 +270,7 @@ final class SendViewModel: ObservableObject {
     }
 
     private func destinationDidChange() {
+        guard contactRecipient == nil else { return }
         let sanitized = addressText.trimmingCharacters(in: .whitespacesAndNewlines)
         if sanitized != addressText {
             addressText = sanitized

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -480,7 +480,7 @@ final class SendViewModel: ObservableObject {
     /// Refreshes when a host becomes visible or the clipboard changes. Both
     /// the form registration and the host's permission must allow the read.
     func refreshClipboardSuggestion() {
-        guard !clipboardMonitors.isEmpty, isClipboardReadAllowed() else {
+        guard contactRecipient == nil, !clipboardMonitors.isEmpty, isClipboardReadAllowed() else {
             // Not allowed to read is also not allowed to keep offering what an
             // earlier read found: the pasteboard may have changed since, and
             // the chip must not outlive the screen that produced it.

--- a/DashWalletTests/DashPayWithdrawalStoreTests.swift
+++ b/DashWalletTests/DashPayWithdrawalStoreTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import XCTest
+@testable import dashwallet
+
+final class DashPayWithdrawalStoreTests: XCTestCase {
+    private var directory: URL!
+    private var store: DashPayWithdrawalStore!
+    private let contact = Data(repeating: 3, count: 32)
+    private let scope = DashPayWithdrawalStore.Scope(
+        networkRaw: 1, walletId: Data(repeating: 1, count: 32),
+        ownerIdentityId: Data(repeating: 2, count: 32))
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        store = DashPayWithdrawalStore(directory: directory)
+    }
+
+    override func tearDownWithError() throws {
+        if FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    private func begin(
+        scope: DashPayWithdrawalStore.Scope? = nil,
+        source: DashPayWithdrawalStore.Source = .shielded
+    ) throws -> DashPayWithdrawalStore.Entry {
+        try store.begin(
+            scope: scope ?? self.scope, contactIdentityId: contact,
+            address: "reserved-contact-address", amountDuffs: 10_000, source: source)
+    }
+
+    func testAttemptSurvivesRestartWithoutClaimingSubmissionSucceeded() throws {
+        let entry = try begin()
+        let reopened = DashPayWithdrawalStore(directory: directory)
+        let entries = try reopened.entries(scope: scope, contactIdentityId: contact)
+        XCTAssertEqual(entries, [entry])
+        XCTAssertEqual(entries.first?.status, .submitting)
+    }
+
+    func testSubmittedAndUnconfirmedOutcomesStayDistinctAfterRestart() throws {
+        let submitted = try begin(source: .platform)
+        let uncertain = try begin()
+        try store.update(submitted, status: .submitted)
+        try store.update(uncertain, status: .unconfirmed)
+        let reopened = DashPayWithdrawalStore(directory: directory)
+        let entries = try reopened.entries(scope: scope, contactIdentityId: contact)
+        XCTAssertEqual(entries.first(where: { $0.id == submitted.id })?.status, .submitted)
+        XCTAssertEqual(entries.first(where: { $0.id == uncertain.id })?.status, .unconfirmed)
+        XCTAssertEqual(entries.count, 2)
+    }
+
+    func testMaximumWithdrawalKeepsItsAmountEstimateAcrossRestart() throws {
+        let estimated = try store.begin(
+            scope: scope, contactIdentityId: contact, address: "reserved-contact-address",
+            amountDuffs: 10_000, amountIsEstimate: true, source: .platform)
+        try store.update(estimated, status: .submitted)
+        let reopened = DashPayWithdrawalStore(directory: directory)
+        let entry = try XCTUnwrap(reopened.entries(scope: scope, contactIdentityId: contact).first)
+        XCTAssertTrue(entry.amountIsEstimate)
+        XCTAssertEqual(entry.amountDuffs, 10_000)
+    }
+
+    func testNetworkWalletOwnerAndContactIsolation() throws {
+        let original = try begin()
+        let scopes = [
+            DashPayWithdrawalStore.Scope(networkRaw: 0, walletId: scope.walletId,
+                                         ownerIdentityId: scope.ownerIdentityId),
+            DashPayWithdrawalStore.Scope(networkRaw: 1, walletId: Data(repeating: 8, count: 32),
+                                         ownerIdentityId: scope.ownerIdentityId),
+            DashPayWithdrawalStore.Scope(networkRaw: 1, walletId: scope.walletId,
+                                         ownerIdentityId: Data(repeating: 9, count: 32)),
+        ]
+        for other in scopes {
+            XCTAssertTrue(try store.entries(scope: other, contactIdentityId: contact).isEmpty)
+            _ = try begin(scope: other)
+        }
+        XCTAssertTrue(try store.entries(scope: scope, contactIdentityId: Data(repeating: 4, count: 32)).isEmpty)
+        XCTAssertEqual(try store.entries(scope: scope, contactIdentityId: contact), [original])
+    }
+
+    func testFailedPersistencePreventsCreatingAnAttempt() throws {
+        // A file where the journal directory belongs makes atomic persistence
+        // fail, just like an inaccessible/full storage location at send time.
+        try Data([1]).write(to: directory)
+        XCTAssertThrowsError(try begin())
+    }
+
+    func testCorruptHistoryIsNotSilentlyOverwrittenByAnotherSend() throws {
+        _ = try begin()
+        let file = try XCTUnwrap(FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil).first)
+        let corrupt = Data("incomplete journal".utf8)
+        try corrupt.write(to: file)
+        XCTAssertThrowsError(try begin())
+        XCTAssertEqual(try Data(contentsOf: file), corrupt)
+    }
+
+    func testWalletRemovalPreservesOtherWalletAndFullWipeRemovesAll() throws {
+        _ = try begin()
+        let other = DashPayWithdrawalStore.Scope(
+            networkRaw: 1, walletId: Data(repeating: 8, count: 32),
+            ownerIdentityId: scope.ownerIdentityId)
+        let survivor = try begin(scope: other)
+        try store.clearForWallet(walletId: scope.walletId)
+        XCTAssertTrue(try store.entries(scope: scope, contactIdentityId: contact).isEmpty)
+        XCTAssertEqual(try store.entries(scope: other, contactIdentityId: contact), [survivor])
+        try store.resetForWipe()
+        XCTAssertTrue(try store.entries(scope: other, contactIdentityId: contact).isEmpty)
+    }
+
+    func testNeverSubmittedAttemptCanBeRemovedWithoutDroppingOtherRecords() throws {
+        let aborted = try begin()
+        let survivor = try begin()
+        try store.remove(aborted)
+        XCTAssertEqual(try store.entries(scope: scope, contactIdentityId: contact), [survivor])
+        XCTAssertThrowsError(try store.update(aborted, status: .submitted))
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

DashPay contact payments currently require Transparent Core funds. This lets the sender choose Transparent, Platform, or Shielded funds; Platform and Shielded payments withdraw directly to a fresh DashPay address belonging to the contact.

## What was done?

- Reuse the existing source picker, amount validation, withdrawal fee preflight, Max, and confirmation screens with a fixed DashPay recipient.
- Preserve the atomic SDK contact-send path for Transparent payments. Reserve a withdrawal address only after explicit confirmation and monetary authentication, with wallet, identity, and network checks around awaits.
- Persist withdrawal submission history before entering the SDK call. Unknown submission outcomes remain visible without a retry button; the UI distinguishes withdrawal submission from eventual receipt.
- Avoid clipboard reads for fixed contact recipients and update the funding explanation.

**Dependencies:** https://github.com/dashpay/platform/pull/4614 adds contact address reservation. Receiving these withdrawals also requires https://github.com/dashpay/rust-dashcore/pull/1004 to reach the SDK through a separate upstream dependency update. The reservation PR does not change rust-dashcore dependencies. Both are needed for the complete app flow. The app uses a local sibling SDK package; this PR does not change a release pin.

**Test-build provenance:** The verified recipient ran combined SDK build `2c17d85b855c667ff8a738d9d4b937db0740716e`, containing the reservation API and a test backport of the receipt fix. This is the exact build behind the receipt screenshots, not the current reservation PR’s dependency configuration.

## How Has This Been Tested?

- Local `dashpay` arm64 simulator builds for exact base and head; installation and launch checks on cloned iPhone 16 Pro / iOS 26.5 simulators.
- Eight withdrawal journal XCTest tests passed in a standalone Foundation package: persistence, scoped history, status updates, invalid input, corrupt/unwritable storage, and wipe behavior. The repository app test target has pre-existing breakage documented in `CLAUDE.md`.
- SDK prerequisite: 61 DashPay payment tests, 16 watch-only persistence tests, five AssetUnlock backport tests, locked FFI check, and final release simulator framework build passed. iOS app built successfully against SDK `2c17d85`; bundle signing, required resources, and absence of capture scaffolding verified. The earlier API change also passed clippy and Swift example compilation.
- Accessibility audit: no new blocking findings. Reviewed auth boundaries, address consumption, uncertain submission, network switching, and history isolation.
- Simulator UI smoke: source selection with zero Transparent balance, Shielded amount entry and withdrawal confirmation, and existing Transparent payment sheet.

**Live testnet validation:** Registered `Pasta-dashpay-send-0907` and `Pasta-dashpay-recv-0907`, established their contact relationship, and funded real balances. A 0.01 DASH Transparent contact payment was received and attributed to the sender. With zero Transparent balance, a 0.02 DASH Platform contact withdrawal was submitted; the user also submitted a 0.1 DASH Shielded contact withdrawal. Both payouts exist on Core at the reserved DIP-15 addresses.

**Live recipient verification passed:** Normal recipient relaunch with SDK `2c17d85` recovered both real AssetUnlock payouts. The 0.02 DASH Platform payment and user-submitted 0.1 DASH Shielded payment each have one persisted DashPay receipt and a confirmed, unspent, unlocked output for the exact transaction ID and amount. Both receipt screens show `Pasta-dashpay-send-0907`; the recipient transparent balance is 1.09999737 DASH. Wallet data was preserved, with no database edits or mock data. The device-local sender withdrawal journal still records submission and does not reconcile eventual delivery.

## Screenshots

Real registered testnet wallets and contact relationship, with no mock balances or capture patches. This replaces the withdrawn synthetic Alex evidence. Both views use matching real sender wallet state with zero Transparent funds.

| Before — exact base `9e5c39a` | After — full head `fc66451` |
|---|---|
| <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/81b8448e5498ab6555dabcef0a2e5855ac5175ac/dashwallet-ios/pr-1117/live/before-contact-zero-core.png" width="280" alt="Base: contact payment disabled with zero Core funds" /> | <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/81b8448e5498ab6555dabcef0a2e5855ac5175ac/dashwallet-ios/pr-1117/live/after-contact-sources.png" width="280" alt="Head: Platform and Shielded funds available for the real contact" /> |

[Full-resolution images, build provenance, transaction IDs and receipt verification](https://github.com/PastaPastaPasta/dash-ui-artifacts/blob/d1f33a977c8165c171832117c20c975c0904528a/dashwallet-ios/pr-1117/README.md). The original before/after and submission images use SDK0298; the receipt images below use SDK2c17 with the AssetUnlock routing fix.

| Platform payment received | Shielded payment received |
|---|---|
| <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/d1f33a977c8165c171832117c20c975c0904528a/dashwallet-ios/pr-1117/live/platform-received.png" width="280" alt="Real 0.02 DASH contact receipt" /> | <img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/d1f33a977c8165c171832117c20c975c0904528a/dashwallet-ios/pr-1117/live/shielded-received.png" width="280" alt="Real 0.1 DASH contact receipt" /> |

## Breaking Changes

Requires the SDK API added by platform#4614. No wallet storage migration.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
