### PR TITLE
fix(ui): stop the receive tab scanning the whole transaction history

### DIFF
--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -167,8 +167,19 @@ public final class TransactionObserver {
         if let floor = firstSeenAtOrAfter {
             // `firstSeen` is indexed, so this is what turns the scan from a
             // full-table join into an index range.
+            //
+            // Unconfirmed rows join it regardless of the floor, because
+            // `firstSeen` is not immutable: once a transaction is mined the
+            // persister adopts the BLOCK timestamp in its place. An existing
+            // payment that sat below the floor while unconfirmed therefore
+            // rises above it the moment it confirms, becomes emittable, and —
+            // if it was not in this snapshot — is presented as a new receipt.
+            // Reachable in one session: receive to the Core address, switch
+            // rails until the payment ages past the window, come back before
+            // it is mined. Only unconfirmed rows can move, and there are few
+            // of them, so this keeps the index range and closes the hole.
             descriptor.predicate = #Predicate {
-                $0.firstSeen >= floor &&
+                ($0.firstSeen >= floor || $0.blockHeight == 0) &&
                     ($0.outputs.contains { $0.walletId == walletId } ||
                         $0.inputs.contains { $0.walletId == walletId })
             }

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -167,28 +167,67 @@ public final class TransactionObserver {
         if let floor = firstSeenAtOrAfter {
             // `firstSeen` is indexed, so this is what turns the scan from a
             // full-table join into an index range.
-            //
-            // Unconfirmed rows join it regardless of the floor, because
-            // `firstSeen` is not immutable: once a transaction is mined the
-            // persister adopts the BLOCK timestamp in its place. An existing
-            // payment that sat below the floor while unconfirmed therefore
-            // rises above it the moment it confirms, becomes emittable, and —
-            // if it was not in this snapshot — is presented as a new receipt.
-            // Reachable in one session: receive to the Core address, switch
-            // rails until the payment ages past the window, come back before
-            // it is mined. Only unconfirmed rows can move, and there are few
-            // of them, so this keeps the index range and closes the hole.
             descriptor.predicate = #Predicate {
-                ($0.firstSeen >= floor || $0.blockHeight == 0) &&
+                $0.firstSeen >= floor &&
                     ($0.outputs.contains { $0.walletId == walletId } ||
                         $0.inputs.contains { $0.walletId == walletId })
             }
         }
         descriptor.propertiesToFetch = [\.txid]
         do {
-            return Set(try context.fetch(descriptor).map(\.txid))
+            var ids = Set(try context.fetch(descriptor).map(\.txid))
+            if let floor = firstSeenAtOrAfter {
+                ids.formUnion(unconfirmedIDs(context: context, walletId: walletId, floor: floor))
+            }
+            return ids
         } catch {
             logger.error("🅾 OBSERVER :: txid snapshot failed: \(String(describing: error), privacy: .public)")
+            return []
+        }
+    }
+
+    /// How far below a subscription's floor the unconfirmed sweep reaches.
+    ///
+    /// `firstSeen` is not immutable: once a transaction is mined the persister
+    /// adopts the BLOCK timestamp in its place. A payment that sat below the
+    /// floor while unconfirmed therefore rises above it on confirmation,
+    /// becomes emittable, and — absent from the exclusion snapshot — is
+    /// presented as a new receipt. Reachable in one session: receive to the
+    /// Core address, switch rails until it ages past the match window, return
+    /// before it is mined.
+    ///
+    /// Only unconfirmed rows can move, so only they need sweeping. The sweep
+    /// is a SECOND indexed range rather than an `OR blockHeight == 0` branch
+    /// on the first: `blockHeight` carries no index, so that branch made
+    /// SQLite evaluate the correlated wallet relationship across the whole
+    /// table — the full history scan this snapshot exists to avoid.
+    ///
+    /// The bound is the stated limit of the fix: a transaction that has been
+    /// unconfirmed for longer than this and then confirms mid-session can
+    /// still surface as a receipt. A day is far past normal confirmation, and
+    /// the alternative is scanning history on every entry to the Receive tab.
+    private static let unconfirmedLookback: UInt64 = 24 * 60 * 60
+
+    /// Wallet transactions still unmined, within `unconfirmedLookback` of
+    /// `floor`. Same indexed `firstSeen` range shape as the main snapshot.
+    private static func unconfirmedIDs(
+        context: ModelContext,
+        walletId: Data,
+        floor: UInt64
+    ) -> Set<Data> {
+        let sweepFloor = floor > unconfirmedLookback ? floor - unconfirmedLookback : 0
+        var descriptor = FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate {
+                $0.firstSeen >= sweepFloor &&
+                    $0.blockHeight == 0 &&
+                    ($0.outputs.contains { $0.walletId == walletId } ||
+                        $0.inputs.contains { $0.walletId == walletId })
+            })
+        descriptor.propertiesToFetch = [\.txid]
+        do {
+            return Set(try context.fetch(descriptor).map(\.txid))
+        } catch {
+            logger.error("🅾 OBSERVER :: unconfirmed sweep failed: \(String(describing: error), privacy: .public)")
             return []
         }
     }

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -88,6 +88,18 @@ public final class TransactionObserver {
     /// request (e.g. an earlier deposit's ack) out of this wait while never
     /// dropping a response that raced the subscription.
     private static let matchFloorSkew: TimeInterval = 120
+
+    /// The `firstSeen` floor a subscription started at `after` will scan from.
+    ///
+    /// Public because the exclusion snapshot a caller passes to
+    /// `observeUpdates` has to be bounded by the SAME floor: a transaction
+    /// below it can never be emitted, so carrying its txid in the exclusion
+    /// set is work with no effect on the outcome. Two independently derived
+    /// floors could drift apart and silently start admitting rows the snapshot
+    /// no longer covers, so there is exactly one.
+    static func matchFloor(after: Date) -> UInt64 {
+        UInt64(max(0, after.timeIntervalSince1970 - matchFloorSkew))
+    }
     /// Rows admitted per rescan; the floor predicate already bounds the
     /// window, this guards a resync burst mid-wait.
     private static let rescanFetchLimit = 200
@@ -132,7 +144,18 @@ public final class TransactionObserver {
     /// sessions snapshot these at start so a restore burst cannot present an
     /// already-persisted transaction as a new payment merely because its
     /// device-clock `firstSeen` is recent.
-    static func persistedTransactionIDs() -> Set<Data> {
+    ///
+    /// `firstSeenAtOrAfter` must be the subscription's own floor
+    /// (`matchFloor(after:)`). Rows below it are already unreachable — the
+    /// rescan predicate drops them before any filter runs — so excluding them
+    /// again changes nothing and costs everything: unbounded, this walked
+    /// every transaction the wallet has ever persisted, materialized each one
+    /// (SwiftData's `propertiesToFetch` does not spare the object), and did it
+    /// on whichever thread asked. A restored wallet turned that into thousands
+    /// of rows on the main thread on every entry to the Receive tab. `nil`
+    /// keeps the unbounded behaviour for a caller that genuinely wants the
+    /// whole history.
+    static func persistedTransactionIDs(firstSeenAtOrAfter: UInt64? = nil) -> Set<Data> {
         guard let resolved = resolveHostHandles() else { return [] }
         let context = ModelContext(resolved.container)
         let walletId = resolved.walletId
@@ -141,6 +164,15 @@ public final class TransactionObserver {
                 $0.outputs.contains { $0.walletId == walletId } ||
                     $0.inputs.contains { $0.walletId == walletId }
             })
+        if let floor = firstSeenAtOrAfter {
+            // `firstSeen` is indexed, so this is what turns the scan from a
+            // full-table join into an index range.
+            descriptor.predicate = #Predicate {
+                $0.firstSeen >= floor &&
+                    ($0.outputs.contains { $0.walletId == walletId } ||
+                        $0.inputs.contains { $0.walletId == walletId })
+            }
+        }
         descriptor.propertiesToFetch = [\.txid]
         do {
             return Set(try context.fetch(descriptor).map(\.txid))
@@ -266,7 +298,7 @@ public final class TransactionObserver {
         filters: [TransactionFilter],
         after: Date
     ) -> AnyPublisher<ObservedTransaction, Never> {
-        let floor = UInt64(max(0, after.timeIntervalSince1970 - Self.matchFloorSkew))
+        let floor = Self.matchFloor(after: after)
         return NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)
             .map { _ in () }
             .prepend(()) // immediate initial scan

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -2089,6 +2089,26 @@ class SwiftDashSDKWalletSource: TransactionSource {
         return SwiftDashSDKWalletTransactionSnapshot(walletId: walletId, transactions: transactions)
     }
 
+    /// Ids, in `ShieldedActivityItem.id` form, of every shielded activity row
+    /// the active wallet has persisted. Safe from any thread.
+    ///
+    /// A superset of what `fetchShieldedActivity` projects — no row is
+    /// dropped or deduped here — which is what a "what already existed"
+    /// baseline needs: a row present now is not a new payment, whatever the
+    /// projection later makes of it. It reads two columns of one small table
+    /// and never touches the Core history, where the projection materializes
+    /// every wallet transaction to reconcile against.
+    static func persistedShieldedActivityIds() -> Set<String> {
+        guard let (container, walletId) = hostHandles() else { return [] }
+        var descriptor = FetchDescriptor<PersistentShieldedActivity>(
+            predicate: #Predicate { $0.walletId == walletId })
+        descriptor.propertiesToFetch = [\.entryId, \.accountIndex]
+        guard let rows = try? ModelContext(container).fetch(descriptor) else { return [] }
+        return Set(rows.map {
+            ShieldedActivityItem.id(entryId: $0.entryId, accountIndex: $0.accountIndex)
+        })
+    }
+
     /// The active wallet's shielded operations as history items, for
     /// interleaving with the Core rows. Safe from any thread.
     ///

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -113,6 +113,12 @@ struct ShieldedActivityItem: Identifiable {
     let isAwaitingTransparentReceipt: Bool
 
     var id: String {
+        Self.id(entryId: entryId, accountIndex: accountIndex)
+    }
+
+    /// The id a row projects to, for callers that need it without building
+    /// the item (`persistedShieldedActivityIds`).
+    static func id(entryId: Data, accountIndex: UInt32) -> String {
         "shielded-" + entryId.map { String(format: "%02x", $0) }.joined() + "-\(accountIndex)"
     }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -632,23 +632,25 @@ final class InternalTransferViewModel: ObservableObject {
     /// every balance is a valid FROM for a top-up, so there is nothing to
     /// sanitise away from.
     func selectStandaloneDestination(_ destination: TransferDestination) {
-        switch destination {
-        case .balance(let network):
-            isIdentityDestination = false
-            // With the identity on the FROM side, `source` is not in play and
-            // `selectStandaloneTarget`'s collision sanitising would move a
-            // balance the transfer never touches.
-            if isIdentitySource {
-                sendTarget = network
-            } else {
-                selectStandaloneTarget(network)
+        applyingRouteChange {
+            switch destination {
+            case .balance(let network):
+                isIdentityDestination = false
+                // With the identity on the FROM side, `source` is not in play
+                // and `selectStandaloneTarget`'s collision sanitising would
+                // move a balance the transfer never touches.
+                if isIdentitySource {
+                    sendTarget = network
+                } else {
+                    selectStandaloneTarget(network)
+                }
+            case .identity:
+                // An identity cannot fund itself: taking the TO side releases
+                // the FROM side back to a balance.
+                isIdentitySource = false
+                isIdentityDestination = true
+                refreshIdentitySnapshot()
             }
-        case .identity:
-            // An identity cannot fund itself: taking the TO side releases
-            // the FROM side back to a balance.
-            isIdentitySource = false
-            isIdentityDestination = true
-            refreshIdentitySnapshot()
         }
     }
 
@@ -657,22 +659,24 @@ final class InternalTransferViewModel: ObservableObject {
     /// to a balance and moves it off Shielded, which no single transition
     /// reaches from an identity.
     func selectStandaloneSource(_ source: TransferSource) {
-        switch source {
-        case .balance(let network):
-            isIdentitySource = false
-            if isIdentityDestination {
-                // Top-up mode: every balance is a valid funding source, and
-                // the TO side is the identity, so there is no collision to
-                // sanitise.
-                self.source = network
-            } else {
-                selectStandaloneSource(network)
+        applyingRouteChange {
+            switch source {
+            case .balance(let network):
+                isIdentitySource = false
+                if isIdentityDestination {
+                    // Top-up mode: every balance is a valid funding source,
+                    // and the TO side is the identity, so there is no
+                    // collision to sanitise.
+                    self.source = network
+                } else {
+                    selectStandaloneSource(network)
+                }
+            case .identity:
+                isIdentityDestination = false
+                isIdentitySource = true
+                sendTarget = Self.sanitizedWithdrawalTarget(sendTarget)
+                refreshIdentitySnapshot()
             }
-        case .identity:
-            isIdentityDestination = false
-            isIdentitySource = true
-            sendTarget = Self.sanitizedWithdrawalTarget(sendTarget)
-            refreshIdentitySnapshot()
         }
     }
 
@@ -838,17 +842,23 @@ final class InternalTransferViewModel: ObservableObject {
         isAdvancedMode = DWGlobalOptions.sharedInstance().advancedModeEnabled
         guard !isAdvancedMode else { return }
 
-        isIdentitySource = false
-        isIdentityDestination = false
+        // Withdrawing the mode retires both identity overlays and moves every
+        // endpoint that was sitting on Platform — up to five in a row, and one
+        // recompute each, all but the last against a route the next line
+        // replaced.
+        applyingRouteChange {
+            isIdentitySource = false
+            isIdentityDestination = false
 
-        if source == .platform {
-            source = .core
-        }
-        if sendTarget == .platform {
-            sendTarget = Self.defaultDestination(for: source)
-        }
-        if receiveSource == .platform {
-            receiveSource = .shielded
+            if source == .platform {
+                source = .core
+            }
+            if sendTarget == .platform {
+                sendTarget = Self.defaultDestination(for: source)
+            }
+            if receiveSource == .platform {
+                receiveSource = .shielded
+            }
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -477,13 +477,13 @@ final class InternalTransferViewModel: ObservableObject {
     /// because most users have BIP44 funds before they have Platform or
     /// Shielded balance.
     @Published var source: ChainNetwork = .core {
-        didSet { guard oldValue != source else { return }; routeDidChange() }
+        didSet { guard oldValue != source else { return }; routeEndpointDidChange() }
     }
 
     /// Fixed destination when this VM drives the receive sheet's embedded
     /// form: the balance being received into. `nil` = the standalone form.
     @Published private(set) var receiveTarget: ChainNetwork? = nil {
-        didSet { guard oldValue != receiveTarget else { return }; routeDidChange() }
+        didSet { guard oldValue != receiveTarget else { return }; routeEndpointDidChange() }
     }
 
     /// Fixed source when this VM drives the send sheet's embedded form
@@ -491,20 +491,20 @@ final class InternalTransferViewModel: ObservableObject {
     /// rows pick `sendTarget` among the other two balances. Mutually
     /// exclusive with `receiveTarget`; `nil` = not the send sheet.
     @Published private(set) var sendSource: ChainNetwork? = nil {
-        didSet { guard oldValue != sendSource else { return }; routeDidChange() }
+        didSet { guard oldValue != sendSource else { return }; routeEndpointDidChange() }
     }
 
     /// The destination balance picked on the send sheet's To rows. Only
     /// meaningful while `sendSource` is set, but reused by the standalone
     /// screen as the selected To balance as well.
     @Published var sendTarget: ChainNetwork = .shielded {
-        didSet { guard oldValue != sendTarget else { return }; routeDidChange() }
+        didSet { guard oldValue != sendTarget else { return }; routeEndpointDidChange() }
     }
 
     /// The source balance picked on the receive sheet's From rows. Only
     /// meaningful while `receiveTarget` is set.
     @Published var receiveSource: ChainNetwork = .shielded {
-        didSet { guard oldValue != receiveSource else { return }; routeDidChange() }
+        didSet { guard oldValue != receiveSource else { return }; routeEndpointDidChange() }
     }
 
     /// True while the standalone destination is the DashPay identity rather
@@ -514,7 +514,7 @@ final class InternalTransferViewModel: ObservableObject {
     /// execution go through the identity top-up path instead. Standalone
     /// only; the send/receive-pinned variants stay balance-to-balance.
     @Published private(set) var isIdentityDestination = false {
-        didSet { guard oldValue != isIdentityDestination else { return }; routeDidChange() }
+        didSet { guard oldValue != isIdentityDestination else { return }; routeEndpointDidChange() }
     }
 
     /// Standalone screen: the FROM side is the identity's credit balance
@@ -523,7 +523,7 @@ final class InternalTransferViewModel: ObservableObject {
     /// balance pair and only `identityWithdrawalTransfer` describes the
     /// transfer, exactly as with the destination overlay.
     @Published private(set) var isIdentitySource = false {
-        didSet { guard oldValue != isIdentitySource else { return }; routeDidChange() }
+        didSet { guard oldValue != isIdentitySource else { return }; routeEndpointDidChange() }
     }
 
     /// The 32-byte id of the identity a transfer would top up, loaded when
@@ -590,9 +590,11 @@ final class InternalTransferViewModel: ObservableObject {
     /// Pins the route for the receive sheet: a transfer INTO `target`.
     /// The From rows then pick the source among the other two balances.
     func applyReceiveRoute(into target: ChainNetwork) {
-        sendSource = nil
-        receiveTarget = target
-        receiveSource = Self.sanitizedSource(into: target, proposed: receiveSource)
+        applyingRouteChange {
+            sendSource = nil
+            receiveTarget = target
+            receiveSource = Self.sanitizedSource(into: target, proposed: receiveSource)
+        }
     }
 
     /// Pins the route for the send sheet: a transfer OUT OF `from`. The To
@@ -601,22 +603,28 @@ final class InternalTransferViewModel: ObservableObject {
     /// Platform default to Shielded (privacy-forward); Shielded defaults
     /// to Core.
     func applySendRoute(from source: ChainNetwork) {
-        receiveTarget = nil
-        sendSource = source
-        sendTarget = Self.sanitizedDestination(from: source, proposed: sendTarget)
+        applyingRouteChange {
+            receiveTarget = nil
+            sendSource = source
+            sendTarget = Self.sanitizedDestination(from: source, proposed: sendTarget)
+        }
     }
 
     /// Endpoint picks always apply. A pick that collides with the opposite
     /// endpoint moves THAT endpoint to its default instead — the two sides
     /// can never be the same balance.
     func selectStandaloneSource(_ network: ChainNetwork) {
-        source = network
-        sendTarget = Self.sanitizedDestination(from: network, proposed: sendTarget)
+        applyingRouteChange {
+            source = network
+            sendTarget = Self.sanitizedDestination(from: network, proposed: sendTarget)
+        }
     }
 
     func selectStandaloneTarget(_ network: ChainNetwork) {
-        sendTarget = network
-        source = Self.sanitizedSource(into: network, proposed: source)
+        applyingRouteChange {
+            sendTarget = network
+            source = Self.sanitizedSource(into: network, proposed: source)
+        }
     }
 
     /// Destination-typed standalone pick: a balance keeps the pre-existing
@@ -733,33 +741,37 @@ final class InternalTransferViewModel: ObservableObject {
     func swapStandaloneEndpoints() {
         guard canSwapEndpoints else { return }
 
-        if isIdentitySource {
-            // Withdrawal → top-up: the target balance becomes the funding
-            // source. Read the target before clearing the overlay, since
-            // `resolvedWithdrawalTarget` is only meaningful while it is on.
-            let fundingSource = resolvedWithdrawalTarget.network
-            isIdentitySource = false
-            isIdentityDestination = true
-            source = fundingSource
-            refreshIdentitySnapshot()
-            return
-        }
+        // Every branch below moves two or three endpoints; the `return`s exit
+        // the batch, exactly as they exited the function before.
+        applyingRouteChange {
+            if isIdentitySource {
+                // Withdrawal → top-up: the target balance becomes the funding
+                // source. Read the target before clearing the overlay, since
+                // `resolvedWithdrawalTarget` is only meaningful while it is on.
+                let fundingSource = resolvedWithdrawalTarget.network
+                isIdentitySource = false
+                isIdentityDestination = true
+                source = fundingSource
+                refreshIdentitySnapshot()
+                return
+            }
 
-        if isIdentityDestination {
-            // Top-up → withdrawal: the funding balance becomes the payout
-            // target. `canSwapEndpoints` has already ruled out Shielded.
-            let payoutTarget = source
-            isIdentityDestination = false
-            isIdentitySource = true
-            sendTarget = Self.sanitizedWithdrawalTarget(payoutTarget)
-            refreshIdentitySnapshot()
-            return
-        }
+            if isIdentityDestination {
+                // Top-up → withdrawal: the funding balance becomes the payout
+                // target. `canSwapEndpoints` has already ruled out Shielded.
+                let payoutTarget = source
+                isIdentityDestination = false
+                isIdentitySource = true
+                sendTarget = Self.sanitizedWithdrawalTarget(payoutTarget)
+                refreshIdentitySnapshot()
+                return
+            }
 
-        let newSource = resolvedSendTarget
-        let newTarget = source
-        source = newSource
-        sendTarget = newTarget
+            let newSource = resolvedSendTarget
+            let newTarget = source
+            source = newSource
+            sendTarget = newTarget
+        }
     }
 
     func selectSendTarget(_ network: ChainNetwork) {
@@ -884,6 +896,47 @@ final class InternalTransferViewModel: ObservableObject {
     /// input-selection envelope. While the destination is Identity, `route`
     /// is a stale balance pair, so the route preflights stay down and the
     /// identity ceiling refreshes instead.
+    /// True while one user action is moving more than one endpoint.
+    private var isApplyingRouteChange = false
+    /// Set when an endpoint moved during such an action, so the recompute
+    /// runs once at the end instead of once per endpoint.
+    private var routeChangeIsPending = false
+
+    /// Every endpoint `didSet` reports here rather than straight to
+    /// `routeDidChange`.
+    ///
+    /// Pinning a route moves two endpoints — the pinned side and the other
+    /// side sanitised against it — and each move used to recompute all of the
+    /// route-dependent state: the shielded spend ceiling (two SwiftData
+    /// fetches plus a run of `estimateShieldedFee` calls across the FFI) and
+    /// whichever Platform preflight the route needs. Twice, for one tap, with
+    /// the first pass computed against a half-applied route that the second
+    /// immediately replaced.
+    private func routeEndpointDidChange() {
+        guard !isApplyingRouteChange else {
+            routeChangeIsPending = true
+            return
+        }
+        routeDidChange()
+    }
+
+    /// Applies a multi-endpoint change as one route change.
+    private func applyingRouteChange(_ mutate: () -> Void) {
+        // Re-entrant callers (a standalone pick made from inside another) must
+        // not close the outer batch early.
+        guard !isApplyingRouteChange else {
+            mutate()
+            return
+        }
+        isApplyingRouteChange = true
+        routeChangeIsPending = false
+        mutate()
+        isApplyingRouteChange = false
+        guard routeChangeIsPending else { return }
+        routeChangeIsPending = false
+        routeDidChange()
+    }
+
     private func routeDidChange() {
         clearMaxSelection()
         refreshShieldedSpendCeiling()

--- a/DashWallet/Sources/UI/Payments/Landing/Components/PaymentsReceiveContent.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/Components/PaymentsReceiveContent.swift
@@ -220,9 +220,13 @@ struct PaymentsReceiveContent: View {
                             .accessibilityAddTraits(.isButton)
                             .accessibilityHint(Text(NSLocalizedString("Copy", comment: "")))
                         } else {
+                            // Same full-width, leading slot the address takes,
+                            // so the copy button stays on the trailing edge
+                            // instead of the pair centring in the row.
                             Text(NSLocalizedString("No address available", comment: "Payments"))
                                 .font(.footnote)
                                 .foregroundColor(Color.dash.secondaryText)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
 
 
@@ -276,11 +280,14 @@ struct PaymentsReceiveContent: View {
         }
     }
 
-    @ViewBuilder
+    /// Always laid out, and only faded when there is nothing to watch: an
+    /// absent view takes its padding with it, which left the actions sitting
+    /// on the card's bottom edge and made the card jump when watching began.
     private var watchingForPayment: some View {
-        if viewModel.isWatchingForReceipt {
-            ReceiveWatchingIndicator()
-        }
+        ReceiveWatchingIndicator()
+            .opacity(viewModel.isWatchingForReceipt ? 1 : 0)
+            .accessibilityHidden(!viewModel.isWatchingForReceipt)
+            .animation(.easeInOut(duration: 0.2), value: viewModel.isWatchingForReceipt)
     }
 
     private var hasAddress: Bool {

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -165,9 +165,8 @@ final class PaymentsLandingViewModel: ObservableObject {
         case shielded(activityIds: Set<String>)
     }
 
-    /// Everything about a session that is known before its baseline is read.
-    /// Separate because the shielded baseline is resolved off the main actor,
-    /// and these have to be captured before that suspension.
+    /// Everything about a session other than its baseline, captured before
+    /// the baseline is read.
     private struct ReceiptSessionSeed {
         let generation: UInt64
         let rail: ChainNetwork
@@ -211,12 +210,6 @@ final class PaymentsLandingViewModel: ObservableObject {
     private var platformReceiptCancellable: AnyCancellable?
     private var shieldedReceiptCancellable: AnyCancellable?
     private var attendedRefreshTask: Task<Void, Never>?
-    /// In-flight shielded baseline read. Held so leaving the surface, or a
-    /// route change, cancels the session it was about to open.
-    private var receiptSessionTask: Task<Void, Never>?
-    /// Which rail that in-flight read is for, so a reconcile arriving while it
-    /// runs can tell "already being started" from "needs starting".
-    private var receiptSessionRail: ChainNetwork?
     private var shieldedProjectionTask: Task<Void, Never>?
     private var shieldedProjectionRefreshPending = false
     private var shieldedProjectionGeneration: UInt64 = 0
@@ -376,17 +369,6 @@ final class PaymentsLandingViewModel: ObservableObject {
         if session?.rail == network, let displayedAddress {
             return displayedAddress
         }
-        // A rail whose baseline is still being built has no session yet, and
-        // handing out its address anyway put the QR and every receive action
-        // on screen ahead of one. Two ways that loses a payment: one persisted
-        // while the notes are being walked is folded INTO the baseline and
-        // excluded for the whole session, and sharing suspends watching, which
-        // cancels the pending baseline so the replacement — built afterwards —
-        // contains it too. Shielded is the only rail whose baseline cannot be
-        // a cheap read, so it is the only one that ever waits here.
-        if receiptSessionRail == network {
-            return nil
-        }
         return candidateAddress(for: network)
     }
 
@@ -526,72 +508,47 @@ final class PaymentsLandingViewModel: ObservableObject {
             return
         }
 
-        // A baseline for this rail is already being read. Let it land rather
-        // than cancelling and re-reading: `reconcileReceiptWatching` is driven
-        // by publishers that tick faster than the read completes, and
-        // restarting on each tick would mean it never completes at all.
-        if receiptSessionRail == network { return }
-
         generation &+= 1
-        let rail = network
-        // Stamped once, above the baseline reads rather than below them. Both
+        // Stamped once, above the baseline read rather than below it. Both
         // the Core snapshot's floor and the subscription's own floor derive
         // from it, and a transaction persisted between two separately-stamped
         // instants would land in neither.
         let seed = ReceiptSessionSeed(
             generation: generation,
-            rail: rail,
+            rail: network,
             address: address,
             walletId: walletId,
             environment: environment,
             startedAt: Date())
-        let sessionGeneration = seed.generation
 
-        switch rail {
+        // Every rail's baseline is a cheap read, so the session exists before
+        // the address can be acted on and nothing is ever withheld waiting
+        // for one.
+        let baseline: ReceiptBaseline
+        switch network {
         case .core:
             // Bounded by the floor the subscription will scan from: anything
             // older cannot be emitted, so it does not need excluding.
-            beginSession(seed, baseline: .core(
+            baseline = .core(
                 transactionIds: TransactionObserver.persistedTransactionIDs(
-                    firstSeenAtOrAfter: TransactionObserver.matchFloor(after: seed.startedAt))))
+                    firstSeenAtOrAfter: TransactionObserver.matchFloor(after: seed.startedAt)))
         case .platform:
-            beginSession(seed, baseline: .platform(
+            baseline = .platform(
                 activityCursor: PlatformAddressActivityDAO.shared.latestActivityId(
                     walletId: walletId,
-                    networkRaw: Int64(environment.rawValue))))
+                    networkRaw: Int64(environment.rawValue)))
         case .shielded:
-            // The only baseline that cannot be a cheap read: it walks the
-            // wallet's notes and rebuilds the whole projected activity list.
-            // Off the main actor, exactly as every later refresh of the same
-            // projection already is — and the session is created in the
-            // completion rather than left to be filled in, so a note that was
-            // already there can never be admitted as a new payment.
-            receiptSessionTask?.cancel()
-            receiptSessionRail = rail
-            receiptSessionTask = Task { [weak self] in
-                let ids = await Task.detached(priority: .userInitiated) {
-                    Set(Self.projectedShieldedActivity().map(\.id))
-                }.value
-                guard let self, !Task.isCancelled else { return }
-                self.receiptSessionTask = nil
-                self.receiptSessionRail = nil
-                // The route can have moved while the notes were being walked.
-                guard self.generation == sessionGeneration,
-                      self.network == rail,
-                      self.canActivelyWatch,
-                      self.session == nil
-                else { return }
-                self.beginSession(seed, baseline: .shielded(activityIds: ids))
-            }
+            // The persisted rows' ids, not the projected activity list: the
+            // projection materializes the wallet's whole Core history to
+            // reconcile against. A row that exists now is not a new payment
+            // whatever the projection later makes of it, so the unprojected
+            // superset is the right thing to exclude.
+            baseline = .shielded(
+                activityIds: SwiftDashSDKWalletSource.persistedShieldedActivityIds())
         }
-    }
 
-    /// Installs the session and starts watching on it. Split out so the rails
-    /// whose baseline is a cheap read and the one that has to leave the main
-    /// actor for it arrive at the same place.
-    private func beginSession(_ seed: ReceiptSessionSeed, baseline: ReceiptBaseline) {
         session = ReceiptSession(seed: seed, baseline: baseline)
-        displayedAddress = seed.address
+        displayedAddress = address
         resumeReceiptWatching()
     }
 
@@ -846,9 +803,6 @@ final class PaymentsLandingViewModel: ObservableObject {
 
     private func suspendReceiptWatching() {
         isWatchingForReceipt = false
-        receiptSessionTask?.cancel()
-        receiptSessionTask = nil
-        receiptSessionRail = nil
         coreReceiptCancellable?.cancel()
         coreReceiptCancellable = nil
         platformReceiptCancellable?.cancel()

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -152,16 +152,58 @@ final class PaymentsLandingViewModel: ObservableObject {
 
     let allowsTransactionDetails: Bool
 
-    private struct ReceiptSession {
+    /// What already existed on the rail when the session opened, so a receipt
+    /// is only ever raised for something that arrived after.
+    ///
+    /// One case per rail rather than three flat fields: they were always
+    /// mutually exclusive — two of them zero on every session — and nothing
+    /// said so, which left every construction restating the two that did not
+    /// apply.
+    private enum ReceiptBaseline {
+        case core(transactionIds: Set<Data>)
+        case platform(activityCursor: Int64)
+        case shielded(activityIds: Set<String>)
+    }
+
+    /// Everything about a session that is known before its baseline is read.
+    /// Separate because the shielded baseline is resolved off the main actor,
+    /// and these have to be captured before that suspension.
+    private struct ReceiptSessionSeed {
         let generation: UInt64
         let rail: ChainNetwork
         let address: String
         let walletId: Data
         let environment: Network
         let startedAt: Date
-        let coreTransactionIds: Set<Data>
-        let platformActivityCursor: Int64
-        let shieldedActivityIds: Set<String>
+    }
+
+    private struct ReceiptSession {
+        let seed: ReceiptSessionSeed
+        let baseline: ReceiptBaseline
+
+        var generation: UInt64 { seed.generation }
+        var rail: ChainNetwork { seed.rail }
+        var address: String { seed.address }
+        var walletId: Data { seed.walletId }
+        var environment: Network { seed.environment }
+        var startedAt: Date { seed.startedAt }
+
+        // Read by the rail's own watcher, which only runs when the baseline is
+        // that rail's case; the empty fallbacks are unreachable in practice.
+        var coreTransactionIds: Set<Data> {
+            guard case .core(let ids) = baseline else { return [] }
+            return ids
+        }
+
+        var platformActivityCursor: Int64 {
+            guard case .platform(let cursor) = baseline else { return 0 }
+            return cursor
+        }
+
+        var shieldedActivityIds: Set<String> {
+            guard case .shielded(let ids) = baseline else { return [] }
+            return ids
+        }
     }
 
     private var cancellables = Set<AnyCancellable>()
@@ -480,42 +522,32 @@ final class PaymentsLandingViewModel: ObservableObject {
         if receiptSessionRail == network { return }
 
         generation &+= 1
-        let sessionGeneration = generation
         let rail = network
         // Stamped once, above the baseline reads rather than below them. Both
         // the Core snapshot's floor and the subscription's own floor derive
         // from it, and a transaction persisted between two separately-stamped
         // instants would land in neither.
-        let startedAt = Date()
+        let seed = ReceiptSessionSeed(
+            generation: generation,
+            rail: rail,
+            address: address,
+            walletId: walletId,
+            environment: environment,
+            startedAt: Date())
+        let sessionGeneration = seed.generation
 
         switch rail {
         case .core:
             // Bounded by the floor the subscription will scan from: anything
             // older cannot be emitted, so it does not need excluding.
-            beginSession(
-                generation: sessionGeneration,
-                rail: rail,
-                address: address,
-                walletId: walletId,
-                environment: environment,
-                startedAt: startedAt,
-                coreTransactionIds: TransactionObserver.persistedTransactionIDs(
-                    firstSeenAtOrAfter: TransactionObserver.matchFloor(after: startedAt)),
-                platformActivityCursor: 0,
-                shieldedActivityIds: [])
+            beginSession(seed, baseline: .core(
+                transactionIds: TransactionObserver.persistedTransactionIDs(
+                    firstSeenAtOrAfter: TransactionObserver.matchFloor(after: seed.startedAt))))
         case .platform:
-            beginSession(
-                generation: sessionGeneration,
-                rail: rail,
-                address: address,
-                walletId: walletId,
-                environment: environment,
-                startedAt: startedAt,
-                coreTransactionIds: [],
-                platformActivityCursor: PlatformAddressActivityDAO.shared.latestActivityId(
+            beginSession(seed, baseline: .platform(
+                activityCursor: PlatformAddressActivityDAO.shared.latestActivityId(
                     walletId: walletId,
-                    networkRaw: Int64(environment.rawValue)),
-                shieldedActivityIds: [])
+                    networkRaw: Int64(environment.rawValue))))
         case .shielded:
             // The only baseline that cannot be a cheap read: it walks the
             // wallet's notes and rebuilds the whole projected activity list.
@@ -538,16 +570,7 @@ final class PaymentsLandingViewModel: ObservableObject {
                       self.canActivelyWatch,
                       self.session == nil
                 else { return }
-                self.beginSession(
-                    generation: sessionGeneration,
-                    rail: rail,
-                    address: address,
-                    walletId: walletId,
-                    environment: environment,
-                    startedAt: startedAt,
-                    coreTransactionIds: [],
-                    platformActivityCursor: 0,
-                    shieldedActivityIds: ids)
+                self.beginSession(seed, baseline: .shielded(activityIds: ids))
             }
         }
     }
@@ -555,28 +578,9 @@ final class PaymentsLandingViewModel: ObservableObject {
     /// Installs the session and starts watching on it. Split out so the rails
     /// whose baseline is a cheap read and the one that has to leave the main
     /// actor for it arrive at the same place.
-    private func beginSession(
-        generation sessionGeneration: UInt64,
-        rail: ChainNetwork,
-        address: String,
-        walletId: Data,
-        environment: Network,
-        startedAt: Date,
-        coreTransactionIds: Set<Data>,
-        platformActivityCursor: Int64,
-        shieldedActivityIds: Set<String>
-    ) {
-        session = ReceiptSession(
-            generation: sessionGeneration,
-            rail: rail,
-            address: address,
-            walletId: walletId,
-            environment: environment,
-            startedAt: startedAt,
-            coreTransactionIds: coreTransactionIds,
-            platformActivityCursor: platformActivityCursor,
-            shieldedActivityIds: shieldedActivityIds)
-        displayedAddress = address
+    private func beginSession(_ seed: ReceiptSessionSeed, baseline: ReceiptBaseline) {
+        session = ReceiptSession(seed: seed, baseline: baseline)
+        displayedAddress = seed.address
         resumeReceiptWatching()
     }
 

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -376,6 +376,17 @@ final class PaymentsLandingViewModel: ObservableObject {
         if session?.rail == network, let displayedAddress {
             return displayedAddress
         }
+        // A rail whose baseline is still being built has no session yet, and
+        // handing out its address anyway put the QR and every receive action
+        // on screen ahead of one. Two ways that loses a payment: one persisted
+        // while the notes are being walked is folded INTO the baseline and
+        // excluded for the whole session, and sharing suspends watching, which
+        // cancels the pending baseline so the replacement — built afterwards —
+        // contains it too. Shielded is the only rail whose baseline cannot be
+        // a cheap read, so it is the only one that ever waits here.
+        if receiptSessionRail == network {
+            return nil
+        }
         return candidateAddress(for: network)
     }
 

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -169,6 +169,12 @@ final class PaymentsLandingViewModel: ObservableObject {
     private var platformReceiptCancellable: AnyCancellable?
     private var shieldedReceiptCancellable: AnyCancellable?
     private var attendedRefreshTask: Task<Void, Never>?
+    /// In-flight shielded baseline read. Held so leaving the surface, or a
+    /// route change, cancels the session it was about to open.
+    private var receiptSessionTask: Task<Void, Never>?
+    /// Which rail that in-flight read is for, so a reconcile arriving while it
+    /// runs can tell "already being started" from "needs starting".
+    private var receiptSessionRail: ChainNetwork?
     private var shieldedProjectionTask: Task<Void, Never>?
     private var shieldedProjectionRefreshPending = false
     private var shieldedProjectionGeneration: UInt64 = 0
@@ -467,30 +473,106 @@ final class PaymentsLandingViewModel: ObservableObject {
             return
         }
 
+        // A baseline for this rail is already being read. Let it land rather
+        // than cancelling and re-reading: `reconcileReceiptWatching` is driven
+        // by publishers that tick faster than the read completes, and
+        // restarting on each tick would mean it never completes at all.
+        if receiptSessionRail == network { return }
+
         generation &+= 1
         let sessionGeneration = generation
-        var coreTransactionIds = Set<Data>()
-        var platformActivityCursor: Int64 = 0
-        var shieldedActivityIds = Set<String>()
+        let rail = network
+        // Stamped once, above the baseline reads rather than below them. Both
+        // the Core snapshot's floor and the subscription's own floor derive
+        // from it, and a transaction persisted between two separately-stamped
+        // instants would land in neither.
+        let startedAt = Date()
 
-        switch network {
+        switch rail {
         case .core:
-            coreTransactionIds = TransactionObserver.persistedTransactionIDs()
-        case .platform:
-            platformActivityCursor = PlatformAddressActivityDAO.shared.latestActivityId(
+            // Bounded by the floor the subscription will scan from: anything
+            // older cannot be emitted, so it does not need excluding.
+            beginSession(
+                generation: sessionGeneration,
+                rail: rail,
+                address: address,
                 walletId: walletId,
-                networkRaw: Int64(environment.rawValue))
+                environment: environment,
+                startedAt: startedAt,
+                coreTransactionIds: TransactionObserver.persistedTransactionIDs(
+                    firstSeenAtOrAfter: TransactionObserver.matchFloor(after: startedAt)),
+                platformActivityCursor: 0,
+                shieldedActivityIds: [])
+        case .platform:
+            beginSession(
+                generation: sessionGeneration,
+                rail: rail,
+                address: address,
+                walletId: walletId,
+                environment: environment,
+                startedAt: startedAt,
+                coreTransactionIds: [],
+                platformActivityCursor: PlatformAddressActivityDAO.shared.latestActivityId(
+                    walletId: walletId,
+                    networkRaw: Int64(environment.rawValue)),
+                shieldedActivityIds: [])
         case .shielded:
-            shieldedActivityIds = Set(Self.projectedShieldedActivity().map(\.id))
+            // The only baseline that cannot be a cheap read: it walks the
+            // wallet's notes and rebuilds the whole projected activity list.
+            // Off the main actor, exactly as every later refresh of the same
+            // projection already is — and the session is created in the
+            // completion rather than left to be filled in, so a note that was
+            // already there can never be admitted as a new payment.
+            receiptSessionTask?.cancel()
+            receiptSessionRail = rail
+            receiptSessionTask = Task { [weak self] in
+                let ids = await Task.detached(priority: .userInitiated) {
+                    Set(Self.projectedShieldedActivity().map(\.id))
+                }.value
+                guard let self, !Task.isCancelled else { return }
+                self.receiptSessionTask = nil
+                self.receiptSessionRail = nil
+                // The route can have moved while the notes were being walked.
+                guard self.generation == sessionGeneration,
+                      self.network == rail,
+                      self.canActivelyWatch,
+                      self.session == nil
+                else { return }
+                self.beginSession(
+                    generation: sessionGeneration,
+                    rail: rail,
+                    address: address,
+                    walletId: walletId,
+                    environment: environment,
+                    startedAt: startedAt,
+                    coreTransactionIds: [],
+                    platformActivityCursor: 0,
+                    shieldedActivityIds: ids)
+            }
         }
+    }
 
+    /// Installs the session and starts watching on it. Split out so the rails
+    /// whose baseline is a cheap read and the one that has to leave the main
+    /// actor for it arrive at the same place.
+    private func beginSession(
+        generation sessionGeneration: UInt64,
+        rail: ChainNetwork,
+        address: String,
+        walletId: Data,
+        environment: Network,
+        startedAt: Date,
+        coreTransactionIds: Set<Data>,
+        platformActivityCursor: Int64,
+        shieldedActivityIds: Set<String>
+    ) {
         session = ReceiptSession(
             generation: sessionGeneration,
-            rail: network,
+            rail: rail,
             address: address,
             walletId: walletId,
             environment: environment,
-            startedAt: Date(),
+            startedAt: startedAt,
             coreTransactionIds: coreTransactionIds,
             platformActivityCursor: platformActivityCursor,
             shieldedActivityIds: shieldedActivityIds)
@@ -749,6 +831,9 @@ final class PaymentsLandingViewModel: ObservableObject {
 
     private func suspendReceiptWatching() {
         isWatchingForReceipt = false
+        receiptSessionTask?.cancel()
+        receiptSessionTask = nil
+        receiptSessionRail = nil
         coreReceiptCancellable?.cancel()
         coreReceiptCancellable = nil
         platformReceiptCancellable?.cancel()

--- a/DashWallet/Sources/UI/Payments/Pay/QRCodeGenerator.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/QRCodeGenerator.swift
@@ -32,7 +32,16 @@ enum QRCodeGenerator {
         "\(Int(size.rounded()))|\(string)" as NSString
     }
 
-    static func image(for string: String, size: CGFloat = 280) -> UIImage? {
+    /// The size the key rounds to, so the cached image is the image that key
+    /// describes. Rendering the fractional request while keying the rounded
+    /// one let `280.4` and `280.49` share an entry and hand back an image
+    /// rendered for a different width.
+    private static func normalizedSize(_ size: CGFloat) -> CGFloat {
+        size.rounded()
+    }
+
+    static func image(for string: String, size requestedSize: CGFloat = 280) -> UIImage? {
+        let size = normalizedSize(requestedSize)
         let key = cacheKey(string, size)
         if let cached = cache.object(forKey: key) { return cached }
 

--- a/DashWallet/Sources/UI/Payments/Pay/QRCodeGenerator.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/QRCodeGenerator.swift
@@ -7,7 +7,35 @@ import CoreImage.CIFilterBuiltins
 import UIKit
 
 enum QRCodeGenerator {
+    /// One context for the whole app. `CIContext()` allocates a rendering
+    /// context (Metal device, caches and all) on every call, which is most of
+    /// what a render here costs — and the receive screen was building one per
+    /// SwiftUI `body`. `CIContext` is documented thread-safe.
+    private static let ciContext = CIContext()
+
+    /// Rendered codes, keyed by payload and size.
+    ///
+    /// The QR for an address is a pure function of that address, but it was
+    /// being recomputed from inside a `body` — so every publication on the
+    /// screen (a balance tick, a sync pass, the watching spinner) redrew a
+    /// bitmap that could not have changed. `NSCache` rather than a dictionary:
+    /// it is thread-safe on its own and gives the images back under memory
+    /// pressure, which a receive screen that has shown a few addresses should
+    /// not be holding onto.
+    private static let cache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.countLimit = 16
+        return cache
+    }()
+
+    private static func cacheKey(_ string: String, _ size: CGFloat) -> NSString {
+        "\(Int(size.rounded()))|\(string)" as NSString
+    }
+
     static func image(for string: String, size: CGFloat = 280) -> UIImage? {
+        let key = cacheKey(string, size)
+        if let cached = cache.object(forKey: key) { return cached }
+
         let data = Data(string.utf8)
         let filter = CIFilter.qrCodeGenerator()
         filter.setValue(data, forKey: "inputMessage")
@@ -17,11 +45,12 @@ enum QRCodeGenerator {
         let scale = size / output.extent.width
         let scaled = output.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
 
-        let context = CIContext()
-        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else {
+        guard let cgImage = ciContext.createCGImage(scaled, from: scaled.extent) else {
             return nil
         }
-        return UIImage(cgImage: cgImage)
+        let image = UIImage(cgImage: cgImage)
+        cache.setObject(image, forKey: key)
+        return image
     }
 
     // MARK: - Dash-branded rendering
@@ -139,8 +168,7 @@ enum QRCodeGenerator {
         filter.setValue(data, forKey: "inputMessage")
         filter.setValue("H", forKey: "inputCorrectionLevel")
         guard let output = filter.outputImage else { return nil }
-        let context = CIContext()
-        guard let cgImage = context.createCGImage(output, from: output.extent) else { return nil }
+        guard let cgImage = ciContext.createCGImage(output, from: output.extent) else { return nil }
 
         let width = cgImage.width
         let height = cgImage.height


### PR DESCRIPTION
## Issue being fixed or feature implemented

Switching to the Receive tab's **Core** segment froze the UI. The freeze scales with wallet history, so it appears overnight on a wallet that has just been rescanned and is invisible on a fresh one.

`PaymentsLandingViewModel.startReceiptSession()` calls `TransactionObserver.persistedTransactionIDs()` on the main actor on every entry to Core. That fetch had **no fetch limit and no floor predicate** — it is the only unbounded query on this screen; every other one is either capped at 200 rows or cut by the indexed `firstSeen`. It walks the whole transaction table through a relationship predicate, which SQLite plans as a full scan running a correlated subquery per row.

Measured against a real container (6,946 transactions, 14,061 TXOs, 6,787 of them matching the active wallet), the same predicate in raw `sqlite3`:

```
before:  3.33s / 3.27s / 3.27s   →  6787 rows
after:   0.00s                   →  0 rows
```

```
before: SCAN t USING COVERING INDEX Z_PersistentTransaction_UNIQUE_txid
after:  SEARCH t USING INDEX Z_PersistentTransaction_SwiftDataIndexOnBinaryfirstSeen (ZFIRSTSEEN>?)
```

That is SQLite alone, before SwiftData materializes ~6,800 objects on top (`propertiesToFetch` does not spare the object).

Related to #1114, but **a different defect**. That issue is about blocking FFI calls parked behind the wallet-manager lock; this is an unbounded SwiftData query that takes no lock and calls no FFI. Neither fix cures the other, and this PR should not close it. `reloadCoreAddress()` — named in #1114 as a caller of the blocking receive-address reader, and living in a file this PR touches — is deliberately left alone.

The issue's own sample corroborates the magnitude from the other direction: `CrowdNode scan: fetch 2712 rows in 5686ms, decode in 2597ms` is the sibling scan in the same file.

## What was done?

**Bound the snapshot by the floor the subscription already uses.** The snapshot exists only to stop an already-persisted transaction being presented as a new payment, and `observeUpdates` already drops everything below `after - matchFloorSkew`. A txid under that floor can never be emitted, so excluding it changes no outcome. `persistedTransactionIDs(firstSeenAtOrAfter:)` now takes that floor, and the floor itself is derived in one place — `TransactionObserver.matchFloor(after:)` — so the snapshot and the scan cannot drift into admitting rows the snapshot no longer covers.

**Keep unconfirmed rows in the snapshot.** `firstSeen` is not immutable: once a transaction is mined the persister adopts the block timestamp in its place, so a pending payment that sat below the floor can rise above it on confirmation. Unconfirmed rows within a day of the floor join the snapshot through a second indexed `firstSeen` range — not an `OR blockHeight == 0` branch, which would cost the index. A transaction pending for longer than that which then confirms mid-session can still surface; the code states that bound.

**Stamp `startedAt` above the baseline reads, not below them.** It was taken after the snapshot, so a transaction persisted between the two instants landed in neither.

**Shielded baseline from the persisted rows, not the projection.** The baseline only has to say which shielded activity already existed. It used to rebuild the whole projected activity list, which materializes every Core transaction the wallet has persisted to reconcile against — seconds on a large wallet. It now reads `entryId` + `accountIndex` from `PersistentShieldedActivity` (`SwiftDashSDKWalletSource.persistedShieldedActivityIds()`), a superset of the projected ids: a row present when the session opens is not a new payment, whatever the projection later makes of it. That is as cheap as the Core and Platform baselines, so every rail opens its session synchronously — the QR and address are never withheld waiting for a read, and there is no window in which an already-rendered QR outlives a pending baseline.

**Cache the QR, share one `CIContext`.** The QR was rebuilt inside `body`, allocating a fresh `CIContext` each time — most of what a render costs. It is a pure function of the address.

**Apply a route change once, not per endpoint.** Pinning a transfer route moves two endpoints, and each move recomputed all route-dependent state: the shielded spend ceiling (two SwiftData fetches plus a run of `estimateShieldedFee` calls across the FFI) and the route's Platform preflight. The first pass ran against a half-applied route that the second immediately replaced.

**Receive card layout.** "No address available" takes the address's full-width leading slot instead of centring with the copy button, and the watching indicator is always laid out and only faded, so the card keeps its bottom inset without it and no longer jumps when watching starts.

### Deliberately not done

`ShieldedTransferCoordinator.sweepAvailability` still runs synchronously on `mainContext` and crosses the FFI. On the measured container it is cheap — 6 unspent notes — and it sits on the spend path with three executor call sites. Changing its threading for a cost the data says is small is a bad trade; the coalescing above already halves how often it runs.

## How Has This Been Tested?

- `xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -configuration Debug -sdk iphonesimulator ARCHS=arm64` → **BUILD SUCCEEDED**.
- Query cost and query plans measured with `sqlite3` against a copy of a live simulator container (numbers and plans above), old predicate vs. new, three runs each with a warm page cache.
- Manual: iPhone 13 Pro Max simulator, iOS 26.5, mainnet wallet with the history above — Receive sheet, repeated switching across Core / Shielded / Platform and Receive / Internal / Send.
- In-app, `-com.apple.CoreData.SQLDebug 1`, mainnet large-history wallet (6,787 transactions), both sides on develop `6b44a5a60` + platform `v4.2-dev` `e096d1e89d`: develop's unbounded snapshot took **8.15 s** and **9.26 s** on two entries to Core (SwiftData's own SQL, matching the predicate above). This branch merged onto the same develop issues only the two bounded `ZFIRSTSEEN >= ?` fetches, with no fetch over a second around seven consecutive entries; Shielded shows its QR immediately on every return.

Behaviour to watch in review, since the snapshot is a correctness guard and not only a cost: a transaction already persisted before the screen opened must still never surface as a receipt, and a shielded activity row that already existed must not be admitted as a new payment.

## Breaking Changes

None. `persistedTransactionIDs()` keeps its unbounded behaviour when called without the new argument.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved payment route updates to reduce redundant recalculations when multiple endpoints change.
  * Improved QR code generation with faster repeated rendering and image reuse.
  * Reduced unnecessary transaction-history scanning during payment session updates.

* **Reliability**
  * Improved payment receipt tracking by using accurate persisted activity baselines and safely stopping when baseline data is unavailable.
  * Improved transaction synchronization when newly confirmed transactions become eligible after a specified time.
  * Distinguished failed activity reads from cases where no activity exists.

* **UI Improvements**
  * Improved payment receive layout stability when addresses or payment-watching indicators are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

