### PR TITLE
fix: enable advanced mode once when Platform funds are detected

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -828,7 +828,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
         // Seed from persisted state before kicking the sync loop, so the UI has
         // something to show immediately on relaunch.
-        seedFromPersistedState(manager: manager, walletId: resolvedWallet.walletId, network: network)
+        seedFromPersistedState(manager: manager, walletId: resolvedWallet.walletId)
 
         do {
             if try !manager.isPlatformAddressSyncRunning() {
@@ -1354,9 +1354,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
                     balance: row.balance)
             }
             platformBalance = rows.reduce(0) { $0 + $1.balance }
-            if let network = runningNetwork {
-                enableAdvancedModeIfFunded(balance: platformBalance, walletId: walletId, network: network)
-            }
+            enableAdvancedModeIfFunded(balance: platformBalance)
             activeAddressCount = rows.reduce(0) { $1.balance > 0 ? $0 + 1 : $0 }
             // Observed-payment ledger: diff this snapshot against the
             // persisted baseline and record unattributed increases as
@@ -1375,7 +1373,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
     // MARK: - Seed from persistence
 
-    private func seedFromPersistedState(manager: PlatformWalletManager, walletId: Data, network: Network) {
+    private func seedFromPersistedState(manager: PlatformWalletManager, walletId: Data) {
         guard let handler = manager.persistence else { return }
 
         let cached = handler.loadCachedBalances(walletId: walletId)
@@ -1387,7 +1385,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
                 if balance > 0 { nonZero += 1 }
             }
             platformBalance = total
-            enableAdvancedModeIfFunded(balance: total, walletId: walletId, network: network)
+            enableAdvancedModeIfFunded(balance: total)
             activeAddressCount = nonZero
         }
 
@@ -1403,11 +1401,13 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
     // MARK: - Helpers
 
