### PR TITLE
fix(wallet): render the persisted balance offline and stop a Platform outage from wiping Core

### DIFF
--- a/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
+++ b/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
@@ -540,7 +540,13 @@ extension SyncingActivityMonitor {
                 guard let self else { return }
 
                 // `handlePathUpdate` posts on every path update, not only on a
-                // change, so act on the transition INTO `.online` alone.
+                // change, so act on `.offline → .online` alone. Specifically
+                // `previous == .offline`, not `previous != .online`: the field
+                // starts at `.unknown`, so the looser test made the first path
+                // report of every cold launch look like connectivity returning.
+                // That fired a refresh the launch path had already queued, and
+                // during onboarding it reached `refresh`'s unconditional
+                // `fullReset` before the `hasSDKWallet` guard could bail.
                 // `startIfReady` elides the rebuild when Core is already up and
                 // starts Platform on its own, so this brings a degraded
                 // Platform back without stopping a healthy Core sync.
@@ -553,7 +559,7 @@ extension SyncingActivityMonitor {
                 // on the lifecycle queue.
                 let previous = self.lastNetworkStatus
                 self.lastNetworkStatus = status
-                if status == .online, previous != .online {
+                if status == .online, previous == .offline {
                     SwiftDashSDKWalletRuntime.startIfReadyWhenLifecycleIdle()
                 }
 

--- a/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
+++ b/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
@@ -545,21 +545,16 @@ extension SyncingActivityMonitor {
                 // starts Platform on its own, so this brings a degraded
                 // Platform back without stopping a healthy Core sync.
                 //
-                // Held back while a wallet-lifecycle transition is in flight or
-                // parked on a failure card: that state machine owns recovery.
-                // A rebuild behind its back would heal the runtime with nothing
-                // calling `finish()`, leaving a blocking failure card over a
-                // working wallet — and its Retry would then hit
-                // `switchNetwork`'s ready-runtime no-op and do nothing, so the
-                // card could not be dismissed at all. The card's own Retry is
-                // the recovery path in that state.
+                // `startIfReadyWhenLifecycleIdle` rather than `startIfReady`:
+                // the recovery must be held back while a wallet-lifecycle
+                // transition owns the runtime, and that has to be true when the
+                // op RUNS, not when it is queued. Checking here would race — a
+                // network switch can begin and fail while the op waits its turn
+                // on the lifecycle queue.
                 let previous = self.lastNetworkStatus
                 self.lastNetworkStatus = status
-                let lifecycleIsIdle = MainActor.assumeIsolated {
-                    WalletLifecycleTransitionState.shared.phase == .idle
-                }
-                if status == .online, previous != .online, lifecycleIsIdle {
-                    SwiftDashSDKWalletRuntime.startIfReady()
+                if status == .online, previous != .online {
+                    SwiftDashSDKWalletRuntime.startIfReadyWhenLifecycleIdle()
                 }
 
                 let coord = SwiftDashSDKSPVCoordinator.shared

--- a/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
+++ b/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
@@ -195,6 +195,12 @@ class SyncingActivityMonitor: NSObject, NetworkReachabilityHandling {
     private let observers = NSHashTable<AnyObject>.weakObjects()
     private let observersLock = NSLock()
 
+    /// Reachability reported by the previous path update, so the runtime kick
+    /// in `initializeReachibility()` fires on the transition into `.online`
+    /// rather than on every repeated `.online` path report. Main-confined:
+    /// only the main-hopped closure in `initializeReachibility()` touches it.
+    private var lastNetworkStatus: NetworkStatus = .unknown
+
     override init() {
         super.init()
 
@@ -516,7 +522,7 @@ extension SyncingActivityMonitor {
 
 extension SyncingActivityMonitor {
     private func initializeReachibility() {
-        networkStatusDidChange = { [weak self] _ in
+        networkStatusDidChange = { [weak self] status in
             // Re-evaluate state when reachability flips by replaying the
             // current coordinator snapshot through `handleCoordinatorUpdate`.
             // The Combine pipeline doesn't fire on reachability changes, so
@@ -527,9 +533,23 @@ extension SyncingActivityMonitor {
             // from a background Task (e.g. `CoinJoinService.restoreMode`),
             // `handleCoordinatorUpdate` would otherwise run off-main and
             // `isSyncing`'s `UIApplication.isIdleTimerDisabled` didSet would
-            // trip the main-thread barrier.
+            // trip the main-thread barrier. `lastNetworkStatus` is read and
+            // written inside this closure for the same reason — it stays
+            // main-confined.
             let apply: () -> Void = {
                 guard let self else { return }
+
+                // `handlePathUpdate` posts on every path update, not only on a
+                // change, so act on the transition INTO `.online` alone.
+                // `startIfReady` elides the rebuild when Core is already up and
+                // starts Platform on its own, so this brings a degraded
+                // Platform back without stopping a healthy Core sync.
+                let previous = self.lastNetworkStatus
+                self.lastNetworkStatus = status
+                if status == .online, previous != .online {
+                    SwiftDashSDKWalletRuntime.startIfReady()
+                }
+
                 let coord = SwiftDashSDKSPVCoordinator.shared
                 self.handleCoordinatorUpdate(
                     sdkState: coord.state,

--- a/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
+++ b/DashWallet/Sources/Application/Syncyng Activity Monitor/SyncingActivityMonitor.swift
@@ -544,9 +544,21 @@ extension SyncingActivityMonitor {
                 // `startIfReady` elides the rebuild when Core is already up and
                 // starts Platform on its own, so this brings a degraded
                 // Platform back without stopping a healthy Core sync.
+                //
+                // Held back while a wallet-lifecycle transition is in flight or
+                // parked on a failure card: that state machine owns recovery.
+                // A rebuild behind its back would heal the runtime with nothing
+                // calling `finish()`, leaving a blocking failure card over a
+                // working wallet — and its Retry would then hit
+                // `switchNetwork`'s ready-runtime no-op and do nothing, so the
+                // card could not be dismissed at all. The card's own Retry is
+                // the recovery path in that state.
                 let previous = self.lastNetworkStatus
                 self.lastNetworkStatus = status
-                if status == .online, previous != .online {
+                let lifecycleIsIdle = MainActor.assumeIsolated {
+                    WalletLifecycleTransitionState.shared.phase == .idle
+                }
+                if status == .online, previous != .online, lifecycleIsIdle {
                     SwiftDashSDKWalletRuntime.startIfReady()
                 }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
@@ -649,6 +649,13 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
                 unconfirmed: core.unconfirmed,
                 immature: core.immature,
                 locked: core.locked)
+            if SwiftDashSDKWalletState.shared.balance == nil {
+                // First publish of the session. Logged because a "my wallet
+                // shows 0" report is answered by whether this line appeared
+                // and what it carried.
+                Self.logger.info(
+                    "🛰️ SPVCOORD :: first balance published total=\(mapped.total, privacy: .public) spv=\(self.isRunning, privacy: .public)")
+            }
             SwiftDashSDKWalletState.shared.applyBalance(mapped)
         } catch {
             Self.logger.warning(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
@@ -653,7 +653,7 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
     }
 
     /// Pull the latest core-wallet balance via FFI and republish through
-    /// `SwiftDashSDKWalletState.shared.applyBalance(_:)` so the home screen
+    /// `SwiftDashSDKWalletState.shared.applyBalanceOnMainActor(_:)` so the home screen
     /// `BalanceModel` and friends keep working off the same `@Published`
     /// surface they always did. The legacy callback that used to feed this
     /// publisher was removed in the SDK refactor, so the bridge replaces it.
@@ -692,7 +692,7 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
                 Self.logger.info(
                     "🛰️ SPVCOORD :: first balance published total=\(mapped.total, privacy: .private) spv=\(self.isRunning, privacy: .public)")
             }
-            SwiftDashSDKWalletState.shared.applyBalance(mapped)
+            SwiftDashSDKWalletState.shared.applyBalanceOnMainActor(mapped)
         } catch {
             Self.logger.warning(
                 "🛰️ SPVCOORD :: balance bridge fetch failed: \(String(describing: error), privacy: .public)")

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
@@ -152,6 +152,24 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
     @MainActor
     var isRunning: Bool { runningNetwork != nil }
 
+    /// Whether the SDK's SPV client is actually running — not merely whether
+    /// this coordinator believes it started one.
+    ///
+    /// `isRunning` is a Swift-side flag: set when this coordinator starts a
+    /// client, cleared when it stops one. A client that dies inside the SDK
+    /// never clears it, so `isRunning` alone reports a dead Core as healthy.
+    /// Readiness must ask the SDK, or every self-firing trigger — launch, the
+    /// sync strip's Retry, "Sync Now", the connectivity-return kick — elides
+    /// the very rebuild that would revive it, and the session has no way back.
+    /// `isAlreadyRunning(manager:network:)` asks the same question of a manager
+    /// the caller already holds; this one resolves the manager from the host.
+    @MainActor
+    var isSPVClientRunning: Bool {
+        guard runningNetwork != nil,
+              let manager = SwiftDashSDKHost.shared.manager else { return false }
+        return (try? manager.isSpvRunning()) == true
+    }
+
     // MARK: - Init
 
     private override init() {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
@@ -239,6 +239,15 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
             return .failure(StartError.walletImport(error))
         }
 
+        // Publish the persisted balance before any network work. `host.start`
+        // has run `loadFromPersistor` (HOST stage 4/4), which hydrates the core
+        // wallet's balance from SwiftData, and `coreWallet().balance()` reads
+        // that in memory — no SPV client, no peers, no I/O. Without this the
+        // home screen sits on 0.00 until the DashPay readiness pass and
+        // `startSpv` both complete, and stays there for the whole session when
+        // either fails: exactly the offline "wallet shows 0" report.
+        refreshBalanceBridge()
+
 #if DASHPAY
         // Startup order: identity → contacts → contact accounts → core sync.
         // A contact's DIP-15 addresses must be watched before the first filter

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
@@ -682,9 +682,12 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
                 immature: core.immature,
                 locked: core.locked)
             if SwiftDashSDKWalletState.shared.balance == nil {
-                // First publish of the session. Logged because a "my wallet
-                // shows 0" report is answered by whether this line appeared
-                // and what it carried.
+                // First publish after each bind — not once per session:
+                // `clearAllState()` restores `nil` on every network switch,
+                // wallet switch and wipe, so one support capture can carry
+                // several of these. Logged because a "my wallet shows 0"
+                // report is answered by whether this line appeared and what it
+                // carried.
                 // The amount is `.private`: this line ships in release builds
                 // and lands in diagnostic captures, where the aggregate balance
                 // would be readable without unlocking the wallet. The event and

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -721,7 +721,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
             boundNetwork: currentNetwork,
             target: network,
             hasBoundWallet: SwiftDashSDKHost.shared.wallet != nil,
-            isSPVRunning: spv.isRunning,
+            isSPVRunning: spv.isSPVClientRunning,
             subscriptionsDetached: spv.subscriptionsDetached)
     }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -212,6 +212,30 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         dispatchOnPipeline { shared.enqueueRefresh(trigger: .startIfReady) }
     }
 
+    /// Connectivity-return recovery, used by `SyncingActivityMonitor` when the
+    /// path flips back to online.
+    ///
+    /// Separate from `startIfReady()` because the lifecycle phase has to hold
+    /// until the op actually runs, not merely when it is queued: this hops
+    /// through `entryQueue` and then waits its turn on the serial lifecycle
+    /// queue, and a network switch can begin AND fail in that window. Rebuilding
+    /// then would heal the runtime with nothing calling `finish()`, leaving a
+    /// blocking failure card over a working wallet. The phase is therefore
+    /// re-read on the lifecycle queue, where an interactive transition either
+    /// owns the runtime or does not.
+    nonisolated static func startIfReadyWhenLifecycleIdle() {
+        dispatchOnPipeline {
+            shared.enqueue {
+                guard WalletLifecycleTransitionState.shared.phase == .idle else {
+                    Self.logger.info(
+                        "🧭 RUNTIME :: connectivity-return kick skipped — a lifecycle transition owns the runtime")
+                    return
+                }
+                await shared.refresh(trigger: .startIfReady)
+            }
+        }
+    }
+
     @objc(stop)
     nonisolated static func stop() {
         dispatchOnPipeline { shared.enqueueFullReset(lastError: nil, forWipe: false) }
@@ -310,6 +334,18 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         // lifecycle operation — network switch, wallet switch, or removal —
         // is in flight, replacing the old network-only `.switching` guard.
         if WalletEnvironment.networkKind == kind, isRuntimeReady(for: targetNetwork) {
+            // A failure card toward this very target is now obsolete: the
+            // runtime is bound and running on the network the user asked for,
+            // so the switch they retried has effectively completed. Without
+            // this, Retry reaches the no-op, returns without touching the
+            // transition state, and the blocking card can never be dismissed —
+            // whatever healed the runtime in the meantime.
+            if case .failedNetworkSwitch(_, let failedTarget, _) =
+                WalletLifecycleTransitionState.shared.phase, failedTarget == kind {
+                Self.logger.info("🧭 RUNTIME :: switchNetwork — runtime already ready on the failed target; finishing the transition")
+                WalletLifecycleTransitionState.shared.finish()
+                return
+            }
             Self.logger.info("🧭 RUNTIME :: switchNetwork — already on \(String(describing: kind), privacy: .public) with a ready runtime; no-op")
             return
         }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -57,6 +57,45 @@ final class SerialAsyncLifecycleQueue {
     }
 }
 
+/// Which readiness each refresh trigger is allowed to elide a rebuild on.
+///
+/// Separated from the runtime so the routing can be exercised without a live
+/// host, SPV client or BLAST — same shape as `PlatformSyncRearmPolicy`.
+struct RuntimeRefreshPolicy {
+    /// Whether `trigger` may skip the teardown-and-rebuild.
+    ///
+    /// `.startIfReady` and `.platformSyncRearm` elide on Core readiness alone:
+    /// a launch/foreground kick, the sync strip's Retry and "Sync Now" must
+    /// never tear down a running Core sync because Platform is down. The
+    /// rebuild's `fullReset` stops SPV, clears the published balance and nils
+    /// the host's `modelContainer`, which is what the home transaction list
+    /// reads — so eliding on Core is what keeps an offline wallet legible.
+    /// `refresh` starts Platform separately in the elided branch, so a degraded
+    /// Platform still recovers.
+    ///
+    /// `.networkDidChange` requires full readiness because its callers run
+    /// `prepareForNetworkSwitch()` first, detaching the SPV progress/balance
+    /// subscriptions that only a rebuild re-attaches.
+    ///
+    /// A wallet change never elides: the registry was repointed to a different
+    /// wallet on the same network, so a network-equality check would wrongly
+    /// elide the rebind.
+    static func shouldSkipRebuild(
+        trigger: SwiftDashSDKWalletRuntime.RefreshTrigger,
+        isCoreReady: Bool,
+        isFullyReady: Bool
+    ) -> Bool {
+        switch trigger {
+        case .walletMaterialChanged, .walletDidChange:
+            return false
+        case .startIfReady, .platformSyncRearm:
+            return isCoreReady
+        case .networkDidChange:
+            return isFullyReady
+        }
+    }
+}
+
 @objc(DWSwiftDashSDKWalletRuntime)
 @MainActor
 final class SwiftDashSDKWalletRuntime: NSObject {
@@ -87,7 +126,38 @@ final class SwiftDashSDKWalletRuntime: NSObject {
 
     private var observerToken: NSObjectProtocol?
     private let lifecycleQueue = SerialAsyncLifecycleQueue()
+
+    /// The network Core is bound to, set once Core SPV has started and BEFORE
+    /// Platform/BLAST is asked to start. It means "Core is bound", not
+    /// "everything is up" — read it through `isCoreRuntimeReady(for:)` or
+    /// `isRuntimeReady(for:)`, never raw.
     private var currentNetwork: Network?
+
+    /// What the last Platform/BLAST start produced for the network Core is
+    /// bound to. `.degraded` is the runtime's stable "Core running, Platform
+    /// not running" state: refresh elision reads Core readiness only, so the
+    /// runtime stays in it instead of rebuilding a healthy Core, and the retry
+    /// paths call `startPlatform(for:)` again. Reset by `fullReset`.
+    ///
+    /// Carries no error text: the concrete BLAST failure lives in
+    /// `PlatformAddressSyncCoordinator.lastError`, which is what the Sync Info
+    /// screen and the switch-failure detail already read.
+    private enum PlatformPhase: Equatable {
+        case notStarted
+        case running(Network)
+        case degraded(Network)
+
+        /// Compact form for the network-switch telemetry line.
+        var logLabel: String {
+            switch self {
+            case .notStarted: return "not-started"
+            case .running(let network): return "running(\(network.rawValue))"
+            case .degraded(let network): return "degraded(\(network.rawValue))"
+            }
+        }
+    }
+
+    private var platformPhase: PlatformPhase = .notStarted
 
     private override init() {
         super.init()
@@ -244,9 +314,16 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         }.value
 
         let ms = Int((CFAbsoluteTimeGetCurrent() - started) * 1000)
-        if isRuntimeReady(for: targetNetwork) {
+        // The switch's verdict is Core: the destination host, wallet, balance
+        // and transaction list are what the user switched for. A Platform
+        // outage must not raise a blocking, Retry-only failure card over a
+        // runtime that works — a degraded Platform is reported by the Sync Info
+        // screen (`PlatformAddressSyncCoordinator.lastError`), not here. The
+        // no-op check above stays on full readiness, so an explicit tap on the
+        // already-selected network still self-heals through a full rebuild.
+        if isCoreRuntimeReady(for: targetNetwork) {
             WalletLifecycleTransitionState.shared.finish()
-            DWLogger.log("🔀 NETSWITCH [\(transitionID)] ready in \(ms)ms")
+            DWLogger.log("🔀 NETSWITCH [\(transitionID)] ready in \(ms)ms platform=\(platformPhase.logLabel)")
         } else {
             let detail = SwiftDashSDKSPVCoordinator.shared.lastError
                 ?? PlatformAddressSyncCoordinator.shared.lastError
@@ -431,6 +508,12 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         case .success(let network):
             if shouldSkipRefresh(for: network, trigger: trigger) {
                 Self.logger.info("🧭 RUNTIME :: refresh is already satisfied for \(network.rawValue, privacy: .public)")
+                // Core is up, so the rebuild is elided — but Platform may be
+                // down from a degraded start or a stop issued out of band.
+                // Bring it up here so a launch/foreground kick, the sync
+                // strip's Retry and "Sync Now" all recover Platform without
+                // taking a working Core sync down with it.
+                await startPlatformIfNotRunning(for: network)
                 return
             }
 
@@ -455,25 +538,64 @@ final class SwiftDashSDKWalletRuntime: NSObject {
                 return
             }
 
+            // Core and Platform start in separate `do/catch` blocks on
+            // purpose. A shared one made a Platform failure run `fullReset`,
+            // which stops Core SPV, clears the published balance and nils the
+            // host's `modelContainer` — the SwiftData handle the home
+            // transaction list reads. Offline that turned a reachable Platform
+            // outage into an empty wallet with no retry.
             do {
                 try await SwiftDashSDKSPVCoordinator.shared.startAsync(for: network)
-                try await PlatformAddressSyncCoordinator.shared.startAsync(for: network)
-                currentNetwork = network
-                if trigger == .walletMaterialChanged {
-                    publishActiveWalletDidChange(reason: "wallet-started")
-                } else if trigger == .networkDidChange {
-                    // The same walletId can exist on both networks, but its
-                    // SwiftData container and identity set are network-scoped.
-                    // Publish only after the destination runtime is fully
-                    // bound so identity/banner consumers re-read destination
-                    // state instead of the cleared transition mirror.
-                    publishActiveWalletDidChange(reason: "network-changed")
-                }
             } catch {
-                Self.logger.error("🧭 RUNTIME :: start failed: \(String(describing: error), privacy: .public)")
+                Self.logger.error("🧭 RUNTIME :: Core start failed: \(String(describing: error), privacy: .public)")
                 await fullReset(lastError: error.localizedDescription, forWipe: false)
+                return
             }
+
+            // Core owns `currentNetwork`, and it is recorded before Platform is
+            // asked to start: a Platform failure must leave a runtime that
+            // still reports itself bound to `network` (`isCoreRuntimeReady`),
+            // or every later `startIfReady` would rebuild a healthy Core.
+            currentNetwork = network
+
+            // Published before the Platform start for the same reason: every
+            // consumer keys off the host's bound wallet and `modelContainer`,
+            // both established by Core. The same walletId can exist on both
+            // networks, but its SwiftData container and identity set are
+            // network-scoped, so identity/banner consumers re-read destination
+            // state instead of the cleared transition mirror.
+            if trigger == .walletMaterialChanged {
+                publishActiveWalletDidChange(reason: "wallet-started")
+            } else if trigger == .networkDidChange {
+                publishActiveWalletDidChange(reason: "network-changed")
+            }
+
+            await startPlatform(for: network)
         }
+    }
+
+    /// Start Platform/BLAST for `network` and record the verdict in
+    /// `platformPhase`. A Platform failure is contained here: the host, Core
+    /// SPV, the published balance and the SwiftData handles the home
+    /// transaction list reads all stay up.
+    private func startPlatform(for network: Network) async {
+        do {
+            try await PlatformAddressSyncCoordinator.shared.startAsync(for: network)
+            platformPhase = .running(network)
+        } catch {
+            platformPhase = .degraded(network)
+            Self.logger.error(
+                "🧭 RUNTIME :: Platform start failed; Core stays up: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Start Platform/BLAST unless it already runs on `network`. The retry
+    /// entry point for a runtime sitting in `.degraded` and for a BLAST stopped
+    /// out of band (the Sync Info screen) — neither may rebuild Core.
+    private func startPlatformIfNotRunning(for network: Network) async {
+        let blast = PlatformAddressSyncCoordinator.shared
+        guard !(blast.isRunning && blast.runningNetwork == network) else { return }
+        await startPlatform(for: network)
     }
 
     /// Deterministic teardown: BLAST → SPV → wallet state → host.
@@ -494,6 +616,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         // so switch telemetry survives into diagnostic exports.
         await SwiftDashSDKHost.shared.stopAsync()
         currentNetwork = nil
+        platformPhase = .notStarted
         if forWipe {
             DWCurrentUserIdentityInfo.shared.resetForWalletRemoval()
             publishActiveWalletDidChange(reason: "wallet-removed")
@@ -526,23 +649,29 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     }
 
     private func shouldSkipRefresh(for network: Network, trigger: RefreshTrigger) -> Bool {
-        switch trigger {
-        case .walletMaterialChanged, .walletDidChange:
-            // A runtime wallet switch always rebuilds — the active-wallet
-            // registry was repointed to a different wallet on the SAME
-            // network, so `currentNetwork == network` would otherwise wrongly
-            // elide the rebind.
-            return false
-        case .startIfReady, .networkDidChange, .platformSyncRearm:
-            return isRuntimeReady(for: network)
-        }
+        RuntimeRefreshPolicy.shouldSkipRebuild(
+            trigger: trigger,
+            isCoreReady: isCoreRuntimeReady(for: network),
+            isFullyReady: isRuntimeReady(for: network))
     }
 
-    /// Whether the runtime is fully bound and running for `network`: host has
-    /// a bound wallet, SPV runs, and BLAST runs on that same network. The one
-    /// readiness predicate shared by refresh elision (`shouldSkipRefresh`)
-    /// and `switchNetwork(to:)`'s no-op / ready checks — a persisted network
-    /// key alone never counts as "ready".
+    /// Whether Core is bound and running for `network`: the host has a bound
+    /// wallet and Core SPV runs on the network the runtime last brought up.
+    ///
+    /// This is what decides whether a refresh may be elided. Platform/BLAST is
+    /// deliberately excluded: a Platform outage must not make a healthy Core
+    /// runtime look rebuildable, because the rebuild's `fullReset` stops SPV,
+    /// clears the published balance and nils the host's `modelContainer` —
+    /// which is what the home transaction list reads.
+    func isCoreRuntimeReady(for network: Network) -> Bool {
+        currentNetwork == network
+            && SwiftDashSDKHost.shared.wallet != nil
+            && SwiftDashSDKSPVCoordinator.shared.isRunning
+    }
+
+    /// Core ready AND BLAST running on that same network — a persisted network
+    /// key alone never counts as "ready". Used by `switchNetwork(to:)`'s no-op
+    /// check and by the `.networkDidChange` refresh elision.
     ///
     /// Consulting live coordinator state matters beyond switches too:
     /// external callers (PlatformSyncStatusScreen, StorageExplorerUnavailableView,
@@ -551,11 +680,9 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     /// stop would leave the user without the sync they triggered.
     func isRuntimeReady(for network: Network) -> Bool {
         let blast = PlatformAddressSyncCoordinator.shared
-        return currentNetwork == network
-            && SwiftDashSDKHost.shared.wallet != nil
+        return isCoreRuntimeReady(for: network)
             && blast.isRunning
             && blast.runningNetwork == network
-            && SwiftDashSDKSPVCoordinator.shared.isRunning
     }
 
     /// Internal (was private): reused by CrowdNode's TransactionObserver row
@@ -634,7 +761,10 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         Self.logger.info("🧭 RUNTIME :: registered DWCurrentNetworkDidChangeNotification observer")
     }
 
-    private enum RefreshTrigger: String {
+    /// Internal (was private) so `RuntimeRefreshPolicy` can be exercised
+    /// directly from the lifecycle tests — the routing it encodes is the part
+    /// of this file most likely to regress.
+    enum RefreshTrigger: String {
         case startIfReady
         case networkDidChange
         case walletMaterialChanged

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -96,6 +96,44 @@ struct RuntimeRefreshPolicy {
     }
 }
 
+/// How the runtime decides that Core, and then the whole runtime, is ready for
+/// a network. Separated from the singletons it reads so the composition itself
+/// is testable — the terms below are the fix for a real defect, and a policy
+/// that only ever sees pre-computed booleans cannot guard them.
+struct RuntimeReadinessPolicy {
+    /// Core is bound, running, and actually feeding the UI.
+    ///
+    /// `subscriptionsDetached` is a term because `prepareForNetworkSwitch()`
+    /// cancels the progress/peer/balance publishers and clears wallet state
+    /// while leaving Core's running flag set. Without it, a refresh queued
+    /// between that preparation and the switch's own rebuild elides the
+    /// rebuild, the `.networkDidChange` behind it then sees full readiness and
+    /// elides too, and the runtime is stranded with no subscriptions and a
+    /// cleared balance that no later refresh repairs.
+    static func isCoreReady(
+        boundNetwork: Network?,
+        target: Network,
+        hasBoundWallet: Bool,
+        isSPVRunning: Bool,
+        subscriptionsDetached: Bool
+    ) -> Bool {
+        boundNetwork == target
+            && hasBoundWallet
+            && isSPVRunning
+            && !subscriptionsDetached
+    }
+
+    /// Core ready AND Platform/BLAST running on that same network.
+    static func isFullyReady(
+        isCoreReady: Bool,
+        isBlastRunning: Bool,
+        blastNetwork: Network?,
+        target: Network
+    ) -> Bool {
+        isCoreReady && isBlastRunning && blastNetwork == target
+    }
+}
+
 @objc(DWSwiftDashSDKWalletRuntime)
 @MainActor
 final class SwiftDashSDKWalletRuntime: NSObject {
@@ -679,10 +717,12 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     /// and a cleared balance that no later refresh repairs.
     func isCoreRuntimeReady(for network: Network) -> Bool {
         let spv = SwiftDashSDKSPVCoordinator.shared
-        return currentNetwork == network
-            && SwiftDashSDKHost.shared.wallet != nil
-            && spv.isRunning
-            && !spv.subscriptionsDetached
+        return RuntimeReadinessPolicy.isCoreReady(
+            boundNetwork: currentNetwork,
+            target: network,
+            hasBoundWallet: SwiftDashSDKHost.shared.wallet != nil,
+            isSPVRunning: spv.isRunning,
+            subscriptionsDetached: spv.subscriptionsDetached)
     }
 
     /// Core ready AND BLAST running on that same network — a persisted network
@@ -696,9 +736,11 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     /// stop would leave the user without the sync they triggered.
     func isRuntimeReady(for network: Network) -> Bool {
         let blast = PlatformAddressSyncCoordinator.shared
-        return isCoreRuntimeReady(for: network)
-            && blast.isRunning
-            && blast.runningNetwork == network
+        return RuntimeReadinessPolicy.isFullyReady(
+            isCoreReady: isCoreRuntimeReady(for: network),
+            isBlastRunning: blast.isRunning,
+            blastNetwork: blast.runningNetwork,
+            target: network)
     }
 
     /// Internal (was private): reused by CrowdNode's TransactionObserver row

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
@@ -366,13 +366,16 @@ public final class SwiftDashSDKWalletState: NSObject, ObservableObject {
         }
     }
 
-    // MARK: - Clear (called from wallet wiper)
+    // MARK: - Clear
 
-    /// Called from `SwiftDashSDKWalletWiper.performWipe` after the wallet
-    /// state has been deleted from keychain-backed storage. Without this, the
-    /// published value would keep showing the previous wallet's balance
-    /// across a wipe-then-recover or wipe-then-create flow until the new
-    /// wallet's first balance event arrives.
+    /// Drop the published balance back to "not known yet".
+    ///
+    /// Called by `SwiftDashSDKSPVCoordinator` when Core SPV stops and when the
+    /// balance bridge finds no wallet bound to the host — NOT on the wipe path,
+    /// which resets per-wallet options through
+    /// `DWGlobalOptions.restoreToDefaults()` in `SwiftDashSDKWalletWiper`.
+    /// Without this the published value would keep showing the previous
+    /// wallet's balance until the next balance event arrives.
     @objc public func clearBalance() {
         DispatchQueue.main.async { [weak self] in
             Self.logger.info("💰 WALLET :: clearing balance")

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
@@ -202,25 +202,40 @@ public final class SwiftDashSDKWalletState: NSObject, ObservableObject {
     /// on every relevant block / mempool tx / InstantSend confirmation.
     /// Marshals to the main queue so SwiftUI/Combine consumers receive
     /// updates on the right thread.
+    /// A caller already on the main queue publishes synchronously; everyone
+    /// else marshals. The synchronous path matters for the startup publication
+    /// in `SwiftDashSDKSPVCoordinator.performStart`: that runs on the
+    /// MainActor and is followed by main-actor startup work that can occupy
+    /// the actor for seconds before reaching any suspension point — the
+    /// DashPay readiness budget lookup, and on the non-DASHPAY build the
+    /// CoinJoin recovery-gap widening, which pre-generates addresses.
+    /// Deferring the assignment behind that would leave the home screen on
+    /// 0.00 for exactly that long, which is the symptom this publication
+    /// exists to remove. Delivery is never later than the previous
+    /// always-async behaviour.
     public func applyBalance(_ snapshot: WalletBalance) {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated { publishBalance(snapshot) }
+            return
+        }
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            self.balance = snapshot
-            // Both refresh methods are @MainActor (they read
-            // MainActor-isolated `SwiftDashSDKHost.shared` state).
-            // We're already on the main queue here, so
-            // `assumeIsolated` is the synchronous, zero-hop way to
-            // satisfy the isolation requirement. The credits refresh
-            // only schedules a throttled background tally, so this
-            // stays cheap even during sync-burst balance events.
-            MainActor.assumeIsolated {
-                self.refreshPlatformPaymentCredits()
-                self.refreshCoinJoinBalance()
-            }
-            NotificationCenter.default.post(
-                name: SwiftDashSDKWalletState.balanceDidChangeNotification,
-                object: nil)
+            MainActor.assumeIsolated { self.publishBalance(snapshot) }
         }
+    }
+
+    /// The single publication path, main-actor bound. Both refresh methods
+    /// read MainActor-isolated `SwiftDashSDKHost.shared` state; the credits
+    /// refresh only schedules a throttled background tally, so this stays
+    /// cheap even during sync-burst balance events.
+    @MainActor
+    private func publishBalance(_ snapshot: WalletBalance) {
+        balance = snapshot
+        refreshPlatformPaymentCredits()
+        refreshCoinJoinBalance()
+        NotificationCenter.default.post(
+            name: SwiftDashSDKWalletState.balanceDidChangeNotification,
+            object: nil)
     }
 
     /// Non-nil while a Platform-credit tally (plus its 1 s cool-down)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
@@ -107,9 +107,12 @@ public final class SwiftDashSDKWalletState: NSObject, ObservableObject {
         subsystem: "org.dashfoundation.dash",
         category: "swift-sdk-migration.wallet-state")
 
-    /// Latest wallet balance from SwiftDashSDK. `nil` until either
-    /// `seedInitialBalance(walletManager:walletId:)` succeeds or the
-    /// first `applyBalance(_:)` call arrives. Updated on the main queue.
+    /// Latest wallet balance from SwiftDashSDK. `nil` until the first
+    /// `applyBalance(_:)` call arrives, which `SwiftDashSDKSPVCoordinator`'s
+    /// balance bridge makes as soon as the host has bound the wallet — before
+    /// SPV starts, so the persisted balance renders without a network. `nil`
+    /// means "not known yet" and must never be read as an empty wallet.
+    /// Updated on the main queue.
     @Published public private(set) var balance: WalletBalance? = nil
 
     /// Fee-aware "Max" / all-funds amount for a core send: spendable minus a
@@ -345,37 +348,6 @@ public final class SwiftDashSDKWalletState: NSObject, ObservableObject {
         if coinJoinBalanceDuffs != duffs {
             coinJoinBalanceDuffs = duffs
             Self.logger.info("💰 WALLET :: coinJoinBalanceDuffs=\(duffs, privacy: .public)")
-        }
-    }
-
-    // MARK: - Seed (called from coordinator after wallet import)
-
-    /// Called from `SwiftDashSDKSPVCoordinator.performStart` after
-    /// `walletManager.importWallet` succeeds. The FFI does not emit an
-    /// `onBalanceUpdated` event on `startSync` for a wallet with zero
-    /// new activity, so without this seed the home screen would sit on
-    /// `nil` until the first relevant tx (potentially hours into a
-    /// fresh sync).
-    ///
-    /// `WalletManager.getWalletBalance` returns only `(confirmed, unconfirmed)`
-    /// — the `immature`/`locked` fields aren't exposed by this API surface.
-    /// They default to 0 in the seed and are populated properly by the
-    /// first live `applyBalance(_:)` call. Mining wallets are unaffected
-    /// (we don't support them).
-    ///
-    /// Non-fatal — if the FFI call fails, live updates eventually catch up.
-    public func seedInitialBalance(walletManager: WalletManager, walletId: Data) {
-        do {
-            let tuple = try walletManager.getWalletBalance(walletId: walletId)
-            let initial = WalletBalance(
-                confirmed: tuple.confirmed,
-                unconfirmed: tuple.unconfirmed,
-                immature: 0,
-                locked: 0)
-            Self.logger.info("💰 WALLET :: initial balance seed: confirmed=\(initial.confirmed, privacy: .public) unconfirmed=\(initial.unconfirmed, privacy: .public) total=\(initial.total, privacy: .public)")
-            applyBalance(initial)
-        } catch {
-            Self.logger.warning("💰 WALLET :: initial balance seed failed (non-fatal): \(String(describing: error), privacy: .public)")
         }
     }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
@@ -108,11 +108,11 @@ public final class SwiftDashSDKWalletState: NSObject, ObservableObject {
         category: "swift-sdk-migration.wallet-state")
 
     /// Latest wallet balance from SwiftDashSDK. `nil` until the first
-    /// `applyBalance(_:)` call arrives, which `SwiftDashSDKSPVCoordinator`'s
-    /// balance bridge makes as soon as the host has bound the wallet — before
-    /// SPV starts, so the persisted balance renders without a network. `nil`
-    /// means "not known yet" and must never be read as an empty wallet.
-    /// Updated on the main queue.
+    /// publication arrives, which `SwiftDashSDKSPVCoordinator`'s balance bridge
+    /// makes through `applyBalanceOnMainActor(_:)` as soon as the host has
+    /// bound the wallet — before SPV starts, so the persisted balance renders
+    /// without a network. `nil` means "not known yet" and must never be read as
+    /// an empty wallet. Updated on the main actor.
     @Published public private(set) var balance: WalletBalance? = nil
 
     /// Fee-aware "Max" / all-funds amount for a core send: spendable minus a
@@ -202,26 +202,31 @@ public final class SwiftDashSDKWalletState: NSObject, ObservableObject {
     /// on every relevant block / mempool tx / InstantSend confirmation.
     /// Marshals to the main queue so SwiftUI/Combine consumers receive
     /// updates on the right thread.
-    /// A caller already on the main queue publishes synchronously; everyone
-    /// else marshals. The synchronous path matters for the startup publication
-    /// in `SwiftDashSDKSPVCoordinator.performStart`: that runs on the
-    /// MainActor and is followed by main-actor startup work that can occupy
-    /// the actor for seconds before reaching any suspension point — the
-    /// DashPay readiness budget lookup, and on the non-DASHPAY build the
-    /// CoinJoin recovery-gap widening, which pre-generates addresses.
-    /// Deferring the assignment behind that would leave the home screen on
-    /// 0.00 for exactly that long, which is the symptom this publication
-    /// exists to remove. Delivery is never later than the previous
-    /// always-async behaviour.
+    /// MainActor-isolated callers use `applyBalanceOnMainActor(_:)` instead,
+    /// which publishes synchronously.
     public func applyBalance(_ snapshot: WalletBalance) {
-        if Thread.isMainThread {
-            MainActor.assumeIsolated { publishBalance(snapshot) }
-            return
-        }
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             MainActor.assumeIsolated { self.publishBalance(snapshot) }
         }
+    }
+
+    /// Publish from a caller the compiler already knows is MainActor-isolated:
+    /// `SwiftDashSDKSPVCoordinator`'s balance bridge. Isolation is checked
+    /// statically here, so no `Thread.isMainThread` proxy stands in for it and
+    /// nothing can trap on a main-thread callback that is not running on the
+    /// MainActor's executor.
+    ///
+    /// Synchronous on purpose. The startup publication is followed by
+    /// main-actor work that can hold the actor for seconds before reaching any
+    /// suspension point — the DashPay readiness budget lookup, and on the
+    /// non-DASHPAY build the CoinJoin recovery-gap widening, which
+    /// pre-generates addresses. Marshalling would park the assignment behind
+    /// that and leave the home screen on 0.00 for exactly as long, which is the
+    /// symptom this publication exists to remove.
+    @MainActor
+    public func applyBalanceOnMainActor(_ snapshot: WalletBalance) {
+        publishBalance(snapshot)
     }
 
     /// The single publication path, main-actor bound. Both refresh methods

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
@@ -65,10 +65,11 @@ struct UnconfirmedTransactionRemover {
         /// Runtime reloaded, but the rescan did not arm (no chain tip to
         /// anchor on, or the arm threw). Rescan Filters still works.
         case rescanUnavailable
-        /// The reload took the runtime down and it did not come back: a BLAST
-        /// start failure makes `refresh` fall back to `fullReset`, which stops
-        /// the host and Core SPV too. Rescan Filters refuses while SPV is
-        /// stopped, so this case must NOT point the user at it.
+        /// The reload took Core down and it did not come back — a Core start
+        /// failure, which `refresh` still answers with `fullReset`. A Platform
+        /// outage alone no longer lands here: it is contained and leaves SPV
+        /// running. Rescan Filters refuses while SPV is stopped, so this case
+        /// must NOT point the user at it.
         case runtimeStopped
     }
 
@@ -312,15 +313,19 @@ struct UnconfirmedTransactionRemover {
         // rebroadcasting) restarts without the removed transactions.
         await SwiftDashSDKWalletRuntime.shared.reloadAfterWalletRowsChanged()
 
-        // Did the reload actually bring the runtime back? `refresh` starts
-        // Core SPV and then BLAST, and falls back to `fullReset` if EITHER
-        // throws — so a Platform outage, which has nothing to do with the
-        // Core-side row the user just repaired, stops the host and Core SPV
-        // as well. The rows are already deleted and stay deleted; what this
-        // decides is which remedy the caller can honestly offer, because
-        // Rescan Filters refuses while SPV is stopped.
+        // Did the reload actually bring Core back? Core readiness is the right
+        // question, not full readiness: the rows are already deleted and stay
+        // deleted, and what this decides is which remedy the caller can
+        // honestly offer — Rescan Filters refuses while SPV is stopped, and
+        // cares about nothing else. `refresh` now contains a Platform start
+        // failure instead of running `fullReset`, so a Platform outage, which
+        // has nothing to do with the Core-side row the user just repaired,
+        // leaves SPV running and the rescan armable. Asking `isRuntimeReady`
+        // here would report the wallet stopped and withhold the rescan that
+        // this type calls the only on-chain safety check the dropped
+        // transactions ever get.
         let runtimeReady = WalletEnvironment.network
-            .map { SwiftDashSDKWalletRuntime.shared.isRuntimeReady(for: $0) } ?? false
+            .map { SwiftDashSDKWalletRuntime.shared.isCoreRuntimeReady(for: $0) } ?? false
 
         let outcome: RemovalOutcome
         if !runtimeReady {

--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceModel.swift
@@ -100,7 +100,14 @@ final class BalanceModel: ObservableObject {
             options.balanceChangedDate = Date()
         }
 
-        options.userHasBalance = balanceValue > 0
+        // Only write when the balance is actually known. `userHasBalance` is
+        // persisted per wallet and is an input to the default shortcut bar, so
+        // writing `false` for a not-yet-loaded balance let a single launch
+        // before the wallet was bound permanently drop a shortcut from a funded
+        // wallet's bar. `nil` means "not known yet", never "empty".
+        if let total = walletBalance?.total {
+            options.userHasBalance = total > 0
+        }
         isBalanceHidden = DWGlobalOptions.sharedInstance().balanceHidden
     }
     

--- a/DashWalletTests/PassiveWalletStateUITailTests.swift
+++ b/DashWalletTests/PassiveWalletStateUITailTests.swift
@@ -94,7 +94,14 @@ final class PassiveWalletStateUITailTests: XCTestCase {
 
         let backupReminderDate = options.balanceChangedDate
         await clearBalance(expecting: model)
-        XCTAssertFalse(options.userHasBalance)
+        // `userHasBalance` deliberately survives a cleared balance. `nil` means
+        // "not known yet" — Core SPV stopped, or no wallet bound to the host —
+        // never "this wallet is empty", and the flag is persisted per wallet and
+        // feeds the default shortcut bar. Writing `false` here let one offline
+        // launch permanently drop a shortcut from a funded wallet. The wipe path
+        // is what legitimately resets it, through
+        // `DWGlobalOptions.restoreToDefaults()` in `SwiftDashSDKWalletWiper`.
+        XCTAssertTrue(options.userHasBalance)
         XCTAssertEqual(options.balanceChangedDate, backupReminderDate)
         XCTAssertTrue(model.isBalanceHidden)
 

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -543,14 +543,43 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
     /// no subscriptions and a cleared balance that no later refresh repairs.
     func testNoTriggerElidesWhileSwitchPreparationHasDetachedSubscriptions() {
         typealias Trigger = SwiftDashSDKWalletRuntime.RefreshTrigger
+        let target = Network.testnet
 
-        // Detached subscriptions ⇒ Core not ready ⇒ not fully ready either.
+        // The state `prepareForNetworkSwitch()` leaves behind: host still bound,
+        // Core SPV still flagged running on the target, publishers detached.
+        // Readiness is computed here rather than asserted as a literal, so
+        // dropping the `subscriptionsDetached` term from the predicate fails
+        // this test instead of silently restoring the defect.
+        let preparedCoreReady = RuntimeReadinessPolicy.isCoreReady(
+            boundNetwork: target, target: target, hasBoundWallet: true,
+            isSPVRunning: true, subscriptionsDetached: true)
+        XCTAssertFalse(preparedCoreReady, "detached subscriptions must make Core unready")
+
+        let preparedFullyReady = RuntimeReadinessPolicy.isFullyReady(
+            isCoreReady: preparedCoreReady, isBlastRunning: true,
+            blastNetwork: target, target: target)
+        XCTAssertFalse(preparedFullyReady, "full readiness must not outrank detached Core")
+
+        // With those computed values, nothing may elide the rebuild.
         for trigger in [Trigger.startIfReady, .platformSyncRearm, .networkDidChange,
                         .walletMaterialChanged, .walletDidChange] {
             XCTAssertFalse(
                 RuntimeRefreshPolicy.shouldSkipRebuild(
-                    trigger: trigger, isCoreReady: false, isFullyReady: false),
+                    trigger: trigger, isCoreReady: preparedCoreReady, isFullyReady: preparedFullyReady),
                 "\(trigger.rawValue) must rebuild while the switch preparation has detached the subscriptions")
+        }
+
+        // Re-attaching the publishers makes the same runtime ready again, and
+        // the Core-only triggers go back to eliding.
+        let reattachedCoreReady = RuntimeReadinessPolicy.isCoreReady(
+            boundNetwork: target, target: target, hasBoundWallet: true,
+            isSPVRunning: true, subscriptionsDetached: false)
+        XCTAssertTrue(reattachedCoreReady, "re-attached subscriptions must restore Core readiness")
+
+        for trigger in [Trigger.startIfReady, .platformSyncRearm] {
+            XCTAssertTrue(
+                RuntimeRefreshPolicy.shouldSkipRebuild(
+                    trigger: trigger, isCoreReady: reattachedCoreReady, isFullyReady: false))
         }
     }
 

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -262,6 +262,48 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
                 hasWalletManager: true))
     }
 
+    /// A Platform outage must not cost the user a working Core runtime: with
+    /// Core up and Platform down, the triggers that fire on their own (launch,
+    /// foreground, the sync strip's Retry, "Sync Now") elide the rebuild whose
+    /// `fullReset` would stop SPV, clear the balance and empty the home
+    /// transaction list. This is the offline-launch regression in table form.
+    func testCoreOnlyTriggersElideTheRebuildWhilePlatformIsDown() {
+        typealias Trigger = SwiftDashSDKWalletRuntime.RefreshTrigger
+
+        // Core up, Platform down.
+        for trigger in [Trigger.startIfReady, .platformSyncRearm] {
+            XCTAssertTrue(
+                RuntimeRefreshPolicy.shouldSkipRebuild(
+                    trigger: trigger, isCoreReady: true, isFullyReady: false),
+                "\(trigger.rawValue) must not rebuild a healthy Core because Platform is down")
+        }
+
+        // A network switch still rebuilds on Core alone — it detached the SPV
+        // subscriptions that only a rebuild re-attaches.
+        XCTAssertFalse(
+            RuntimeRefreshPolicy.shouldSkipRebuild(
+                trigger: .networkDidChange, isCoreReady: true, isFullyReady: false))
+        XCTAssertTrue(
+            RuntimeRefreshPolicy.shouldSkipRebuild(
+                trigger: .networkDidChange, isCoreReady: true, isFullyReady: true))
+
+        // A wallet change never elides, however ready the runtime looks.
+        for trigger in [Trigger.walletMaterialChanged, .walletDidChange] {
+            XCTAssertFalse(
+                RuntimeRefreshPolicy.shouldSkipRebuild(
+                    trigger: trigger, isCoreReady: true, isFullyReady: true),
+                "\(trigger.rawValue) must always rebind the wallet")
+        }
+
+        // Nothing elides when Core itself is down.
+        for trigger in [Trigger.startIfReady, .platformSyncRearm, .networkDidChange] {
+            XCTAssertFalse(
+                RuntimeRefreshPolicy.shouldSkipRebuild(
+                    trigger: trigger, isCoreReady: false, isFullyReady: false),
+                "\(trigger.rawValue) must rebuild when Core is not running")
+        }
+    }
+
     func testWalletWithoutPlatformPaymentAccountUsesNeutralState() {
         let availability = PlatformAccountAvailabilityPolicy.resolve(
             hasWalletRecord: true,


### PR DESCRIPTION
## Why

Bug report: *"I noticed a pretty terrible bug if you don't have internet. The wallet will not load (or you will see 0 balance)."*

Reproduced from the code. Two independent app-side causes, neither needing an SDK or FFI change.

**A. The balance was never published from local state.** Its only producer is the SPV coordinator's balance bridge, and every caller ran *after* a successful `startSpv`. Offline that start is delayed by the DashPay readiness budget and can fail outright, so the published balance stayed `nil` and the home screen collapsed it to `0.00`.

**B. A Platform failure took Core down with it.** `refresh` started Core SPV and Platform/BLAST inside one `do/catch`. A Platform throw ran `fullReset`, which stops SPV, clears wallet state and nils the host's `modelContainer` — the SwiftData handle the home transaction list reads. So the list emptied too, and nothing retried. That is the "wallet will not load" half.

## What changed

- **Publish the persisted balance as soon as the host is bound**, before any network work. `host.start` already runs `loadFromPersistor`, and `coreWallet().balance()` is a lock-free in-memory read — no SPV, no peers, no I/O. The home transaction list reloads off that same balance change, so it comes back with it.
- **Split the two starts.** A Platform failure is contained in its own phase; the host, Core SPV, the balance and the SwiftData handles all stay up. `currentNetwork` is recorded before Platform is asked to start, so the degraded state is recognisable.
- **Refresh elision now reads Core readiness alone** for the triggers that fire on their own (launch, foreground, the sync strip's Retry, "Sync Now"). They recover Platform in place instead of rebuilding a healthy Core. `.networkDidChange` keeps full readiness, because its callers detach the SPV subscriptions that only a rebuild re-attaches.
- **The network-switch verdict moves to Core readiness**, so an offline switch no longer raises a blocking, Retry-only failure card over a runtime that works.
- **Reachability returning kicks the runtime**, which brings a degraded Platform back on its own.

Two defects found on the same path and fixed here:

- `BalanceModel` persisted `userHasBalance = false` for a not-yet-loaded balance. That value is per-wallet and feeds the default shortcut bar, so a single offline launch permanently dropped a shortcut from a funded wallet's bar. It now only writes when the balance is actually known.
- The dead `seedInitialBalance`, whose doc comment claimed to be the balance's first producer, is gone.

The trigger routing is extracted to `RuntimeRefreshPolicy` so it can be tested without a live host, matching the existing `PlatformSyncRearmPolicy`.

## No UI change

The red "Unable to connect" strip already appears on a cold offline launch — `SyncingActivityMonitor`'s reachability gate forces `.noConnection` during its own `init`, before the home header reads it. Telling the user was never the missing piece. The missing piece was the number next to it, which read as an empty wallet.

## Verification

Clean `dashpay` build at the time of the smoke below. Accessibility audit reports no new findings.

**The added tests have never been compiled, let alone run** — stating it plainly because "compile-ready" overstated it. `DashWalletTests` cannot build as a target at all: 7 of its files `@testable import dashwallet` and 26 `@testable import dashpay`, and no scheme builds both modules. The routing/readiness tests sit in the `dashpay` group and the `userHasBalance` assertion in the `dashwallet` group, so neither has been type-checked. That is pre-existing and not introduced here, but it means the tests document intent rather than guard it.

### Re-verified at head, 2026-09-11

Rebuilt `DashSDKFFI.xcframework` against platform `v4.2-dev` @ `e096d1e89d` and rebuilt the app clean, so every commit on this branch — including the two review fixes that landed after the last smoke — is now covered by a real build.

The maintainer then cut the host's connectivity for real and ran the offline path on that build. The strip appeared and cleared itself on reconnect, and the log shows the runtime did the right thing on the way back:

```
12:38:02  SYNCSTATE :: reported done — scanned tip 1551625
              … ~3 min offline, no sync activity …
12:41:12  SYNCSTATE :: reported done — scanned tip 1551626
12:41:12  RUNTIME :: refreshing runtime for startIfReady
12:41:12  RUNTIME :: refresh is already satisfied for 1
```

That single refresh is the connectivity-return kick firing through the new `startIfReadyWhenLifecycleIdle` entry point. It did not log a skip, so the lifecycle phase was idle as expected; it elided the rebuild rather than tearing Core down; and there is not one `HOST :: stopped` / `HOST :: starting` line after 12:38, so the balance and transaction list were never cleared.

**Still not exercised at runtime: the `.failedNetworkSwitch` path.** Reaching it needs a Core start that actually fails, and an offline switch does not fail — `startSpv` needs no peers, which this PR verified separately. So the ready-runtime no-op completing a failed transition, and the phase re-check suppressing the kick, are reasoned from the code and compiled, not driven end to end. Flagging it rather than implying otherwise. Testnet smoke on iPhone 17:

**Cause A — cold launch ordering.** The balance is published 5.1 s before SPV starts, with SPV not yet running:

```
11:45:12.923  SPVCOORD :: first balance published total=10708219969 spv=false
11:45:15.994  DP-READY :: ready for SPV in 3.1s scans=0 drained=4
11:45:18.014  SPVCOORD :: started on 1
```

Previously the balance first appeared at that last line, and offline it never appeared at all.

**Cause B — recovery without a Core teardown.** Platform stopped from the Sync Info screen, then "Sync Now":

```
11:50:35.772  RUNTIME :: refreshing runtime for platformSyncRearm
11:50:35.772  RUNTIME :: refresh is already satisfied for 1
11:50:35.772  PLATFORM-ADDR :: starting for 1
11:50:38.735  PLATFORM-ADDR :: started for 1
```

No host stop/start, no SPV restart, no balance clearing. On `develop` this same path went through the full teardown and rebuild.

**Now verified: a true no-network cold launch.** Every uplink on the host was taken down — the first attempt only looked offline, because the Mac had silently failed over to a tethered iPhone on `172.20.10.x`. With the machine genuinely cut off, the maintainer ran all of it end to end: cold launch shows the persisted balance and history immediately with the red "Unable to connect" strip; repeated Retry never blanks them; connectivity returning resumes sync on its own; and an offline network switch completes both ways.

`startSpv` succeeds with no network, which is what makes the fix hold on the reported path — `PeerNetworkManager::new` only opens the on-disk peer store, it does not resolve or connect. The offline logs show it:

```
08:45:59.838  SPVCOORD :: first balance published spv=false     (mainnet)
08:46:05.211  SPVCOORD :: started on 0
08:47:15.882  SPVCOORD :: first balance published spv=false     (testnet)
08:47:29.425  SPVCOORD :: started on 1
```

If Core start did throw, the catch runs `fullReset` and the balance goes back to `nil` — deliberately, because that path tears the host down and a balance published from a dead runtime would be state with nothing behind it.

## Review notes

- `currentNetwork` now means "Core is bound", not "everything is up". It is private and read only through the two predicates.
- An offline network switch now reports success with Platform degraded. The Sync Info screen's `lastError` is the surface that says so. Worth confirming that is the intended product behaviour.
- The elided `.startIfReady` branch now awaits a BLAST start instead of returning immediately. Bounded by the `isRunning` guard, and offline each attempt is a fast throw.

Out of scope, deliberately: distinguishing "unknown" from zero in the balance UI, a "last updated" timestamp, and a reachability gate on `discoverIdentities` (which offline can park an uncancellable thread for ~200 s). Happy to follow up on any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet startup and network recovery when platform services are unavailable.
  * Prevented repeated online status updates from triggering unnecessary restarts.
  * Avoided runtime restarts during active wallet transitions.
  * Preserved the known “has balance” state while balance data is unavailable.
  * Wallet balances now appear earlier during startup.
  * Improved recovery when platform services restart without requiring a full wallet reset.
  * Improved consistency when publishing balance updates and clearing wallet state.
* **Tests**
  * Added regression coverage for runtime recovery, refresh behavior, and balance-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