-    private func enableAdvancedModeIfFunded(balance: UInt64, walletId: Data, network: Network) {
-        DWGlobalOptions.sharedInstance().enableAdvancedMode(
-            forPlatformBalance: balance,
-            walletIdHex: walletId.map { String(format: "%02x", $0) }.joined(),
-            network: String(network.rawValue))
+    /// The Platform surfaces live behind Advanced mode, so a wallet that holds
+    /// credits with the mode off shows the user nothing and offers no way to
+    /// move them. Both callers pass the balance they just published — the
+    /// cached one at start-up and the freshly summed one after a sync — and
+    /// the policy itself decides whether that is the first funded sighting.
+    private func enableAdvancedModeIfFunded(balance: UInt64) {
+        DWGlobalOptions.sharedInstance().enableAdvancedMode(forPlatformBalance: balance)
     }
 
     private func resolvePlatformAccountAvailability(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -828,7 +828,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
         // Seed from persisted state before kicking the sync loop, so the UI has
         // something to show immediately on relaunch.
-        seedFromPersistedState(manager: manager, walletId: resolvedWallet.walletId)
+        seedFromPersistedState(manager: manager, walletId: resolvedWallet.walletId, network: network)
 
         do {
             if try !manager.isPlatformAddressSyncRunning() {
@@ -1354,6 +1354,9 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
                     balance: row.balance)
             }
             platformBalance = rows.reduce(0) { $0 + $1.balance }
+            if let network = runningNetwork {
+                enableAdvancedModeIfFunded(balance: platformBalance, walletId: walletId, network: network)
+            }
             activeAddressCount = rows.reduce(0) { $1.balance > 0 ? $0 + 1 : $0 }
             // Observed-payment ledger: diff this snapshot against the
             // persisted baseline and record unattributed increases as
@@ -1372,7 +1375,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
     // MARK: - Seed from persistence
 
-    private func seedFromPersistedState(manager: PlatformWalletManager, walletId: Data) {
+    private func seedFromPersistedState(manager: PlatformWalletManager, walletId: Data, network: Network) {
         guard let handler = manager.persistence else { return }
 
         let cached = handler.loadCachedBalances(walletId: walletId)
@@ -1384,6 +1387,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
                 if balance > 0 { nonZero += 1 }
             }
             platformBalance = total
+            enableAdvancedModeIfFunded(balance: total, walletId: walletId, network: network)
             activeAddressCount = nonZero
         }
 
@@ -1398,6 +1402,13 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     }
 
     // MARK: - Helpers
+
+    private func enableAdvancedModeIfFunded(balance: UInt64, walletId: Data, network: Network) {
+        DWGlobalOptions.sharedInstance().enableAdvancedMode(
+            forPlatformBalance: balance,
+            walletIdHex: walletId.map { String(format: "%02x", $0) }.joined(),
+            network: String(network.rawValue))
+    }
 
     private func resolvePlatformAccountAvailability(
         walletId: Data

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -637,6 +637,7 @@ final class SwiftDashSDKWalletWiper: NSObject {
             clearAppState(walletId)
         } else {
             let walletIdHex = walletId.map { String(format: "%02x", $0) }.joined()
+            DWGlobalOptions.sharedInstance().clearAdvancedModeBalanceHistory(forWalletIdHex: walletIdHex)
             CrowdNodeDefaults.shared.clearPerWalletKeys(forWalletIdHex: walletIdHex)
             CoinJoinWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             ShieldedWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -637,7 +637,6 @@ final class SwiftDashSDKWalletWiper: NSObject {
             clearAppState(walletId)
         } else {
             let walletIdHex = walletId.map { String(format: "%02x", $0) }.joined()
-            DWGlobalOptions.sharedInstance().clearAdvancedModeBalanceHistory(forWalletIdHex: walletIdHex)
             CrowdNodeDefaults.shared.clearPerWalletKeys(forWalletIdHex: walletIdHex)
             CoinJoinWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             ShieldedWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)

--- a/DashWallet/Sources/Models/DWGlobalOptions.h
+++ b/DashWallet/Sources/Models/DWGlobalOptions.h
@@ -52,23 +52,29 @@ extern NSNotificationName const DWAdvancedModeDidChangeNotification;
 @property (nonatomic, assign) BOOL balanceHidden;
 @property (nonatomic, assign) BOOL tapToHideBalanceShown;
 
-/// Advanced surfaces are off by default and enabled once when a wallet first
-/// shows a positive Platform address balance. Users can subsequently disable
-/// them. Read it anywhere, but observe
+/// Advanced surfaces are off by default and turned on once, automatically,
+/// when a wallet is first seen holding a positive Platform balance — the
+/// screens that show and move those funds live behind this flag, so leaving
+/// it off hides money the wallet already has. Read it anywhere, but observe
 /// `Notification.Name.advancedModeDidChange` rather than caching the value —
 /// it can be flipped from Settings while any screen is on display.
-@property (nonatomic, assign) BOOL advancedModeEnabled;
+/// Read-only by design: every write goes through one of the two methods
+/// below, so no caller can move the flag without announcing it.
+@property (nonatomic, readonly, assign) BOOL advancedModeEnabled;
 
-/// Persists the preference and announces an actual change to all open screens.
-- (void)updateAdvancedModeEnabled:(BOOL)enabled;
+/// YES once the user has set Advanced mode themselves. From that point the
+/// automatic policy never moves the flag again, in either direction.
+@property (nonatomic, readonly, assign) BOOL advancedModeUserManaged;
 
-/// Handles the first positive balance per wallet/network, even if already on.
-/// Zero balances leave the check pending; subsequent observations respect a
-/// manual disable. Call on the main thread with the balance's own context.
-- (void)enableAdvancedModeForPlatformBalance:(uint64_t)balance
-                                 walletIdHex:(NSString *)walletIdHex
-                                     network:(NSString *)network;
-- (void)clearAdvancedModeBalanceHistoryForWalletIdHex:(NSString *)walletIdHex;
+/// The user's own choice, from Settings. Persists it, hands them the
+/// preference for good, and announces an actual change to all open screens.
+- (void)setAdvancedModeEnabledByUser:(BOOL)enabled;
+
+/// Turns Advanced mode on the first time a wallet is observed funded on
+/// Platform, unless the user has already taken the preference over. A zero
+/// balance leaves the decision pending; repeat observations are no-ops.
+/// Call on the main thread.
+- (void)enableAdvancedModeForPlatformBalance:(uint64_t)balance;
 
 @property (nonatomic, assign) BOOL shouldDisplayOnboarding;
 @property (nonatomic, assign) BOOL shouldDisplayReclassifyYourTransactionsFlow;

--- a/DashWallet/Sources/Models/DWGlobalOptions.h
+++ b/DashWallet/Sources/Models/DWGlobalOptions.h
@@ -52,13 +52,23 @@ extern NSNotificationName const DWAdvancedModeDidChangeNotification;
 @property (nonatomic, assign) BOOL balanceHidden;
 @property (nonatomic, assign) BOOL tapToHideBalanceShown;
 
-/// Opt-in to the advanced surfaces across the app. Off by default: the
-/// screens it unlocks assume the user knows what a UTXO or a derivation path
-/// is, and showing them unasked is how an ordinary wallet stops looking
-/// ordinary. Read it anywhere, but observe
+/// Advanced surfaces are off by default and enabled once when a wallet first
+/// shows a positive Platform address balance. Users can subsequently disable
+/// them. Read it anywhere, but observe
 /// `Notification.Name.advancedModeDidChange` rather than caching the value —
 /// it can be flipped from Settings while any screen is on display.
 @property (nonatomic, assign) BOOL advancedModeEnabled;
+
+/// Persists the preference and announces an actual change to all open screens.
+- (void)updateAdvancedModeEnabled:(BOOL)enabled;
+
+/// Handles the first positive balance per wallet/network, even if already on.
+/// Zero balances leave the check pending; subsequent observations respect a
+/// manual disable. Call on the main thread with the balance's own context.
+- (void)enableAdvancedModeForPlatformBalance:(uint64_t)balance
+                                 walletIdHex:(NSString *)walletIdHex
+                                     network:(NSString *)network;
+- (void)clearAdvancedModeBalanceHistoryForWalletIdHex:(NSString *)walletIdHex;
 
 @property (nonatomic, assign) BOOL shouldDisplayOnboarding;
 @property (nonatomic, assign) BOOL shouldDisplayReclassifyYourTransactionsFlow;

--- a/DashWallet/Sources/Models/DWGlobalOptions.m
+++ b/DashWallet/Sources/Models/DWGlobalOptions.m
@@ -36,7 +36,19 @@ static NSString *const LEGACY_USER_HAS_BALANCE_KEY = @"DW_GLOB_userHasBalance";
 // scoped by the active wallet (`DWWalletEnvironment.activeWalletIdHex`).
 static NSString *const PER_WALLET_NEEDS_BACKUP_PREFIX = @"DW_WALLET_NEEDS_BACKUP_";
 static NSString *const PER_WALLET_HAS_BALANCE_PREFIX = @"DW_WALLET_HAS_BALANCE_";
-static NSString *const PLATFORM_ADVANCED_MODE_HISTORY_KEY = @"DW_PLATFORM_ADVANCED_MODE_HISTORY";
+// `advancedModeEnabled` and `advancedModeUserManaged` are readonly to the rest
+// of the app: a direct assignment would move the flag without posting
+// `DWAdvancedModeDidChangeNotification`, leaving every screen that is already
+// on display showing the old state. Writable only in here, through
+// `updateAdvancedModeEnabled:`.
+@interface DWGlobalOptions ()
+
+@property (nonatomic, assign) BOOL advancedModeEnabled;
+@property (nonatomic, assign) BOOL advancedModeUserManaged;
+
+- (void)updateAdvancedModeEnabled:(BOOL)enabled;
+
+@end
 
 @implementation DWGlobalOptions
 
@@ -48,6 +60,7 @@ static NSString *const PLATFORM_ADVANCED_MODE_HISTORY_KEY = @"DW_PLATFORM_ADVANC
 @dynamic shortcuts;
 @dynamic balanceHidden;
 @dynamic advancedModeEnabled;
+@dynamic advancedModeUserManaged;
 @dynamic tapToHideBalanceShown;
 @dynamic shouldDisplayOnboarding;
 @dynamic paymentsScreenCurrentTab;
@@ -225,41 +238,32 @@ static NSString *const PLATFORM_ADVANCED_MODE_HISTORY_KEY = @"DW_PLATFORM_ADVANC
 
 NSNotificationName const DWAdvancedModeDidChangeNotification = @"org.dash.advanced-mode-did-change";
 
+- (void)setAdvancedModeEnabledByUser:(BOOL)enabled {
+    // Claimed before the write and regardless of whether the value moved: the
+    // point of the flag is that the user has an opinion, not what it is. An
+    // opinion formed before any Platform funds existed counts too — turning
+    // the mode off and then receiving credits must not turn it back on.
+    self.advancedModeUserManaged = YES;
+    [self updateAdvancedModeEnabled:enabled];
+}
+
+- (void)enableAdvancedModeForPlatformBalance:(uint64_t)balance {
+    NSAssert([NSThread isMainThread], @"advanced-mode policy must run on the main thread");
+    if (balance == 0 || self.advancedModeUserManaged) {
+        return;
+    }
+    [self updateAdvancedModeEnabled:YES];
+}
+
+/// The single writer. Nothing to do when the value is already the requested
+/// one — in particular the automatic policy re-running on every balance
+/// refresh, which lands here on each sync and must stay silent.
 - (void)updateAdvancedModeEnabled:(BOOL)enabled {
     if (self.advancedModeEnabled == enabled) {
         return;
     }
     self.advancedModeEnabled = enabled;
     [[NSNotificationCenter defaultCenter] postNotificationName:DWAdvancedModeDidChangeNotification object:nil];
-}
-
-- (void)enableAdvancedModeForPlatformBalance:(uint64_t)balance
-                                 walletIdHex:(NSString *)walletIdHex
-                                     network:(NSString *)network {
-    if (balance == 0 || walletIdHex.length == 0 || network.length == 0) {
-        return;
-    }
-    NSMutableDictionary *history = [[self.userDefaults dictionaryForKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY] mutableCopy];
-    if (history == nil) {
-        history = [NSMutableDictionary dictionary];
-    }
-    NSArray *networks = history[walletIdHex] ?: @[];
-    if ([networks containsObject:network]) {
-        return;
-    }
-    // Mark before notifying observers, including when the mode is already on.
-    // A later manual disable must survive another sync or app launch.
-    history[walletIdHex] = [networks arrayByAddingObject:network];
-    [self.userDefaults setObject:history forKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY];
-    [self updateAdvancedModeEnabled:YES];
-}
-
-- (void)clearAdvancedModeBalanceHistoryForWalletIdHex:(NSString *)walletIdHex {
-    NSMutableDictionary *history = [[self.userDefaults dictionaryForKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY] mutableCopy];
-    [history removeObjectForKey:walletIdHex];
-    if (history != nil) {
-        [self.userDefaults setObject:history forKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY];
-    }
 }
 
 - (void)restoreToDefaults {
@@ -272,7 +276,7 @@ NSNotificationName const DWAdvancedModeDidChangeNotification = @"org.dash.advanc
     self.localNotificationsEnabled = YES;
     self.balanceHidden = NO;
     self.advancedModeEnabled = NO;
-    [self.userDefaults removeObjectForKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY];
+    self.advancedModeUserManaged = NO;
     self.tapToHideBalanceShown = NO;
     self.resyncingWallet = NO;
     self.selectedPaymentCurrency = DWPaymentCurrencyDash;

--- a/DashWallet/Sources/Models/DWGlobalOptions.m
+++ b/DashWallet/Sources/Models/DWGlobalOptions.m
@@ -36,6 +36,7 @@ static NSString *const LEGACY_USER_HAS_BALANCE_KEY = @"DW_GLOB_userHasBalance";
 // scoped by the active wallet (`DWWalletEnvironment.activeWalletIdHex`).
 static NSString *const PER_WALLET_NEEDS_BACKUP_PREFIX = @"DW_WALLET_NEEDS_BACKUP_";
 static NSString *const PER_WALLET_HAS_BALANCE_PREFIX = @"DW_WALLET_HAS_BALANCE_";
+static NSString *const PLATFORM_ADVANCED_MODE_HISTORY_KEY = @"DW_PLATFORM_ADVANCED_MODE_HISTORY";
 
 @implementation DWGlobalOptions
 
@@ -224,6 +225,43 @@ static NSString *const PER_WALLET_HAS_BALANCE_PREFIX = @"DW_WALLET_HAS_BALANCE_"
 
 NSNotificationName const DWAdvancedModeDidChangeNotification = @"org.dash.advanced-mode-did-change";
 
+- (void)updateAdvancedModeEnabled:(BOOL)enabled {
+    if (self.advancedModeEnabled == enabled) {
+        return;
+    }
+    self.advancedModeEnabled = enabled;
+    [[NSNotificationCenter defaultCenter] postNotificationName:DWAdvancedModeDidChangeNotification object:nil];
+}
+
+- (void)enableAdvancedModeForPlatformBalance:(uint64_t)balance
+                                 walletIdHex:(NSString *)walletIdHex
+                                     network:(NSString *)network {
+    if (balance == 0 || walletIdHex.length == 0 || network.length == 0) {
+        return;
+    }
+    NSMutableDictionary *history = [[self.userDefaults dictionaryForKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY] mutableCopy];
+    if (history == nil) {
+        history = [NSMutableDictionary dictionary];
+    }
+    NSArray *networks = history[walletIdHex] ?: @[];
+    if ([networks containsObject:network]) {
+        return;
+    }
+    // Mark before notifying observers, including when the mode is already on.
+    // A later manual disable must survive another sync or app launch.
+    history[walletIdHex] = [networks arrayByAddingObject:network];
+    [self.userDefaults setObject:history forKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY];
+    [self updateAdvancedModeEnabled:YES];
+}
+
+- (void)clearAdvancedModeBalanceHistoryForWalletIdHex:(NSString *)walletIdHex {
+    NSMutableDictionary *history = [[self.userDefaults dictionaryForKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY] mutableCopy];
+    [history removeObjectForKey:walletIdHex];
+    if (history != nil) {
+        [self.userDefaults setObject:history forKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY];
+    }
+}
+
 - (void)restoreToDefaults {
     const BOOL advancedModeWasEnabled = self.advancedModeEnabled;
     self.walletNeedsBackup = YES;
@@ -234,6 +272,7 @@ NSNotificationName const DWAdvancedModeDidChangeNotification = @"org.dash.advanc
     self.localNotificationsEnabled = YES;
     self.balanceHidden = NO;
     self.advancedModeEnabled = NO;
+    [self.userDefaults removeObjectForKey:PLATFORM_ADVANCED_MODE_HISTORY_KEY];
     self.tapToHideBalanceShown = NO;
     self.resyncingWallet = NO;
     self.selectedPaymentCurrency = DWPaymentCurrencyDash;

--- a/DashWallet/Sources/UI/Menu/Settings/SettingsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/SettingsMenuViewModel.swift
@@ -87,11 +87,18 @@ class SettingsMenuViewModel: ObservableObject {
         setupCoinJoinObservers()
         setupSyncStateObserver()
         setupCurrencyChangeObserver()
+        // The flag can move without this screen touching it — the first
+        // funded Platform balance turns it on while Settings is open. The
+        // guard keeps that the only work this does: a change made *here*
+        // has already updated the row, and rebuilding the menu a second
+        // time on the next main-loop turn would be pure churn.
         NotificationCenter.default.publisher(for: .advancedModeDidChange)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                self.advancedModeEnabled = DWGlobalOptions.sharedInstance().advancedModeEnabled
+                let enabled = DWGlobalOptions.sharedInstance().advancedModeEnabled
+                guard enabled != self.advancedModeEnabled else { return }
+                self.advancedModeEnabled = enabled
                 self.refreshMenuItems()
             }
             .store(in: &cancellableBag)
@@ -231,9 +238,12 @@ class SettingsMenuViewModel: ObservableObject {
     /// Write the flag, then announce it. The announcement is the point: the
     /// setting reaches far beyond this screen, and a consumer that only read
     /// the value when it appeared would keep showing the old state until it
-    /// was rebuilt for some unrelated reason.
+    /// was rebuilt for some unrelated reason. This is also the only path that
+    /// marks the preference as the user's, which retires the automatic
+    /// first-funding enable for good.
     func setAdvancedMode(_ enabled: Bool) {
-        DWGlobalOptions.sharedInstance().updateAdvancedModeEnabled(enabled)
+        guard enabled != advancedModeEnabled else { return }
+        DWGlobalOptions.sharedInstance().setAdvancedModeEnabledByUser(enabled)
         advancedModeEnabled = enabled
         DWLogger.log("Settings: advanced mode \(enabled ? "enabled" : "disabled")")
         refreshMenuItems()

--- a/DashWallet/Sources/UI/Menu/Settings/SettingsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/SettingsMenuViewModel.swift
@@ -87,6 +87,14 @@ class SettingsMenuViewModel: ObservableObject {
         setupCoinJoinObservers()
         setupSyncStateObserver()
         setupCurrencyChangeObserver()
+        NotificationCenter.default.publisher(for: .advancedModeDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.advancedModeEnabled = DWGlobalOptions.sharedInstance().advancedModeEnabled
+                self.refreshMenuItems()
+            }
+            .store(in: &cancellableBag)
     }
     
     func resetNavigation() {
@@ -225,11 +233,9 @@ class SettingsMenuViewModel: ObservableObject {
     /// the value when it appeared would keep showing the old state until it
     /// was rebuilt for some unrelated reason.
     func setAdvancedMode(_ enabled: Bool) {
-        guard enabled != advancedModeEnabled else { return }
+        DWGlobalOptions.sharedInstance().updateAdvancedModeEnabled(enabled)
         advancedModeEnabled = enabled
-        DWGlobalOptions.sharedInstance().advancedModeEnabled = enabled
         DWLogger.log("Settings: advanced mode \(enabled ? "enabled" : "disabled")")
-        NotificationCenter.default.post(name: .advancedModeDidChange, object: nil)
         refreshMenuItems()
     }
 

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -282,8 +282,8 @@ final class SendViewModel: ObservableObject {
         // `pinnedSourceMismatch`.
         let valid = validSources
         if pinnedSource == nil, !valid.isEmpty, !userPickedSource || !valid.contains(source) {
-            let preferred = valid.first { balanceDuffs(of: $0) > 0 } ?? valid[0]
-            if preferred != source {
+            if let preferred = valid.first(where: { balanceDuffs(of: $0) > 0 }) ?? valid.first,
+               preferred != source {
                 setSourceWithoutClaimingUserIntent(preferred)
             }
         }

--- a/scripts/advanced_mode_regression/dashwallet-Swift.h
+++ b/scripts/advanced_mode_regression/dashwallet-Swift.h
@@ -1,0 +1,11 @@
+// Foundation-only test substitutes for unrelated keychain/wallet dependencies.
+// DWGlobalOptions and DSDynamicOptions themselves are compiled unchanged.
+#import <Foundation/Foundation.h>
+#define DW_KEYPATH(object, property) @ #property
+@interface DWKeychainStore : NSObject
++ (int64_t)int64ForAccount:(NSString *)account;
++ (void)setInt64:(int64_t)value forAccount:(NSString *)account authenticated:(BOOL)authenticated;
+@end
+@interface DWWalletEnvironment : NSObject
++ (NSString *)activeWalletIdHex;
+@end

--- a/scripts/advanced_mode_regression/main.m
+++ b/scripts/advanced_mode_regression/main.m
@@ -1,0 +1,84 @@
+#import "DWGlobalOptions.h"
+#import "dashwallet-Swift.h"
+#import <Foundation/Foundation.h>
+
+@implementation DWKeychainStore
++ (int64_t)int64ForAccount:(NSString *)account {
+    return 0;
+}
++ (void)setInt64:(int64_t)value forAccount:(NSString *)account authenticated:(BOOL)authenticated {
+}
+@end
+@implementation DWWalletEnvironment
++ (NSString *)activeWalletIdHex {
+    return nil;
+}
+@end
+
+static NSUInteger checks;
+static void check(BOOL condition, NSString *message) {
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", message.UTF8String);
+        exit(1);
+    }
+    checks++;
+    printf("PASS: %s\n", message.UTF8String);
+}
+
+int main(void) {
+    @autoreleasepool {
+        NSString *suite = [@"org.dash.advanced-mode-tests." stringByAppendingString:NSUUID.UUID.UUIDString];
+        NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:suite];
+        DWGlobalOptions *options = [[DWGlobalOptions alloc] initWithUserDefaults:defaults defaults:nil];
+        __block NSUInteger notifications = 0;
+        id observer = [NSNotificationCenter.defaultCenter addObserverForName:DWAdvancedModeDidChangeNotification
+                                                                      object:nil
+                                                                       queue:nil
+                                                                  usingBlock:^(NSNotification *note) {
+                                                                      notifications++;
+                                                                  }];
+        check(!options.advancedModeEnabled, @"Upgrade without saved preference starts off");
+        [options enableAdvancedModeForPlatformBalance:0 walletIdHex:@"a" network:@"testnet"];
+        check(!options.advancedModeEnabled && notifications == 0, @"Zero balance leaves automatic enablement pending");
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"" network:@"testnet"];
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@""];
+        check(!options.advancedModeEnabled, @"Missing wallet/network context cannot enable mode");
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@"testnet"];
+        check(options.advancedModeEnabled && notifications == 1, @"One raw credit enables mode and notifies once");
+        [options enableAdvancedModeForPlatformBalance:200000 walletIdHex:@"a" network:@"testnet"];
+        check(notifications == 1, @"Repeated positive snapshots do not notify again");
+        [options updateAdvancedModeEnabled:NO];
+        check(!options.advancedModeEnabled && notifications == 2, @"Manual disable persists and notifies");
+        options = [[DWGlobalOptions alloc] initWithUserDefaults:[[NSUserDefaults alloc] initWithSuiteName:suite] defaults:nil];
+        [options enableAdvancedModeForPlatformBalance:0 walletIdHex:@"a" network:@"testnet"];
+        [options enableAdvancedModeForPlatformBalance:999999 walletIdHex:@"a" network:@"testnet"];
+        check(!options.advancedModeEnabled && notifications == 2, @"New options instance, resync and refund respect manual disable");
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@"mainnet"];
+        check(options.advancedModeEnabled, @"Another network has independent first-funding history");
+        [options updateAdvancedModeEnabled:NO];
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"b" network:@"testnet"];
+        check(options.advancedModeEnabled, @"Another wallet has independent first-funding history");
+        NSUInteger before = notifications;
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"c" network:@"testnet"];
+        check(notifications == before, @"Already-enabled mode does not emit redundant notification");
+        [options updateAdvancedModeEnabled:NO];
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"c" network:@"testnet"];
+        check(!options.advancedModeEnabled, @"Already-enabled first funding still records history");
+        [options clearAdvancedModeBalanceHistoryForWalletIdHex:@"b"];
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@"testnet"];
+        check(!options.advancedModeEnabled, @"Removing wallet B preserves wallet A history");
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"b" network:@"testnet"];
+        check(options.advancedModeEnabled, @"Removed wallet can auto-enable after reimport");
+        [options restoreToDefaults];
+        check(!options.advancedModeEnabled, @"Full wipe resets advanced mode");
+        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@"testnet"];
+        check(options.advancedModeEnabled, @"Full wipe clears first-funding history");
+        before = notifications;
+        [options updateAdvancedModeEnabled:YES];
+        check(notifications == before, @"Writing unchanged preference does not notify");
+        [NSNotificationCenter.defaultCenter removeObserver:observer];
+        [defaults removePersistentDomainForName:suite];
+        printf("%lu regression checks passed\n", (unsigned long)checks);
+    }
+    return 0;
+}

--- a/scripts/advanced_mode_regression/main.m
+++ b/scripts/advanced_mode_regression/main.m
@@ -25,11 +25,22 @@ static void check(BOOL condition, NSString *message) {
     printf("PASS: %s\n", message.UTF8String);
 }
 
+static NSMutableArray<NSString *> *usedSuites;
+
+static NSString *freshSuite(void) {
+    NSString *suite = [@"org.dash.advanced-mode-tests." stringByAppendingString:NSUUID.UUID.UUIDString];
+    [usedSuites addObject:suite];
+    return suite;
+}
+
+static DWGlobalOptions *optionsForSuite(NSString *suite) {
+    NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:suite];
+    return [[DWGlobalOptions alloc] initWithUserDefaults:defaults defaults:nil];
+}
+
 int main(void) {
     @autoreleasepool {
-        NSString *suite = [@"org.dash.advanced-mode-tests." stringByAppendingString:NSUUID.UUID.UUIDString];
-        NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:suite];
-        DWGlobalOptions *options = [[DWGlobalOptions alloc] initWithUserDefaults:defaults defaults:nil];
+        usedSuites = [NSMutableArray array];
         __block NSUInteger notifications = 0;
         id observer = [NSNotificationCenter.defaultCenter addObserverForName:DWAdvancedModeDidChangeNotification
                                                                       object:nil
@@ -37,47 +48,66 @@ int main(void) {
                                                                   usingBlock:^(NSNotification *note) {
                                                                       notifications++;
                                                                   }];
+
+        // The upgrade path: no saved preference, a wallet that already holds
+        // Platform credits, and the first sighting of them.
+        NSString *suite = freshSuite();
+        DWGlobalOptions *options = optionsForSuite(suite);
         check(!options.advancedModeEnabled, @"Upgrade without saved preference starts off");
-        [options enableAdvancedModeForPlatformBalance:0 walletIdHex:@"a" network:@"testnet"];
+        check(!options.advancedModeUserManaged, @"Upgrade without saved preference is not user-managed");
+        [options enableAdvancedModeForPlatformBalance:0];
         check(!options.advancedModeEnabled && notifications == 0, @"Zero balance leaves automatic enablement pending");
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"" network:@"testnet"];
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@""];
-        check(!options.advancedModeEnabled, @"Missing wallet/network context cannot enable mode");
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@"testnet"];
+        [options enableAdvancedModeForPlatformBalance:1];
         check(options.advancedModeEnabled && notifications == 1, @"One raw credit enables mode and notifies once");
-        [options enableAdvancedModeForPlatformBalance:200000 walletIdHex:@"a" network:@"testnet"];
+        check(!options.advancedModeUserManaged, @"The automatic enable does not claim the preference for the user");
+        [options enableAdvancedModeForPlatformBalance:200000];
         check(notifications == 1, @"Repeated positive snapshots do not notify again");
-        [options updateAdvancedModeEnabled:NO];
+
+        // A manual disable hands the preference to the user for good.
+        [options setAdvancedModeEnabledByUser:NO];
         check(!options.advancedModeEnabled && notifications == 2, @"Manual disable persists and notifies");
-        options = [[DWGlobalOptions alloc] initWithUserDefaults:[[NSUserDefaults alloc] initWithSuiteName:suite] defaults:nil];
-        [options enableAdvancedModeForPlatformBalance:0 walletIdHex:@"a" network:@"testnet"];
-        [options enableAdvancedModeForPlatformBalance:999999 walletIdHex:@"a" network:@"testnet"];
-        check(!options.advancedModeEnabled && notifications == 2, @"New options instance, resync and refund respect manual disable");
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@"mainnet"];
-        check(options.advancedModeEnabled, @"Another network has independent first-funding history");
-        [options updateAdvancedModeEnabled:NO];
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"b" network:@"testnet"];
-        check(options.advancedModeEnabled, @"Another wallet has independent first-funding history");
+        check(options.advancedModeUserManaged, @"Manual disable claims the preference for the user");
+        options = optionsForSuite(suite);
+        check(options.advancedModeUserManaged, @"The claim survives a new options instance");
+        [options enableAdvancedModeForPlatformBalance:0];
+        [options enableAdvancedModeForPlatformBalance:999999];
+        check(!options.advancedModeEnabled && notifications == 2, @"Resync and refund respect the manual disable");
+        // No per-wallet state: a wallet seen funded for the first time is the
+        // same call, and it must not reopen a decision the user has made.
+        [options enableAdvancedModeForPlatformBalance:1];
+        check(!options.advancedModeEnabled, @"A newly funded wallet cannot undo the manual disable");
+
+        // The ordering the per-wallet marker got wrong: an opt-out recorded
+        // before any Platform funds ever arrived.
+        suite = freshSuite();
+        options = optionsForSuite(suite);
+        [options setAdvancedModeEnabledByUser:YES];
+        check(options.advancedModeEnabled && notifications == 3, @"Manual enable persists and notifies");
+        [options setAdvancedModeEnabledByUser:NO];
+        check(!options.advancedModeEnabled && notifications == 4, @"Manual disable before any funding persists");
+        [options enableAdvancedModeForPlatformBalance:1];
+        check(!options.advancedModeEnabled && notifications == 4, @"First funding respects an opt-out made before it");
+
+        // Re-affirming the current value changes nothing on screen but still
+        // settles who owns the preference.
+        suite = freshSuite();
+        options = optionsForSuite(suite);
         NSUInteger before = notifications;
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"c" network:@"testnet"];
-        check(notifications == before, @"Already-enabled mode does not emit redundant notification");
-        [options updateAdvancedModeEnabled:NO];
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"c" network:@"testnet"];
-        check(!options.advancedModeEnabled, @"Already-enabled first funding still records history");
-        [options clearAdvancedModeBalanceHistoryForWalletIdHex:@"b"];
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@"testnet"];
-        check(!options.advancedModeEnabled, @"Removing wallet B preserves wallet A history");
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"b" network:@"testnet"];
-        check(options.advancedModeEnabled, @"Removed wallet can auto-enable after reimport");
+        [options setAdvancedModeEnabledByUser:NO];
+        check(notifications == before, @"Writing an unchanged preference does not notify");
+        [options enableAdvancedModeForPlatformBalance:1];
+        check(!options.advancedModeEnabled, @"An unchanged manual write still claims the preference");
+
+        // A full wipe returns the wallet to a state that can auto-enable again.
         [options restoreToDefaults];
-        check(!options.advancedModeEnabled, @"Full wipe resets advanced mode");
-        [options enableAdvancedModeForPlatformBalance:1 walletIdHex:@"a" network:@"testnet"];
-        check(options.advancedModeEnabled, @"Full wipe clears first-funding history");
-        before = notifications;
-        [options updateAdvancedModeEnabled:YES];
-        check(notifications == before, @"Writing unchanged preference does not notify");
+        check(!options.advancedModeEnabled && !options.advancedModeUserManaged, @"Full wipe resets mode and ownership");
+        [options enableAdvancedModeForPlatformBalance:1];
+        check(options.advancedModeEnabled, @"Automatic enablement works again after a full wipe");
+
         [NSNotificationCenter.defaultCenter removeObserver:observer];
-        [defaults removePersistentDomainForName:suite];
+        for (NSString *usedSuite in usedSuites) {
+            [NSUserDefaults.standardUserDefaults removePersistentDomainForName:usedSuite];
+        }
         printf("%lu regression checks passed\n", (unsigned long)checks);
     }
     return 0;

--- a/scripts/advanced_mode_regression/run.sh
+++ b/scripts/advanced_mode_regression/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Run the real preference and persistence implementation without an iOS host.
+# Requires `pod install`; no SDK, keychain access or network requests are used.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+xcrun clang -fobjc-arc -fblocks -framework Foundation -include Foundation/Foundation.h \
+  -DDASHPAY=1 -I scripts/advanced_mode_regression -I DashWallet/Sources/Models \
+  -I Pods/DSDynamicOptions \
+  Pods/DSDynamicOptions/DSDynamicOptions/DSDynamicOptions.m \
+  DashWallet/Sources/Models/DWGlobalOptions.m \
+  scripts/advanced_mode_regression/main.m -o "$test_dir/advanced-mode-tests"
+"$test_dir/advanced-mode-tests"


### PR DESCRIPTION
## Issue being fixed or feature implemented

Upgrading from a version without the Advanced mode setting leaves it off, hiding Platform address controls even when the wallet already has Platform funds. Enable Advanced mode on the first positive Platform balance, then respect the user's later decision to disable it.

## What was done?

- Apply the policy to cached startup balances and live balance refreshes, using raw credits so even a balance below display precision qualifies.
- Persist a handled marker per wallet ID/network while keeping Advanced mode app-wide. Record the marker even if the mode is already on; leave zero/unavailable balances pending.
- Refresh Settings when the mode changes automatically. Clear the corresponding marker after successful wallet removal and all markers on full wipe.
- Add regression coverage for persistence, duplicate notifications, manual override, wallet/network isolation, deletion and re-import.
- Fix an existing SendViewModel optional-binding compiler error encountered while building the current base.

## How Has This Been Tested?

- Local arm64 iPhone 16 Simulator build on iOS 18.6 succeeded; 16 regression checks passed. No new SwiftLint findings in touched Swift files; no new blocking accessibility findings. Code and simplification reviews completed.
- Used 1 real tDASH from faucet.thepasta.org, confirmed in synced Core data at block 1550555: `69ac2ab7a7c82c7ec0fd5ba6fff48a50123b2fda218f1d98b6f3748465603862`.
- Funded Platform through a real Core-to-Platform transfer and sent between two test wallets. Verified upgrade startup, automatic enablement with Settings open, manual disable through later payments/relaunch, network switching, per-wallet removal, re-import and full wipe.
- Exact zero-to-positive after handling is covered by the regression executable; the live Max send retained a fee reserve.

QA qualifications: re-import required the existing Platform Sync Status **Clear** action to rediscover the balance; auto-enable then worked. The `dashpay` scheme has no test action configured. The simulator build used Xcode 16.4, a local DashUIKit manifest tools-version adjustment from 6.3 to 6.1, prebuilt SDK FFI and local service plist stubs; third-party production services were not validated.

## QA evidence

[Full testnet QA matrix, transaction evidence, screenshots and build provenance](https://github.com/PastaPastaPasta/dash-ui-artifacts/blob/81d9b3d4ae02118e1526f6ad9173f911c1d702e0/dashwallet-ios/pr-1123/README.md). All nine full-resolution captures were inspected; the published files were fetched and verified against local SHA-256 hashes.

The pair below shows Settings across the first incoming Platform payment on the **same head revision**, `2bfee9e3cfeba384799449de54c5495dc25f7223`. It is not a base-versus-head comparison; the exact base did not build because of the SendViewModel compiler error fixed here.

| Before B's first live payment: off | After B's first live payment: on |
|---|---|
| [<img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/81d9b3d4ae02118e1526f6ad9173f911c1d702e0/dashwallet-ios/pr-1123/live-before-settings-off.png" width="250" alt="Advanced mode off before the first Platform payment">](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/81d9b3d4ae02118e1526f6ad9173f911c1d702e0/dashwallet-ios/pr-1123/live-before-settings-off.png) | [<img src="https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/81d9b3d4ae02118e1526f6ad9173f911c1d702e0/dashwallet-ios/pr-1123/live-after-settings-on.png" width="250" alt="Advanced mode on after the first Platform payment">](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/81d9b3d4ae02118e1526f6ad9173f911c1d702e0/dashwallet-ios/pr-1123/live-after-settings-on.png) |

## Breaking Changes

None to APIs or wallet data. Each newly observed funded wallet/network may enable the global preference once, including when it was previously off.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Advanced Mode now enables automatically after the first positive Platform balance.
  - Once manually changed, the Advanced Mode preference remains under user control.
  - Resetting preferences restores automatic Advanced Mode behavior.

- **Bug Fixes**
  - Settings now avoid unnecessary updates and refreshes when Advanced Mode is unchanged.
  - Improved payment address source selection without changing expected behavior.

- **Tests**
  - Added regression coverage for automatic enabling, user overrides, persistence, and preference resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->